### PR TITLE
Fix ocr issues

### DIFF
--- a/src/main/modules/OCRWatcher.js
+++ b/src/main/modules/OCRWatcher.js
@@ -166,12 +166,13 @@ async function processImageBuffer(buffer, timestamp, type) {
     });
 
     if (type === 'area') {
+      logger.debug('Processing area info');
       const area = getAreaInfo(lines);
-      const areaName = await getAreaNameFromDB(timestamp);
-      if (areaName) {
+      try {
+        const areaName = await getAreaNameFromDB(timestamp); 
         logger.info(`Got last entered area from db: ${areaName}`);
         area.name = areaName;
-      } else {
+      } catch (e) {
         logger.info(`Got last entered area from ocr: ${area.name}`);
       }
 

--- a/src/main/modules/ScreenshotWatcher.ts
+++ b/src/main/modules/ScreenshotWatcher.ts
@@ -33,11 +33,11 @@ const emitter = new EventEmitter();
 const getYboundsFromImage = (rawImage: any, metadata: { height: number; width: number }) => {
   type lineData = { blue: number; black: number; total: number };
   const batchSize = Math.floor(metadata.height / 5); // Size of the batch of rows to check together
-  const firstLineMargin = 3; // Margin to make the top line a bit more readable
+  const firstLineMargin = 2; // Margin to make the top line a bit more readable
   const endDetectionHeight = 40; // Height of the bottom limit we detect (Answer to "After how many pixels do we consider this box to be done?")
   const detectionWidth = 40; // Number of pixels to check for detection. We do not need the full line but we need enough pixels to start capturing blue pixels
-  const marginAfterOrange = 85; // Margin after the first orange line to start checking for the end of the box. Distance between bottom of stats and beginning of first mod (-5 px to give room)
-  const minOrangePixels = 20;
+  const marginAfterOrange = 55; // Margin after the first orange line to start checking for the end of the box. Distance between bottom of stats and beginning of first mod (-5 px to give room)
+  const minOrangePixels = 10;
   const initialFirstLine = 200;
 
   let isDone = false;

--- a/src/main/modules/ScreenshotWatcher.ts
+++ b/src/main/modules/ScreenshotWatcher.ts
@@ -287,10 +287,10 @@ async function process(file: string | Buffer) {
     .toBuffer();
   sharp(modsImage).toFile(path.join(filepath, 'mods.jpg'));
 
-  await Promise.all([
-    OCRWatcher.processImageBuffer(statsImage, filePrefix, 'area'),
-    OCRWatcher.processImageBuffer(modsImage, filePrefix, 'mods'),
-  ]);
+  await OCRWatcher.processImageBuffer(statsImage, filePrefix, 'area');
+  await OCRWatcher.processImageBuffer(modsImage, filePrefix, 'mods');
+
+  logger.debug('Finished processing screenshot');
 }
 
 function isBlue(rgba: { r: any; g: any; b: any }) {


### PR DESCRIPTION
# What

Fix some OCR issues:
- Make mods detection work better on thin wide resolutions (yay for Lailloken-UI)
- Make area name detection less prone to error
- Prevent a deadlock state when the text detection was triggered on the area stats and the mods at the same time

