### PR TITLE
Add item filter, add debug option

### DIFF
--- a/src/main/Responder.ts
+++ b/src/main/Responder.ts
@@ -9,6 +9,7 @@ import StashTabsManager from './StashTabsManager';
 import stashGetter from './modules/StashGetter';
 import RendererLogger from './RendererLogger';
 import * as ClientTxtWatcher from './modules/ClientTxtWatcher';
+import RunParser from './modules/RunParser';
 
 const getAppGlobals = async () => {
   logger.info('Loading global settings for the renderer process');
@@ -136,6 +137,11 @@ const saveStashRefreshInterval = async (e, params) => {
   stashGetter.refreshInterval();
 };
 
+const debugRecheckGain = async (e, startDate) => {
+  logger.info('Debugging recheck gain from the renderer process');
+  await RunParser.recheckGained(startDate);
+}
+
 const Responder = {
   'app-globals': getAppGlobals,
   'load-runs': loadRuns,
@@ -151,6 +157,7 @@ const Responder = {
   'oauth:logout': logout,
   'get-all-stats': getAllStats,
   'get-stash-tabs': getStashTabs,
+  'debug:recheck-gain': debugRecheckGain,
 };
 
 export default Responder;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -138,6 +138,7 @@ const createWindow = async () => {
     'get-stash-tabs',
     'save-settings:stashtabs',
     'save-settings:stash-refresh-interval',
+    'debug:recheck-gain',
   ];
   for (const event of events) {
     ipcMain.handle(event, Responder[event]);

--- a/src/main/modules/ItemCategoryParser.js
+++ b/src/main/modules/ItemCategoryParser.js
@@ -97,7 +97,7 @@ function getCategory(item, subcategory = false) {
         logger.info(`No base type found for gem [${t}]`);
         return '';
       }
-    case 5:
+    case 5:  // currency items 
       if (t.startsWith('Captured Soul')) {
         return 'Pantheon Soul';
       } else if (
@@ -108,7 +108,8 @@ function getCategory(item, subcategory = false) {
       ) {
         return 'Harvest Seed';
       }
-      return 'Labyrinth Items';
+      break;
+      // return 'Labyrinth Items';
     case 6:
       return 'Divination Card';
     case 7:

--- a/src/main/modules/RunParser.js
+++ b/src/main/modules/RunParser.js
@@ -546,18 +546,14 @@ function getItemsFor(evt) {
               importantDrops[item.typeline] = (importantDrops[item.typeline] || 0) + 1;
             }
 
-            if (item.value) {
-              totalValue += item.value;
+            const price = (await ItemPricer.price(item)) ?? { isVendor: false, value: 0 };
+            if (price.isVendor) {
+              totalValue += price.value;
+              price = 0;
             } else {
-              const price = (await ItemPricer.price(item)) ?? { isVendor: false, value: 0 };
-              if (price.isVendor) {
-                totalValue += price.value;
-                price = 0;
-              } else {
-                totalValue += price.value;
-              }
-              itemArr.push([price.value, item.id, item.event_id]);
+              totalValue += price.value;
             }
+            itemArr.push([price.value, item.id, item.event_id]);
           }
         }
 

--- a/src/renderer/components/ItemFilterSettings/ItemFilterSettings.css
+++ b/src/renderer/components/ItemFilterSettings/ItemFilterSettings.css
@@ -1,0 +1,65 @@
+.ItemFilter-Settings__Header {
+  margin: 20px 0 0;
+  color: white;
+  /* display: flex;
+  align-items: center;
+  justify-content: space-between; */
+  text-align: center;
+  width: 100%;
+  gap: 20px;
+}
+
+.ItemFilter-Settings__List {
+  width: 100%;
+}
+
+.ItemFilter-Settings__List-Item {
+  color: white;
+  font-family: FontInSmallCaps;
+  /* font-weight: bold; */
+  text-shadow: 0px 0px 5px black;
+  border-radius: 3px;
+  margin: 5px 0px;
+  border: 1px solid #888;
+}
+
+.ItemFilter-Settings__List-Item-Container {
+  display: flex;
+  gap: 10px;
+}
+
+.ItemFilter-Settings__List-Item--Folder {
+  padding-left: 15px;
+}
+
+.ItemFilter-Settings__List-Item--Folder .ItemFilter-Settings__Item-Icon__Image {
+  filter: grayscale(40%) brightness(90%);
+}
+
+.ItemFilter-Settings__Item-Icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.ItemFilter-Settings__Item-Icon__Image {
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.ItemFilter-Settings__Item-Icon__Checkbox {
+  background-color: #888;
+}
+
+.ItemFilter-Settings__Settings-Form {
+  margin: 20px 0 10px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  gap: 50px;
+}
+
+.ItemFilter-Settings__Settings-Form * {
+  flex-grow: 1;
+}

--- a/src/renderer/components/ItemFilterSettings/ItemFilterSettings.tsx
+++ b/src/renderer/components/ItemFilterSettings/ItemFilterSettings.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { observer } from 'mobx-react-lite';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import TextField from '@mui/material/TextField';
+import classNames from 'classnames';
+import './ItemFilterSettings.css';
+
+import { electronService } from '../../electron.service';
+import ListItemButton from '@mui/material/ListItemButton';
+import Checkbox from '@mui/material/Checkbox';                                        
+import ListItemText from '@mui/material/ListItemText';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Button from '@mui/material/Button';
+const { ipcRenderer } = electronService;
+
+const ContainerComponent = ({ children, isFolder, disabled, callback }) => {
+  if (isFolder) {
+    return <div className="ItemFilter-Settings__List-Item-Container">{children}</div>;
+  } else {
+    return (
+      <ListItemButton dense onClick={callback} disabled={disabled}>
+        {children}
+      </ListItemButton>
+    );
+  }
+};
+
+const itemFilterCategories = [
+  { id: "nonunique", desc: "Non-unique equipment", hint: "Normal, magic and rare gear (weapons, armour, jewellery)" },
+  { id: "unique", desc: "Unique equipment", hint: "Weapons, armour, jewellery, flasks and jewels" },
+  { id: "gem", desc: "Skill Gems" },
+  { id: "map", desc: "Maps", hint: "Also includes unique maps" },
+  { 
+    id: "divcard", 
+    desc: "Divination cards", 
+    // TODO: min value/stack options not implemented
+    opts: {
+      "card" : "per Card",
+      "fullStack" : "per Full Stack"
+    }
+  },
+  { id: "oil", desc: "Oils" },
+  { id: "fragment", desc: "Fragments", hint: "Also includes Offering to the Goddess and Maven's Invitation" },
+  { id: "delve", desc: "Fossils and resonators" },
+  { id: "catalyst", desc: "Catalysts" },
+  { id: "essence", desc: "Essences" },
+  { id: "incubator", desc: "Incubators" },
+  { id: "currency", desc: "Currency", hint: "Includes all other currency items not specifically listed above" }
+]; 
+
+const ItemFilterRow = ({filterCat, settings, saveSettingsCallback}) => {
+  const rowClasses = classNames({
+    'ItemFilter-Settings__List-Item': true,
+  });
+  const [ignored, setIgnored] = React.useState(settings[filterCat.id]?.ignore ?? false);
+  const Icon = require(`../../assets/img/itemtypeicons/${filterCat.id}.png`);
+  const toggleEnabled = async (e) => {
+    saveSettingsCallback(filterCat.id, { ignore: !ignored });
+    setIgnored(!ignored);
+  };
+
+  return (
+    <>
+      <ListItem
+        key={filterCat.id}
+        sx={{
+          backgroundColor: 'initial',
+          height: '2.5em',
+          width: `100%`,
+        }}
+        disablePadding
+        className={rowClasses}
+      >
+        <ContainerComponent
+          callback={toggleEnabled}
+          isFolder={false}
+          disabled={false}
+        >
+          <ListItemIcon sx={{ minWidth: 0 }} className="Stash-Settings__Item-Icon">
+            <img className="Stash-Settings__Item-Icon__Image" src={Icon} alt={filterCat.hint} />
+            <Checkbox
+                size="small"
+                edge="start"
+                checked={!ignored}
+                sx={{
+                  // color: pink[800],
+                  '&.Mui-checked': {
+                    color: '#fff',
+                  },
+                }}
+            />
+          </ListItemIcon>
+
+          <ListItemText>
+            {filterCat.desc}
+          </ListItemText>
+        </ContainerComponent>
+      </ListItem>
+    </>
+  );
+};
+const ObservedItemFilterRow = observer(ItemFilterRow);
+
+const ItemFilterSettings = ({ settings }) => {
+  settings.itemFilter = settings.itemFilter ?? {};
+  const saveSettings = React.useCallback((catId, newSetting) => {
+    settings.itemFilter[catId] = {...settings.itemFilter[catId], ...newSetting};
+    ipcRenderer.invoke('save-settings', { settings });
+  }, [settings]);
+  return (
+    <div className="ItemFilter-Settings">
+      <div className="ItemFilter-Settings__Header">
+        <div>
+          Select the items you would like to include in value calculation. Excluded items are still logged but 
+          will not contribute to the map profit.
+        </div>
+      </div>
+      <List className="ItemFilter-Settings__List">
+        {itemFilterCategories.map((filterCat: any) => (
+          <ObservedItemFilterRow filterCat={filterCat} key={filterCat.id} settings={settings.itemFilter} saveSettingsCallback={saveSettings} />
+        ))}
+      </List>
+    </div>
+  );
+};
+
+export default observer(ItemFilterSettings);

--- a/src/renderer/components/MainSettings/MainSettings.tsx
+++ b/src/renderer/components/MainSettings/MainSettings.tsx
@@ -75,6 +75,11 @@ const MainSettings = ({ settings, store }) => {
     navigate('/');
   };
 
+  const [debugStartDate, setDebugStartDate] = React.useState((new Date()).toISOString().replace(/-/g, '').split('T')[0]);
+  const handleDebug = () => {
+    ipcRenderer.invoke('debug:recheck-gain', debugStartDate)
+  }
+
   const handleSubmit = (e) => {
     e.preventDefault();
     const data = {
@@ -256,6 +261,25 @@ const MainSettings = ({ settings, store }) => {
           <Button type="submit">Save</Button>
           <Button onClick={handleBack}>Cancel</Button>
         </ButtonGroup>
+        {
+          process.env.NODE_ENV === 'development' && (
+            <>
+            <Divider className="Settings__Separator" />
+            <TextField
+              fullWidth
+              label="Start date for reparsing the runs"
+              id="debug-start"
+              variant="filled"
+              size="small"
+              value={debugStartDate}
+              onChange={(e) => setDebugStartDate(e.target.value)}
+            />
+            <ButtonGroup variant="outlined" fullWidth aria-label="Debug">
+              <Button onClick={handleDebug}>Debug</Button>
+            </ButtonGroup>
+            </>
+          )
+        }
       </Box>
     </form>
   );

--- a/src/renderer/routes/Settings.tsx
+++ b/src/renderer/routes/Settings.tsx
@@ -4,6 +4,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
 import StashSettings from '../components/StashSettings/StashSettings';
+import ItemFilterSettings from '../components/ItemFilterSettings/ItemFilterSettings';
 import './Settings.css';
 import MainSettings from '../components/MainSettings/MainSettings';
 import { observer } from 'mobx-react-lite';
@@ -46,6 +47,7 @@ const Settings = ({ characterStore, stashTabStore }) => {
         <Tabs value={tabValue} centered aria-label="Settings Tabs" onChange={handleTabChange}>
           <Tab label="Account" {...a11yProps(0)} />
           <Tab label="Stashes" {...a11yProps(1)} />
+          <Tab label="Item Filter" {...a11yProps(2)} />
           {/* Add new stuff here */}
         </Tabs>
       </Box>
@@ -54,6 +56,9 @@ const Settings = ({ characterStore, stashTabStore }) => {
       </div>
       <div hidden={tabValue !== 1}>
         <StashSettings store={stashTabStore} settings={settings} />
+      </div>
+      <div hidden={tabValue !== 2}>
+        <ItemFilterSettings settings={settings} />
       </div>
     </div>
   );


### PR DESCRIPTION
### Item filter 
Move another functionality needed from the old diary -- item filter.
![Screenshot 2023-08-24 010615](https://github.com/Qt-dev/exile-diary/assets/5366284/38387b2f-458f-4332-a33d-dd718f0884d9)


Because the tool kept making me feel richer than I was by counting incubators in.

Haven't thoroughly tested but incubator filter works (ignoring incubator from item filter):

* Before ![Before](https://github.com/Qt-dev/exile-diary/assets/5366284/539c5c05-3d3a-428f-b2e9-013769b1b0e0)
* After ![After](https://github.com/Qt-dev/exile-diary/assets/5366284/b3258046-9cb2-4898-abd3-f2fb17ca9d53)


### Debug option
To test this the debug button is also migrated as `recheckGain` function is already available.

### Pricer logic
Skip the cached item value and force RunParser to use item pricer every time. It makes the logic more consistent (otherwise for some item it calls pricer while for others doesn't). Tested a bit it seems not affecting other activities than debugging run -- normal map parsing already calls pricer every time, and viewing history doesn't seem to trigger it.

### Item category
Remove the old "lab item" thing. `frameType=5` is now generic for all currencies: https://www.pathofexile.com/developer/docs/reference#type-FrameType

This part of logic basically marked everything other than actual currency to lab item, breaking item filter.


