### PR TITLE
Update channel to only update from latest

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -186,7 +186,7 @@ class MainProcess {
       autoUpdater.quitAndInstall();
     });
 
-    autoUpdater.channel = 'alpha'; // TODO: change this when pushing to prod
+    autoUpdater.channel = 'latest'; // TODO: change this when pushing to prod
     autoUpdater.logger = logger;
     autoUpdater.autoDownload = false;
     autoUpdater.on('update-available', (info) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -186,7 +186,7 @@ class MainProcess {
       autoUpdater.quitAndInstall();
     });
 
-    autoUpdater.channel = 'latest'; // TODO: change this when pushing to prod
+    autoUpdater.channel = 'latest';
     autoUpdater.logger = logger;
     autoUpdater.autoDownload = false;
     autoUpdater.on('update-available', (info) => {


### PR DESCRIPTION
# What

Update channel used in the autoupdater

# Why

To prevent users from getting rogue alpha builds without asking