### PR TITLE
Fix missing category crashes

### DIFF
--- a/src/helpers/item.ts
+++ b/src/helpers/item.ts
@@ -90,5 +90,5 @@ export const getCategory = (item, subcategory = false) => {
 
   logger.error(`No category found for item ${item.id || '(no id)'}! JSON follows:`);
   logger.info(item);
-  return null;
+  return "Other";
 };


### PR DESCRIPTION
# What

Make the default category not empty 

# Why

To ensure not recognized items do not crash the app