### PR TITLE
Fixing a bug in incubator alert

### DIFF
--- a/old/main.js
+++ b/old/main.js
@@ -384,12 +384,12 @@ function initWindow(window) {
           equipments
             .map(
               ([name, icon]) =>
-                `<img src='${icon}' class='currencyText'/><span class='eventText'>${name}</span>`
+                `<span><img src='${icon}' class='currencyText'><span class='eventText'>${name}</span></span>`
             )
             .join('; '),
         true
       );
-    }
+    }``
   });
 
   RateGetterV2.emitter.removeAllListeners();

--- a/old/main.js
+++ b/old/main.js
@@ -384,12 +384,12 @@ function initWindow(window) {
           equipments
             .map(
               ([name, icon]) =>
-                `<span><img src='${icon}' class='currencyText'><span class='eventText'>${name}</span></span>`
+                `<img src='${icon}' class='currencyText'/><span class='eventText'>${name}</span>`
             )
             .join('; '),
         true
       );
-    }``
+    }
   });
 
   RateGetterV2.emitter.removeAllListeners();

--- a/src/main/modules/KillTracker.ts
+++ b/src/main/modules/KillTracker.ts
@@ -17,6 +17,7 @@ const incubatorGearSlots = [
   'Weapon',
   'Offhand',
   'Trinket',
+  'Belt',
   // weapon2 and offhand2 not included - alternate weapon set does not accumulate monster kills
   // seems inconsistent with gem leveling??
 ];
@@ -37,7 +38,7 @@ async function logKillCount(timestamp: number, eqp: { [key: string]: ItemData })
   });
 
   const settings = SettingsManager.getAll();
-  if (settings.activeProfile.enableIncubatorAlert) {
+  if (settings.enableIncubatorAlert) {
     // emit any missing incubators
     const emptySlotIcons = Object.values(eqp)
       .filter((item) => incubatorGearSlots.indexOf(item.inventoryId) >= 0 && !item.incubatedItem)

--- a/src/renderer/components/LogBox/LogBox.tsx
+++ b/src/renderer/components/LogBox/LogBox.tsx
@@ -16,8 +16,11 @@ const classPerType = {
 
 const Line = ({ messages, timestamp }) => {
   if (!messages) return null;
-  const formattedMessages = messages.map(({ type, text, link, linkEvent }) => {
-    const Element = type ? <span className={classPerType[type]}>{text}</span> : <>{text}</>;
+  const formattedMessages = messages.map(({ type, text, link, linkEvent, icon }) => {
+    const Element = [
+      icon ? <img src={icon} className={"Text--Icon"}></img> : null, 
+      type ? <span className={classPerType[type]}>{text}</span> : <>{text}</>,
+    ];
     if (link) {
       return (
         <Link to={link} style={{ fontSize: 'inherit' }}>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -100,6 +100,12 @@ span.negative {
   background-color: #111;
 }
 
+.Text--Icon {
+  height: 1em;
+  vertical-align: text-bottom;
+  min-width: 1em;
+}
+
 .Text--Legendary {
   color: #af6025;
 }

--- a/src/renderer/routes/Overlay.tsx
+++ b/src/renderer/routes/Overlay.tsx
@@ -48,8 +48,11 @@ const OverlayMapInfoLine = ({ run }) => {
 
 const OverlayNotificationLine = ({ messages }) => {
   if (!messages) return null;
-  const formattedMessages = messages.map(({ type, text }) => {
-    return type ? <span className={classPerType[type]}>{text}</span> : <>{text}</>;
+  const formattedMessages = messages.map(({ type, text, icon }) => {
+    return [
+      icon ? <img src={icon} className={"Text--Icon"}></img> : null, 
+      type ? <span className={classPerType[type]}>{text}</span> : <>{text}</>,
+    ];
   });
   return <OverlayLineContent message={formattedMessages} />;
 };
@@ -158,8 +161,8 @@ const Overlay = ({ store }) => {
   // Timer management
   const [time, setTime] = React.useState(defaultTimer);
   const [notificationTime, setNotificationTime] = React.useState(0);
-  const mapTrackingIntervalRef = useRef<NodeJS.Timer>();
-  const notificationIntervalRef = useRef<NodeJS.Timer>();
+  const mapTrackingIntervalRef = useRef<ReturnType<typeof setTimeout>>();
+  const notificationIntervalRef = useRef<ReturnType<typeof setTimeout>>();
   const generateDecreaseTimer = (timeType) => () => {
     const setter = timeType === 'map' ? setTime : setNotificationTime;
     const interval =


### PR DESCRIPTION
Fix the bug that incubator alert is not working.

Also add the ability for overlay and log to show icons, like here:

![Log](https://github.com/Qt-dev/exile-diary/assets/5366284/601764cf-33e1-4214-929a-d9a6b1d6b4fc)
![Overlay](https://github.com/Qt-dev/exile-diary/assets/5366284/09489c7c-0602-4ed4-8be0-589b66c3c096)

(stretching icons a bit with min width 1em, so narrow icons are more noticeable

Also change NodeJS.timer type to be dynamically determined. For some reason on my node 16.17 the type is NodeJS.Timeout and blocking build.
