### PR TITLE
fix: Prevent Screenshotwatcher from watching inexistant folder

### DIFF
--- a/src/main/modules/ScreenshotWatcher.js
+++ b/src/main/modules/ScreenshotWatcher.js
@@ -214,7 +214,11 @@ function start() {
 
   settings = require('./settings').get();
 
-  if (settings.screenshotDir !== 'disabled') {
+  if (
+    settings.screenshotDir &&
+    settings.screenshotDir !== 'disabled' &&
+    settings.screenshotDir.length > 0
+  ) {
     logger.info('Watching ' + settings.screenshotDir);
     watcher = chokidar.watch(`${settings.screenshotDir}`, {
       usePolling: true,


### PR DESCRIPTION
# What

Make ScreenshotWatcher abort instead of trying to watch bad folders

# Why

Because this was causing a memory/CPU issue.