### PR TITLE
fix: Issue where new users would not have the right settings to trigger the Stash refresh

### DIFF
--- a/src/main/modules/StashGetter.ts
+++ b/src/main/modules/StashGetter.ts
@@ -79,24 +79,15 @@ class StashGetter {
   }
 
   async checkFullStashInterval() {
-    const settings = SettingsManager.getAll();
-    if (settings.stashCheck.enabled === false) {
+    const settings = SettingsManager.get('netWorthCheck');
+    if (!settings || !settings.interval || settings.enabled === false) {
       return false;
     }
 
-    let interval = settings.stashCheck.interval;
-    let units = settings.stashCheck.units;
+    let interval = settings.interval;
     const latestStashAge = await DB.getLatestStashAge(settings.activeProfile.league);
 
-    switch (units) {
-      case 'hours':
-        return latestStashAge >= interval;
-      case 'maps':
-        return await stashTabsManager.hasReachedMapLimit(interval, latestStashAge);
-      default:
-        logger.info(`Invalid stash check interval: [${interval}] [${units}]`);
-        return false;
-    }
+    return latestStashAge >= interval;
   }
 
   async get(interval = 10) {


### PR DESCRIPTION
# What

Make the first fullStashInterval check run properly by tying it to the new settings used for the rest of the stash check

# Why

I removed the old settings and so it would error in the first check and never really work after that.