### PR TITLE
fix: Make Settings set up default for all needed properties

### DIFF
--- a/src/main/SettingsManager.ts
+++ b/src/main/SettingsManager.ts
@@ -28,6 +28,10 @@ const DefaultSettings = {
   netWorthCheck: {
     interval: 500,
   },
+  overlayPosition: {
+    x: 0,
+    y: 0,
+  },
   trackedStashTabs: {},
   itemFilter: {},
 };
@@ -54,7 +58,11 @@ class SettingsManager {
       logger.info('Initializing settings.json');
       await fs.writeFile(settingsPath, JSON.stringify(DefaultSettings));
     }
-    this.settings = require(settingsPath);
+
+    this.settings = {
+      ...DefaultSettings,
+      ...require(settingsPath),
+    };
 
     this.scheduleSave();
 


### PR DESCRIPTION
# What

Make Settings setup the default structure on start

# Why

To make overlays (and the rest of the app) stop erroring because of silly unset settings