### PR TITLE
Added Memores Categories, Added Missing Sirius's Map Fragments

### DIFF
--- a/modules/ItemCategoryParser.js
+++ b/modules/ItemCategoryParser.js
@@ -17,7 +17,15 @@ const nonStackableBulkItems = [
   'Maps',
   'Incubator',
   'Atlas Region Upgrade Item',
-  "Memory"    
+  "Kirac's Memory",
+  "Einhar's Memory",
+  "Niko's Memory",
+  "Alva's Memory",
+  "Writhing Invitation",
+  "Screaming Invitation",
+  "Polaric Invitation",
+  "Incandescent Invitation",
+  "Maven's Invitation"
 ];
 
 function getCategory(item, subcategory = false) {
@@ -30,8 +38,36 @@ function getCategory(item, subcategory = false) {
     return t;
   }
 
-  if(t.includes("Memory of")){
-    return "Memory";
+  //Memories
+  if(t.includes("Kirac's Memory")){
+    return "Kirac's Memory";
+  }
+  if(t.includes("Einhar's Memory")){
+    return "Einhar's Memory";
+  }
+  if(t.includes("Niko's Memory")){
+    return "Niko's Memory";
+  }
+  if(t.includes("Alva's Memory")){
+    return "Alva's Memory";
+  }
+
+
+  //Invitations
+  if(t.includes("Writhing Invitation")){
+    return "Writhing Invitation";
+  }
+  if(t.includes("Screaming Invitation")){
+    return "Screaming Invitation";
+  }
+  if(t.includes("Polaric Invitation")){
+    return "Polaric Invitation";
+  }
+  if(t.includes("Incandescent Invitation")){
+    return "Incandescent Invitation";
+  }
+  if(t.includes("Maven's Invitation")){
+    return "Maven's Invitation";
   }
   
   if(t.includes("Contract")) {

--- a/modules/ItemPricer.js
+++ b/modules/ItemPricer.js
@@ -136,7 +136,25 @@
     
     if(item.typeline.includes("Maven's Invitation")) {
       return getValueFromTable("Invitation");
-    }    
+    }
+
+    //Invitations 
+    if(item.typeline.includes("Polaric")) {
+      return getValueFromTable("Polaric Invitation");
+    }
+
+    if(item.typeline.includes("Screaming")) {
+      return getValueFromTable("Screaming Invitation");
+    }
+
+    if(item.typeline.includes("Incandescent")) {
+      return getValueFromTable("Incandescent Invitation");
+    }
+
+    if(item.typeline.includes("Writhing")) {
+      return getValueFromTable("Writhing Invitation");
+    }
+
     if(
       item.category === "Map Fragments" 
       || (item.category === "Labyrinth Items" && item.typeline.endsWith("to the Goddess")) 

--- a/res/data/itemCategories.json
+++ b/res/data/itemCategories.json
@@ -1820,6 +1820,12 @@
     "Fragment of Knowledge" : ["Map Fragments", "Guardian Fragment"],
     "Fragment of Terror" : ["Map Fragments", "Guardian Fragment"],
     "Fragment of Emptiness" : ["Map Fragments", "Guardian Fragment"],
+
+    "Drox's Crest" :["Map Fragments", "Guardian Fragment"],
+    "Baran's Crest" :["Map Fragments", "Guardian Fragment"],
+    "Al-Hezmin's Crest" :["Map Fragments", "Guardian Fragment"],
+    "Veritania's Crest" :["Map Fragments", "Guardian Fragment"],
+
     "Ivory Watchstone" : "Atlas Region Upgrade Item",
     
     "Fine Delirium Orb" : ["Stackable Currency", "Delirium Orb"],


### PR DESCRIPTION
- Added Category for each of the memories. (#20)
- Added Categories for Eater of Worlds / Exarch Invitations (#29 )
- Added missing names for Sirius's Map Fragments

note: Cant find out how to get price for these items. currently the invitations are being recognized by the Item pricer but no value is found as shown here:

![image](https://user-images.githubusercontent.com/45792238/197932032-7597abc0-8086-4da5-a4d8-28369d20d6f1.png)
