### PR TITLE
Fix stash not showing

### DIFF
--- a/src/main/db/stashtabs.ts
+++ b/src/main/db/stashtabs.ts
@@ -24,7 +24,8 @@ const StashTabs = {
     const query =
       'SELECT items, value FROM stashes where timestamp <= ? ORDER BY timestamp DESC LIMIT 1';
     try {
-      return (DB.all(query, [timestamp], league)) as any ?? [];
+      const stash = (DB.get(query, [timestamp], league));
+      return stash ?? [];
     } catch (err) {
       logger.error(`Error getting stash data: ${JSON.stringify(err)}`);
       return '{}';

--- a/src/main/db/stats.ts
+++ b/src/main/db/stats.ts
@@ -303,14 +303,14 @@ const stats = {
     `;
 
     try {
-      logger.info(
-        `Getting profit for last hour ${beginningOfTracking}`,
-        DB.get(query, [beginningOfTracking, beginningOfTracking])
-      );
-      const { total_time_seconds: totalTime, total_profit: profit } = DB.get(query, [
+      logger.debug(
+        `Getting profit for period starting at: ${beginningOfTracking}`
+        );
+      const { total_time_seconds: totalTime, total_profit: profit, runs, items } = DB.get(query, [
         beginningOfTracking,
         beginningOfTracking,
-      ]) as { total_time_seconds: number; total_profit: number };
+      ]) as { total_time_seconds: number; total_profit: number, runs: number, items: number };
+      logger.debug('Result', { totalTime, profit, runs, items } );
       const profitPerHour = totalTime > 0 ? (profit / totalTime) * 3600 : 0;
       return parseFloat(profitPerHour.toFixed(2)) ?? 0;
     } catch (err) {


### PR DESCRIPTION
# What

Make Stash DB call use `.get` instead of `.all`

# Why

To make Stash Tabs show up again in the Stash page. The `.all` changed the format of the db call, and was unnecessary since we were calling for one specific entry (one stash tab data)