### PR TITLE
fix: Make GetCurrencyByName not error when no league is set

### DIFF
--- a/src/main/modules/ItemPricer.ts
+++ b/src/main/modules/ItemPricer.ts
@@ -914,7 +914,7 @@ async function price(
 async function getCurrencyByName(
   type: string,
   timestamp = dayjs().format('YYYYMMDD'),
-  league = SettingsManager.get('activeProfile').league
+  league = SettingsManager.get('activeProfile')?.league || 'Standard'
 ) {
   const rates = await getRatesFor(timestamp, league);
   if (!rates || !rates['Currency']) {


### PR DESCRIPTION
# What

Fix issue with GetCurrencyByName erroring when no league is set

# Why

It was happening at random times and alarming players :)