### PR TITLE
fix: missing libvips library for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "category": "Utility",
       "maintainer": "qt-dev",
       "asarUnpack": [
-        "node_modules/sharp/**"
+        "node_modules/sharp/**",
+        "node_modules/@img/sharp-libvips-linux-x64/lib/**"
       ]
     },
     "flatpak": {


### PR DESCRIPTION
I tested it on three distributions: Nobara (Fedora), Arch, and Debian. On all three, the original build threw a Sharp package error and couldn’t find the libvips library. The issue was in the Linux build process — the libraries weren’t being included.
