### PR TITLE
Cleanup run store to save deaths state

### DIFF
--- a/src/renderer/stores/domain/run.ts
+++ b/src/renderer/stores/domain/run.ts
@@ -60,7 +60,7 @@ export class Run {
     this.duration = moment.duration(this.lastEvent.diff(this.firstEvent));
     this.xp = json.xpgained;
     this.xpPerHour = this.xp / this.duration.asHours();
-    this.deaths = json.deaths;
+    this.deaths = this.deaths || json.deaths;
     this.profit = json.gained;
     this.profitPerHour = this.profit / this.duration.asHours();
     this.kills = json.kills;


### PR DESCRIPTION
# What

Cleanup run store to save deaths

# Why

The main page was losing track of death counts