### PR TITLE
Feat-remove-overlay-clicks

### DIFF
--- a/src/main/Responder.ts
+++ b/src/main/Responder.ts
@@ -190,7 +190,7 @@ const debugFetchStashTabs = async () => {
 
 const fetchOverlayPersistanceStatus = async () => {
   logger.info('Fetching Overlay Persistence status for the overlay');
-  return await SettingsManager.get('overlayPersistenceDisabled');
+  return await SettingsManager.get('overlayPersistenceEnabled');
 };
 
 const Responder = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -129,6 +129,8 @@ class MainProcess {
       show: false,
       skipTaskbar: true,
       transparent: true,
+      useContentSize:true,
+      focusable: true,
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false,
@@ -596,22 +598,20 @@ class MainProcess {
     });
 
     OverlayController.events.on('blur', () => {
-      if (!this.overlayWindow.isFocused()) {
-        this.overlayWindow.hide();
-      }
+      this.overlayWindow.setEnabled(false);
     });
 
     OverlayController.events.on('focus', () => {
       logger.info(
-        `Overlay focused, enabled:${SettingsManager.get(
+        `Overlay controller focused, enabled:${SettingsManager.get(
           'overlayEnabled'
         )}, persistenceDisabled:${SettingsManager.get('overlayPersistenceDisabled')}`
       );
       if (SettingsManager.get('overlayEnabled') === true) {
-        this.overlayWindow.show();
+        this.overlayWindow.setEnabled(true);
         this.overlayWindow.setIgnoreMouseEvents(false);
       } else {
-        this.overlayWindow.hide();
+        this.overlayWindow.setEnabled(false);
         this.overlayWindow.setIgnoreMouseEvents(true);
       }
     });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -677,7 +677,8 @@ class MainProcess {
 
     globalShortcut.register('CommandOrControl+F7', () => {
       logger.info('Toggling overlay visibility');
-      this.sendToOverlay('overlay:toggle-visibility');
+      const overlayPersistenceDisabled = SettingsManager.get('overlayPersistenceDisabled');
+      SettingsManager.set('overlayPersistenceDisabled', !overlayPersistenceDisabled);
     });
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -498,9 +498,9 @@ class MainProcess {
     ipcMain.on('get-net-worth', () => {
       StashGetter.getNetWorth();
     });
-    SettingsManager.registerListener('overlayPersistenceDisabled', (isDisabled) => {
-      logger.info(`Setting Persistence to Disabled:${isDisabled}`);
-      this.sendToOverlay('overlay:set-persistence', isDisabled);
+    SettingsManager.registerListener('overlayPersistenceEnabled', (isOverlayEnabled) => {
+      logger.info(`Setting Overlay Persistence to Enabled:${isOverlayEnabled}`);
+      this.sendToOverlay('overlay:set-persistence', isOverlayEnabled);
     });
 
     AuthManager.setMessenger(this.mainWindow.webContents);
@@ -605,7 +605,7 @@ class MainProcess {
       logger.info(
         `Overlay controller focused, enabled:${SettingsManager.get(
           'overlayEnabled'
-        )}, persistenceDisabled:${SettingsManager.get('overlayPersistenceDisabled')}`
+        )}, persistenceEnabled:${SettingsManager.get('overlayPersistenceEnabled')}`
       );
       if (SettingsManager.get('overlayEnabled') === true) {
         this.overlayWindow.setEnabled(true);
@@ -677,8 +677,8 @@ class MainProcess {
 
     globalShortcut.register('CommandOrControl+F7', () => {
       logger.info('Toggling overlay visibility');
-      const overlayPersistenceDisabled = SettingsManager.get('overlayPersistenceDisabled');
-      SettingsManager.set('overlayPersistenceDisabled', !overlayPersistenceDisabled);
+      const overlayPersistenceEnabled = SettingsManager.get('overlayPersistenceEnabled');
+      SettingsManager.set('overlayPersistenceEnabled', !overlayPersistenceEnabled);
     });
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -674,6 +674,11 @@ class MainProcess {
       clearTimeout(this.saveBoundsCallback);
       clearTimeout(this.autoUpdaterInterval);
     });
+
+    globalShortcut.register('CommandOrControl+F7', () => {
+      logger.info('Toggling overlay visibility');
+      this.sendToOverlay('overlay:toggle-visibility');
+    });
   }
 
   async startWindows() {

--- a/src/renderer/components/MainSettings/MainSettings.tsx
+++ b/src/renderer/components/MainSettings/MainSettings.tsx
@@ -75,7 +75,7 @@ const MainSettings = ({ settings, store, runStore }) => {
     settings.screenshots && !!settings.screenshots.allowCustomShortcut;
   const enableScreenshotFolderWatch =
     settings.screenshots && !!settings.screenshots.allowFolderWatch;
-  const overlayPersistenceDisabled = !!settings.overlayPersistenceDisabled;
+  const overlayPersistenceEnabled = !!settings.overlayPersistenceEnabled;
 
   const handleBack = () => {
     navigate('/');
@@ -93,7 +93,6 @@ const MainSettings = ({ settings, store, runStore }) => {
       screenshotDir: e.target.screenshot_location.value,
       alternateSplinterPricing: e.target.alternate_splinter_pricing.checked,
       overlayEnabled: e.target.overlay_enabled.checked,
-      overlayPersistenceDisabled: e.target.overlay_persistence_disabled.checked,
       enableIncubatorAlert: e.target.enable_incubator_alert.checked,
       screenshots: {
         allowCustomShortcut: e.target.enable_screenshot_custom_shortcut.checked,
@@ -242,10 +241,11 @@ const MainSettings = ({ settings, store, runStore }) => {
             control={
               <Checkbox
                 id="overlay_persistence_disabled"
-                defaultChecked={overlayPersistenceDisabled}
+                disabled
+                defaultChecked={overlayPersistenceEnabled}
               />
             }
-            label="Disable Overlay Persistence (= Always visible overlay)"
+            label="Enable Overlay Persistence (Toggle this setting by pressing CTRL+F7)"
           />
         </div>
         <div className="Settings__Checkbox__Row">
@@ -276,7 +276,8 @@ const MainSettings = ({ settings, store, runStore }) => {
             label="Enable Screenshot Folder Monitoring"
           />
         </div>
-        <Divider className="Settings__Separator" />
+        {/* TODO: Add these settings if needed */}
+        {/* <Divider className="Settings__Separator" />
         <div>This section is not plugged in yet</div>
         <div className="Settings__Checkbox__Row">
           <FormControlLabel control={<Checkbox disabled />} label="Minimize to Tray" />
@@ -295,7 +296,7 @@ const MainSettings = ({ settings, store, runStore }) => {
         </div>
         <div className="Settings__Checkbox__Row">
           <FormControlLabel control={<Checkbox disabled />} label="Disable Gear Tracking" />
-        </div>
+        </div> */}
         <Divider className="Settings__Separator" />
         <ButtonGroup variant="outlined" fullWidth aria-label="Settings Control Buttons">
           <Button type="submit">Save</Button>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -9,7 +9,6 @@ html {
   color: #aaaaaa;
   background: transparent;
   padding: 0;
-  background-color: #000;
 }
 
 code {
@@ -19,10 +18,11 @@ code {
 .Root {
   display: grid;
   grid-template-columns: 160px auto;
-  min-height: calc(100% - 20px);
+  min-height: calc(100vh - 20px);
   width: calc(100% - 20px);
   grid-column-gap: 10px;
   padding: 10px;
+  background-color: #000;
 }
 
 .Left-Container {

--- a/src/renderer/routes/Overlay.tsx
+++ b/src/renderer/routes/Overlay.tsx
@@ -136,7 +136,6 @@ const Overlay = ({ store }) => {
   const [latestMessage, setLatestMessage] = React.useState<JSX.Element | null>(<div>---</div>);
   const [latestMapTrackingMessage, setLatestMapTrackingMessage] =
     React.useState<JSX.Element | null>(<div>---</div>);
-  const [persistenceDisabled, setPersistenceDisabled] = React.useState(true);
 
   // Timer management
   const [time, setTime] = React.useState(defaultTimer);
@@ -193,7 +192,7 @@ const Overlay = ({ store }) => {
 
   const boxClassNames = classNames({
     'Overlay__Box--Open': open,
-    'Overlay__Box--Invisible': !open && time <= 0 && notificationTime <= 0 && persistenceDisabled,
+    'Overlay__Box--Invisible': !open && time <= 0 && notificationTime <= 0,
     Overlay__Box: true,
     Box: true,
   });
@@ -206,7 +205,7 @@ const Overlay = ({ store }) => {
     ipcRenderer.removeAllListeners('overlay:set-persistence');
     ipcRenderer.on('overlay:set-persistence', (event, isDisabled) => {
       logger.info('Setting persistence to', isDisabled);
-      setPersistenceDisabled(isDisabled);
+      setOpen(!isDisabled);
     });
   }, []);
 
@@ -224,10 +223,7 @@ const Overlay = ({ store }) => {
       setLatestMessage(<OverlayNotificationLine messages={messages} />);
     });
     ipcRenderer.invoke('overlay:get-persistence').then((isDisabled) => {
-      setPersistenceDisabled(isDisabled);
-    });
-    ipcRenderer.on('overlay:toggle-visibility', () => {
-      setOpen(open => !open);
+      setOpen(!isDisabled);
     });
 
     return () => {
@@ -249,7 +245,6 @@ const Overlay = ({ store }) => {
     <div className="Overlay" ref={ref}>
       <div className={boxClassNames}>
         <OverlayLine
-          invisible={persistenceDisabled}
           time={time}
           isOpen={open || time > -1}
           latestMapTrackingMessage={latestMapTrackingMessage}
@@ -257,7 +252,6 @@ const Overlay = ({ store }) => {
           <OverlayMapInfoLine run={store.currentRun} />
         </OverlayLine>
         <OverlayLine
-          invisible={persistenceDisabled}
           time={notificationTime}
           isOpen={open || notificationTime > -1}
           alwaysVisibleChildren={<img className="Overlay__Logo" src={Logo} alt="Logo" />}


### PR DESCRIPTION
# What

- Prevent any click on the overlay
- Make the overlay toggle work with new shortcut (CTRL+F7)

# Why

To prevent any weird click issues with Overlays on linux and on windows.

Known Error: The overlay still appears in task bar on windows somehow.... 