### PR TITLE
Fix invitation pricing

### DIFF
--- a/modules/ItemCategoryParser.js
+++ b/modules/ItemCategoryParser.js
@@ -17,7 +17,15 @@ const nonStackableBulkItems = [
   'Maps',
   'Incubator',
   'Atlas Region Upgrade Item',
-  "Memory"    
+  "Kirac's Memory",
+  "Einhar's Memory",
+  "Niko's Memory",
+  "Alva's Memory",
+  "Writhing Invitation",
+  "Screaming Invitation",
+  "Polaric Invitation",
+  "Incandescent Invitation",
+  "Maven's Invitation"
 ];
 
 function getCategory(item, subcategory = false) {
@@ -30,8 +38,36 @@ function getCategory(item, subcategory = false) {
     return t;
   }
 
-  if(t.includes("Memory of")){
-    return "Memory";
+  //Memories
+  if(t.includes("Kirac's Memory")){
+    return "Kirac's Memory";
+  }
+  if(t.includes("Einhar's Memory")){
+    return "Einhar's Memory";
+  }
+  if(t.includes("Niko's Memory")){
+    return "Niko's Memory";
+  }
+  if(t.includes("Alva's Memory")){
+    return "Alva's Memory";
+  }
+
+
+  //Invitations
+  if(t.includes("Writhing Invitation")){
+    return "Writhing Invitation";
+  }
+  if(t.includes("Screaming Invitation")){
+    return "Screaming Invitation";
+  }
+  if(t.includes("Polaric Invitation")){
+    return "Polaric Invitation";
+  }
+  if(t.includes("Incandescent Invitation")){
+    return "Incandescent Invitation";
+  }
+  if(t.includes("Maven's Invitation")){
+    return "Maven's Invitation";
   }
   
   if(t.includes("Contract")) {

--- a/modules/ItemPricer.js
+++ b/modules/ItemPricer.js
@@ -136,7 +136,25 @@
     
     if(item.typeline.includes("Maven's Invitation")) {
       return getValueFromTable("Invitation");
-    }    
+    }
+
+    //Invitations 
+    if(item.typeline.includes("Polaric")) {
+      return getValueFromTable("Polaric Invitation");
+    }
+
+    if(item.typeline.includes("Screaming")) {
+      return getValueFromTable("Screaming Invitation");
+    }
+
+    if(item.typeline.includes("Incandescent")) {
+      return getValueFromTable("Incandescent Invitation");
+    }
+
+    if(item.typeline.includes("Writhing")) {
+      return getValueFromTable("Writhing Invitation");
+    }
+
     if(
       item.category === "Map Fragments" 
       || (item.category === "Labyrinth Items" && item.typeline.endsWith("to the Goddess")) 

--- a/modules/ItemPricer.js
+++ b/modules/ItemPricer.js
@@ -135,24 +135,24 @@
     }
     
     if(item.typeline.includes("Maven's Invitation")) {
-      return getValueFromTable("Invitation");
+      return getValueFromTable("Invitation", "Maven's Invitation");
     }
 
     //Invitations 
-    if(item.typeline.includes("Polaric")) {
-      return getValueFromTable("Polaric Invitation");
+    if(item.typeline.includes("Polaric Invitation")) {
+      return getValueFromTable("Invitation", "Polaric Invitation");
     }
 
-    if(item.typeline.includes("Screaming")) {
-      return getValueFromTable("Screaming Invitation");
+    if(item.typeline.includes("Screaming Invitation")) {
+      return getValueFromTable("Invitation", "Screaming Invitation");
     }
 
-    if(item.typeline.includes("Incandescent")) {
-      return getValueFromTable("Incandescent Invitation");
+    if(item.typeline.includes("Incandescent Invitation")) {
+      return getValueFromTable("Invitation", "Incandescent Invitation");
     }
 
-    if(item.typeline.includes("Writhing")) {
-      return getValueFromTable("Writhing Invitation");
+    if(item.typeline.includes("Writhing Invitation")) {
+      return getValueFromTable("Invitation", "Writhing Invitation");
     }
 
     if(

--- a/res/data/itemCategories.json
+++ b/res/data/itemCategories.json
@@ -1820,6 +1820,12 @@
     "Fragment of Knowledge" : ["Map Fragments", "Guardian Fragment"],
     "Fragment of Terror" : ["Map Fragments", "Guardian Fragment"],
     "Fragment of Emptiness" : ["Map Fragments", "Guardian Fragment"],
+
+    "Drox's Crest" :["Map Fragments", "Guardian Fragment"],
+    "Baran's Crest" :["Map Fragments", "Guardian Fragment"],
+    "Al-Hezmin's Crest" :["Map Fragments", "Guardian Fragment"],
+    "Veritania's Crest" :["Map Fragments", "Guardian Fragment"],
+
     "Ivory Watchstone" : "Atlas Region Upgrade Item",
     
     "Fine Delirium Orb" : ["Stackable Currency", "Delirium Orb"],


### PR DESCRIPTION
This goes after #28.

It fixes pricing of invitations by calling the getValueFromTable function with 2 arguments:
- The name of the category to find the item in
- The name of the item to find in the category.

In this case, Maven's invitations were their own category (`Invitation`), back in the days, but the category is now a full array with all of them in it.

This fixes pricing for all of them