### PR TITLE
fix: Vendor recipe for 6-link items

### DIFF
--- a/modules/ItemPricer.js
+++ b/modules/ItemPricer.js
@@ -460,7 +460,7 @@
       if(sockets.length) {
         if(ItemData.countSockets(sockets) === 6) {
           if(sockets.length === 1) {
-            vendorValue = rates["Currency"]["Divine Orb"];
+            vendorValue = rates["Currency"]["Orb of Fusing"] * 20;
           } else {
             vendorValue = rates["Currency"]["Jeweller's Orb"] * 7;
           }


### PR DESCRIPTION
The vendor recipe for 6-link items now rewards 20 Orb of Fusing instead of 1 Divine Orb