### PR TITLE
feat: Prevent unidentified pack size from showing

### DIFF
--- a/main.js
+++ b/main.js
@@ -325,7 +325,8 @@ function initWindow(window) {
   });
   OCRWatcher.emitter.on("areaInfoComplete", (info) => {
     const tier = Utils.getMapTierString({ level: parseInt(info.areaInfo.level) });
-    const stats = `IIR: ${info.mapStats.iir} / IIQ: ${info.mapStats.iiq} / Pack Size: ${info.mapStats.packsize}`;
+    let stats = `IIR: ${info.mapStats.iir} / IIQ: ${info.mapStats.iiq}`;
+    if(info.mapStats.packsize && info.mapStats.packsize > 0) stats+= ` / Pack Size: ${info.mapStats.packsize}`;
     addMessage(`Got area info for <span class='eventText'>${info.areaInfo.name}</span> (${tier} - ${stats})`, true);
   });
   


### PR DESCRIPTION
# What

Make the overlay not show pack size if it cannot read it, like in Contracts or blueprints

# Why

It's cleaner

Fixes #17 