### PR TITLE
Fix timeout errors

### DIFF
--- a/src/main/AuthManager.ts
+++ b/src/main/AuthManager.ts
@@ -152,7 +152,7 @@ const AuthManager = {
         ],
       });
 
-      clearTimeout(logoutTimer);
+      if(logoutTimer) clearTimeout(logoutTimer);
       const maxTimeout = 2147483647; // Max timeout for setTimeout
       if (millisecondsToExpiration > maxTimeout) {
         logger.info(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -455,12 +455,8 @@ const createWindow = async () => {
 
   win.on('close', (e: Event) => {
     clearInterval(autoUpdaterInterval);
+    clearTimeout(saveBoundsCallback);
     return;
-    // if (!isQuitting) {
-    //   e.preventDefault();
-    //   win.hide();
-    //   e.returnValue = false;
-    // }
   });
 
   win.once('ready-to-show', () => {

--- a/src/main/modules/RateGetterV2.ts
+++ b/src/main/modules/RateGetterV2.ts
@@ -48,7 +48,7 @@ var emitter = new EventEmitter();
 class RateGetterV2 {
   ratesReady: boolean = false;
   constructor() {
-    clearTimeout(nextRateGetTimer);
+    if(nextRateGetTimer) clearTimeout(nextRateGetTimer);
   }
 
   on(event, listener) {
@@ -153,7 +153,7 @@ class RateGetterV2 {
     const interval = next.valueOf() - Date.now();
     logger.info(`Set new timer for updating prices in ${Number(interval / 1000).toFixed(2)} sec`);
 
-    clearTimeout(nextRateGetTimer);
+    if(nextRateGetTimer) clearTimeout(nextRateGetTimer);
     nextRateGetTimer = setTimeout(() => {
       logger.info('Executing scheduled rate update');
       this.update();

--- a/src/main/modules/StashGetter.ts
+++ b/src/main/modules/StashGetter.ts
@@ -31,7 +31,7 @@ class StashGetter {
     const settings = SettingsManager.getAll();
     if (settings) {
       // clear any existing scheduled stash check
-      clearTimeout(this.nextStashGetTimer);
+      if(this.nextStashGetTimer) clearTimeout(this.nextStashGetTimer);
 
       emitter.removeAllListeners('scheduleNewStashCheck');
       emitter.on('scheduleNewStashCheck', () => {
@@ -43,7 +43,7 @@ class StashGetter {
 
   async refreshInterval() {
     const { interval = DefaultInterval } = SettingsManager.get('netWorthCheck');
-    clearTimeout(this.nextStashGetTimer);
+    if(this.nextStashGetTimer) clearTimeout(this.nextStashGetTimer);
     // default 5 min between checks
     const newInterval = this.previousTimestamp ? interval - ((moment().unix() - this.previousTimestamp) / 1000) : interval;
 

--- a/src/renderer/components/StashSettings/StashSettings.tsx
+++ b/src/renderer/components/StashSettings/StashSettings.tsx
@@ -93,7 +93,7 @@ const StashSettings = ({ store, settings }) => {
     const newInterval = e.target.value;
     setRefreshInterval(newInterval);
     // We delay the settings save in case the user is still typingF
-    clearTimeout(refreshIntervalUpdateTimeout);
+    if(refreshIntervalUpdateTimeout) clearTimeout(refreshIntervalUpdateTimeout);
     refreshIntervalUpdateTimeout = setTimeout(() => {
       ipcRenderer.invoke('save-settings:stash-refresh-interval', { interval: newInterval });
     }, 3000);


### PR DESCRIPTION
# What

- fixed: Timeouts being too loosely defined
- fixed: Closing down sequence.
 
# Why

These issues made the app stay running even when you thought it closed down properly, which created all of these "object destroyed" errors.