### PR TITLE
Add private league pricing

### DIFF
--- a/src/main/SettingsManager.ts
+++ b/src/main/SettingsManager.ts
@@ -13,6 +13,7 @@ const DefaultSettings = {
   activeProfile: {
     characterName: null,
     league: null,
+    leagueOverride: null,
     valid: false,
   },
   alternateSplinterPricing: true,

--- a/src/main/db/rates.ts
+++ b/src/main/db/rates.ts
@@ -37,7 +37,7 @@ const rates = {
   },
   insertRates: async (league: string, date: string, rates: any): Promise<boolean> => {
     logger.info(`Inserting rates for ${date} (league: ${league}) into DB`);
-    const query = 'INSERT OR IGNORE INTO fullrates (date, data) VALUES (?, ?)';
+    const query = 'INSERT OR REPLACE INTO fullrates (date, data) VALUES (?, ?)';
     const data = JSON.stringify(rates);
     const buffer = await new Promise((resolve, reject) => {
       zlib.deflate(data, (err, buffer) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -466,6 +466,7 @@ class MainProcess {
       logger.info("<span class='eventText'>Getting item prices from poe.ninja...</span>");
     });
     RateGetterV2.on('doneGettingPrices', () => {
+      ItemPricer.updateRates(); 
       logger.info("<span class='eventText'>Finished getting item prices from poe.ninja</span>");
     });
     RateGetterV2.on('gettingPricesFailed', () => {

--- a/src/main/modules/ItemPricer.ts
+++ b/src/main/modules/ItemPricer.ts
@@ -62,6 +62,13 @@ async function getRatesFor(eventId: string, league = SettingsManager.get('active
   return ratesCache[date][league] ?? {};
 }
 
+async function updateRates(league = SettingsManager.get('activeProfile').league) {
+  const date = dayjs().format('YYYYMMDD');
+  ratesCache[date] = ratesCache[date] || {};
+  ratesCache[date][league] = await RatesManager.fetchRatesForDay(league, date);
+  writeFile(`./${date}.json`, JSON.stringify(ratesCache[date][league])); // In case you need to inspect the full rates for a day
+}
+
 class PriceMatcher {
   ratesCache: {};
   date: string;
@@ -980,4 +987,5 @@ export default {
   price,
   getRatesFor,
   getCurrencyByName,
+  updateRates,
 };

--- a/src/main/modules/RateGetterV2.ts
+++ b/src/main/modules/RateGetterV2.ts
@@ -133,7 +133,7 @@ class RateGetterV2 {
     try {
       this.setIsUpdating(true);
       const activeProfile = SettingsManager.get('activeProfile');
-      const privateLeaguePriceMaps = SettingsManager.get('privateLeaguePriceMaps');
+      // const privateLeaguePriceMaps = SettingsManager.get('privateLeaguePriceMaps');
       if (!activeProfile) {
         logger.error('No settings found, will not attempt to get prices');
         return;
@@ -148,22 +148,22 @@ class RateGetterV2 {
         return;
       }
 
-      if (Utils.isPrivateLeague(activeProfile.league)) {
-        // TODO: Fix this part with private leagues
-        if (privateLeaguePriceMaps && privateLeaguePriceMaps[activeProfile.league]) {
-          logger.info(
-            `Private league ${activeProfile.league} will use prices from ${
-              privateLeaguePriceMaps[activeProfile.league]
-            }`
-          );
-          activeProfile.league = privateLeaguePriceMaps[activeProfile.league];
-        } else {
-          logger.info(
-            `No price map set for private league ${activeProfile.league}, will not attempt to get prices`
-          );
-          return;
-        }
-      }
+      // if (Utils.isPrivateLeague(activeProfile.league)) {
+      //   // TODO: Fix this part with private leagues
+      //   if (privateLeaguePriceMaps && privateLeaguePriceMaps[activeProfile.league]) { 
+      //     logger.info(
+      //       `Private league ${activeProfile.league} will use prices from ${
+      //         privateLeaguePriceMaps[activeProfile.league]
+      //       }`
+      //     );
+      //     activeProfile.league = privateLeaguePriceMaps[activeProfile.league];
+      //   } else {
+      //     logger.info(
+      //       `No price map set for private league ${activeProfile.league}, will not attempt to get prices`
+      //     );
+      //     return;
+      //   }
+      // }
 
       const today = dayjs().format('YYYYMMDD');
       const hasExisting = await this.hasExistingRates(today);

--- a/src/main/modules/RateGetterV2.ts
+++ b/src/main/modules/RateGetterV2.ts
@@ -79,17 +79,19 @@ class RateGetterV2 {
     this.postUpdateCallback = postUpdateCallback;
   }
 
-  getLeagueName() {
+  getLeagueName(useOverride = true) {
     const activeProfile = SettingsManager.get('activeProfile');
     let league = activeProfile.league;
 
-    if (
+    if(useOverride && activeProfile.leagueOverride && activeProfile.leagueOverride.length > 0) {
+      league = activeProfile.leagueOverride;
+    } else if (
       activeProfile.league &&
       activeProfile.league.includes('SSF') &&
       activeProfile &&
       activeProfile.overrideSSF
     ) {
-      // override ssf and get item prices from corresponding trade league
+      // override ssf and get item prices from corresponding trade league 
       // TODO undocumented league naming convention change in 3.13... must check this every league from now on
       // as of 3.13 "SSF Ritual HC" <--> "Hardcore Ritual"
       league = activeProfile.league.replace('SSF', '').trim();
@@ -293,7 +295,7 @@ class RateGetterV2 {
     // rates['Seed'] = tempRates['Seed'];
     // rates['Prophecy'] = tempRates['Prophecy'];
 
-    const ratesWereUpdated = await DB.insertRates(this.getLeagueName(), date, rates);
+    const ratesWereUpdated = await DB.insertRates(this.getLeagueName(false), date, rates);
     if (!ratesWereUpdated) {
       emitter.emit('gettingPricesFailed');
       return;

--- a/src/renderer/components/Settings/MainSettings/MainSettings.tsx
+++ b/src/renderer/components/Settings/MainSettings/MainSettings.tsx
@@ -59,6 +59,11 @@ const MainSettings = ({ settings, store, runStore }) => {
     setScreenshotLocation(path.join(e.target.files[0].path));
   };
 
+  // League Override
+  const [leagueOverride, setLeagueOverride] = React.useState(
+    settings.activeProfile.leagueOverride ? settings.activeProfile.leagueOverride : ''
+  );
+
   const handleRedirectToLogin = () => {
     navigate('/login');
   };
@@ -87,6 +92,7 @@ const MainSettings = ({ settings, store, runStore }) => {
       activeProfile: {
         characterName: character,
         league: store.characters.find((char: any) => char.name === character).league,
+        leagueOverride: leagueOverride,
         valid: true,
       },
       clientTxt: e.target.log_location.value,
@@ -220,6 +226,17 @@ const MainSettings = ({ settings, store, runStore }) => {
               onInput={handleOpenScreenshotLocation}
             />
           </Button>
+        </div>
+        <div className="Settings__Row">
+          <TextField
+            fullWidth
+            label="PoE.ninja league name to change league used for pricing, leave blank for character's league. (e.g. Standard, Settlers)"
+            id="league_override"
+            variant="filled"
+            size="small"
+            value={leagueOverride}
+            onChange={(e) => setLeagueOverride(e.target.value)}
+          />
         </div>
         <Divider className="Settings__Separator" />
         <div className="Settings__Checkbox__Row">


### PR DESCRIPTION
# What

Add private league pricing:
- Add new Setting to set an override for pricing (= price everything according to another poe.ninja league)
- Fix issue with new rates not updating old ones
- Cleanup some old code for private leagues that did not work