### PR TITLE
Prevent errors when item filters is not defined yet

### DIFF
--- a/src/main/modules/ItemPricer.ts
+++ b/src/main/modules/ItemPricer.ts
@@ -510,7 +510,7 @@ async function price(
       return { isVendor: false, value: 0 };
     } else {
       let currFilter = ItemFilter.getForCategory('currency');
-      if (currFilter.ignore) {
+      if (currFilter && currFilter.ignore) {
         if (currFilter.minValue) {
           if (vendorValue < currFilter.minValue) {
             if (log) {


### PR DESCRIPTION
# What

Prevent undefined filters from making all the stash tab tracking error

# Why

To remove the 'ignore' error