### PR TITLE
fix: Remove league dates from stats pull

### DIFF
--- a/src/main/StatsManager.ts
+++ b/src/main/StatsManager.ts
@@ -857,7 +857,7 @@ class StatsManager {
 
 export default {
   getAllStats: async ({ league, characterName }: GetStatsParams) => {
-    const runs = (await DB.getAllRuns(league))?.map(formatRun);
+    const runs = (await DB.getAllRuns())?.map(formatRun);
     const items = await DB.getAllItems(league);
     const divinePrice = await RatesManager.getCurrencyValue(
       league,


### PR DESCRIPTION
# What

Remove league dates from stats pull

# Why

It was messing with data in weird cases. There is no point is splitting stats at the moment, we will look into reintroducing it in the future if people need the feature back, but we will need to look into how league dates are defined.