### PR TITLE
Prevent Currency check from erroring if rates are out

### DIFF
--- a/src/main/modules/ItemPricer.ts
+++ b/src/main/modules/ItemPricer.ts
@@ -917,7 +917,7 @@ async function getCurrencyByName(
   league = SettingsManager.get('activeProfile').league
 ) {
   const rates = await getRatesFor(timestamp, league);
-  if (!rates) {
+  if (!rates || !rates['Currency']) {
     return 0;
   }
   const value = rates['Currency'][type];


### PR DESCRIPTION
# What

Fix issue with Divine Prices fetching triggering errors too early (on price checks)
