### PR TITLE
Fix object is destroyed

### DIFF
--- a/src/main/RendererLogger.ts
+++ b/src/main/RendererLogger.ts
@@ -20,8 +20,20 @@ export default {
       return;
     }
     Renderer.send('add-log', { messages });
-    if (onOverlay) {
-      OverlayRenderer.send('overlay:message', { messages });
+    if(onOverlay && !OverlayRenderer) {
+      logger.error('OverlayRenderer does not seem to be initialized');
+      logger.error(OverlayRenderer);
+
+    } else if (onOverlay) {
+      try {
+        OverlayRenderer.send('overlay:message', { messages });
+      } catch(e) {
+        Renderer.send('add-log', { messages: [{ text: 'OverlayRenderer errored while sending a message. Is it disconnected?', type: 'error' }] });
+
+        logger.error('OverlayRenderer errored while sending a message. Is it disconnected?');
+        logger.error(OverlayRenderer);
+        logger.error(e);
+      }
     }
   },
 };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -589,6 +589,17 @@ const createWindow = async () => {
     logger.info('Closing the overlay');
   });
 
+  let isOverlayInitialized = false;
+  overlayWindow.on('ready-to-show', () => {
+    if(!isOverlayInitialized) {
+      logger.info('Overlay is ready to show, attaching it to PoE');
+      OverlayController.attachByTitle(overlayWindow, 'Path of Exile');
+      isOverlayInitialized = true;
+    } else {
+      logger.info('Overlay is ready to show, but it is already initialized');
+    }
+  });
+
   if (isDev) {
     win.loadURL(devUrl);
     overlayWindow.loadURL(`${devUrl}#/overlay`);
@@ -598,7 +609,6 @@ const createWindow = async () => {
     win.loadURL(URL);
     overlayWindow.loadURL(`${URL}#/overlay`);
   }
-  OverlayController.attachByTitle(overlayWindow, 'Path of Exile');
 
   app.on('will-quit', () => {
     logger.info('Exile Diary Reborn is closing');


### PR DESCRIPTION
# What

Make overlay initialization run only when ready, and only once

# Why

This is fixing an issue where the Overlay was starting too fast and getting disconnected from the main process.