### PR TITLE
fix: Enable the option to disable the overlay

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -555,9 +555,13 @@ const createWindow = async () => {
     }
   });
   OverlayController.events.on('focus', () => {
-    if (SettingsManager.get('overlayEnabled')) {
+    logger.info(`Overlay focused, ${SettingsManager.get("overlayEnabled")}`);
+    if (SettingsManager.get('overlayEnabled') === true) {
       overlayWindow.show();
       overlayWindow.setIgnoreMouseEvents(false);
+    } else {
+      overlayWindow.hide();
+      overlayWindow.setIgnoreMouseEvents(true);
     }
   });
   OverlayController.events.on('moveresize', (event) => {


### PR DESCRIPTION
# What

Make the app hide the overlay if it ever focuses on PoE but the settings are set to not enable it

# Why

To allow for the overlay to just not show for people who prefer that.
This will be done in a better and more clever way in the future, but for now that will do the trick while I go on holidays.