### PR TITLE
fix: Separate RateGetter's Init and Getter

### DIFF
--- a/main.js
+++ b/main.js
@@ -228,7 +228,8 @@ function checkLeague(settings, foundLeague) {
 async function init() {
   
   return new Promise(async (resolve, reject) => {
-  
+    RateGetterV2.init();
+
     logger.info("Initializing components");
     
     if(!global.messages) {
@@ -251,7 +252,7 @@ async function init() {
       if(characterCheckStatus === "valid") {
         logger.info("Starting components");
         setTimeout( () => {
-          RateGetterV2.Getter.update();
+          RateGetterV2.getUpdater().update();
         }, 1000);
         ClientTxtWatcher.start();
         ScreenshotWatcher.start();
@@ -454,11 +455,11 @@ async function createWindow() {
     addMessage(`Error uploading map list, please try again`);
   });
   ipcMain.on('rateGetterRetry', function(event) {
-    RateGetterV2.Getter.update();
+    RateGetterV2.getUpdater().update();
   });
   ipcMain.handle('refetchRates', (event) => {
     addMessage("<span class='eventText'>Refreshing item prices from poe.ninja...</span>")
-    RateGetterV2.Getter.update(true);
+    RateGetterV2.getUpdater().update(true);
   });
 
   require('./modules/electron-capture/src/main');

--- a/modules/RateGetterV2.js
+++ b/modules/RateGetterV2.js
@@ -44,15 +44,18 @@ var emitter = new EventEmitter();
 class RateGetterV2 {
   
   constructor() {
-    
     clearTimeout(nextRateGetTimer);
     this.ratesReady = false;
+    this.updateSettings();   
+  }
+
+  updateSettings() {
     this.settings = require('./settings').get();
-    this.league = this.settings.activeProfile.league;
+    this.league = this.settings?.activeProfile.league;
     this.priceCheckLeague = null;
     this.DB = require('./DB').getLeagueDB(this.league);
     
-    if(this.league.includes("SSF") && this.settings.activeProfile.overrideSSF) {
+    if(this.league && this.league.includes("SSF") && this.settings.activeProfile.overrideSSF) {
       // override ssf and get item prices from corresponding trade league
       // TODO undocumented league naming convention change in 3.13... must check this every league from now on
       // as of 3.13 "SSF Ritual HC" <--> "Hardcore Ritual"
@@ -62,14 +65,14 @@ class RateGetterV2 {
       }
       this.priceCheckLeague = l;
     }    
-    
   }
 
 /*
  * get today's rates from POE.ninja 
  */
   async update(isForced = false) {
-    
+    this.updateSettings();
+
     if(!this.league) {
       logger.info("No league set, will not attempt to get prices");
       return;
@@ -449,6 +452,13 @@ function cleanSeeds(arr, getLowConfidence = false) {
   return a;
 }
 
-let Updater = new RateGetterV2();
-module.exports.Getter = Updater;
+let Updater = null;
+module.exports.init = () => {
+  Updater = new RateGetterV2();
+};
+
+module.exports.getUpdater = () => {
+  return Updater;
+};
+
 module.exports.emitter = emitter;

--- a/modules/StashGetter.js
+++ b/modules/StashGetter.js
@@ -5,7 +5,7 @@ const https = require('https');
 const Utils = require('./Utils');
 const ItemParser = require('./ItemParser');
 const ItemPricer = require('./ItemPricer');
-const RateGetterV2 = require('./RateGetterV2').Getter;
+const RateGetterV2 = require('./RateGetterV2');
 
 var emitter = new EventEmitter();
 
@@ -151,7 +151,7 @@ class StashGetter {
 
   async get(interval = 10) {
 
-    if(!RateGetterV2.ratesReady) {
+    if(!RateGetterV2.getUpdater().ratesReady) {
       if(interval > 60) {
         logger.info("Maximum retries exceeded, deferring to next stash getting interval");
       } else {


### PR DESCRIPTION
# What

Separate RateGetter's Initialization call and Getter

# Why

To allow for startup calls to flow properly. When RateGetter is instantiated too early, it tries to read settings before they exists and just die on itself.
This prevented any new install from succeed.