### PR TITLE
Fix Venarius Synth Boss fight getting injected into boss data. Adapt …

### DIFF
--- a/src/main/StatsManager.ts
+++ b/src/main/StatsManager.ts
@@ -743,7 +743,8 @@ class StatsManager {
     const detectedBosses: string[] = [];
 
     for (const config of BossStatsConfig) {
-      if (run.parsedRunInfo?.[config.key]?.bossFights) {
+      const bossFights = run.parsedRunInfo?.[config.key]?.bossFights;
+      if (bossFights && bossFights.length > 0) {
         detectedBosses.push(config.name);
       } else {
         continue;
@@ -759,13 +760,10 @@ class StatsManager {
 
       const stats = this.stats.bosses[config.key];
       stats.count++;
-      if (run.parsedRunInfo[config.key].bossFights[0].started) {
-        const battleTime = this.getRunningTime(
-          run.parsedRunInfo[config.key].bossFights[0].started,
-          run.parsedRunInfo[config.key].bossFights[
-            run.parsedRunInfo[config.key].bossFights.length - 1
-          ].finished
-        );
+      const firstFight = bossFights[0];
+      const lastFight = bossFights[bossFights.length - 1];
+      if (firstFight?.started && lastFight?.finished) {
+        const battleTime = this.getRunningTime(firstFight.started, lastFight.finished);
         stats.totalTime += battleTime;
         stats.fastest = Number(Math.min(stats.fastest, battleTime));
         stats.deaths += Number(run.parsedRunInfo?.deaths ?? 0);

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -553,6 +553,13 @@ const Migrations = {
 
         `pragma user_version = 15`,
       ],
+      [
+        // Fix Venarius bossfights tracking
+        `UPDATE run
+        SET run_info = json_remove(run_info, '$.synthesis')
+        WHERE json_array_length(json_extract(run_info, '$.synthesis.bossFights')) = 0;`,
+        `pragma user_version = 16`,
+      ]
     ],
     maintenance: [
       `delete from incubator where timestamp < (select min(timestamp) from (select timestamp from incubator order by timestamp desc limit 25))`,

--- a/src/main/modules/EventParser.ts
+++ b/src/main/modules/EventParser.ts
@@ -234,12 +234,13 @@ const rules = {
   Synthesis: {
     BossFight: (run, event) => {
       const eventData = JSON.parse(event.event_text);
+      if (eventData.arguments.action === 'unknown') {
+        return null;
+      }
       run.synthesis = run.synthesis || {};
       run.synthesis.bossFights = run.synthesis.bossFights || [];
       run.synthesis.boss = eventData.npc;
-      if (eventData.arguments.action === 'unknown') {
-        return null;
-      } else if (eventData.arguments.action === 'start') {
+      if (eventData.arguments.action === 'start') {
         run.synthesis.bossFights.push({
           enemy: eventData.arguments.enemy,
           started: event.timestamp,

--- a/src/renderer/components/RunEvent/RunEventIcons.tsx
+++ b/src/renderer/components/RunEvent/RunEventIcons.tsx
@@ -74,7 +74,7 @@ const iconMap = {
   },
   betrayalBoss: (info) => {
     return {
-      condition: !!info.betrayal?.bossFights,
+      condition: !!info.betrayal?.bossFights && info.betrayal.bossFights.length > 0,
       icon: CatarinaIcon,
       alt: `Contained a Betrayal Boss Fight.\nFight lasted ${dayjs(
         info.betrayal?.bossFights[0].started

--- a/src/renderer/components/RunEvent/RunEventIcons.tsx
+++ b/src/renderer/components/RunEvent/RunEventIcons.tsx
@@ -73,29 +73,24 @@ const iconMap = {
     };
   },
   betrayalBoss: (info) => {
-    return {
-      condition: !!info.betrayal?.bossFights && info.betrayal.bossFights.length > 0,
-      icon: CatarinaIcon,
-      alt: `Contained a Betrayal Boss Fight.\nFight lasted ${dayjs(
-        info.betrayal?.bossFights[0].started
-      ).diff(
-        dayjs(info.betrayal?.bossFights[info.betrayal?.bossFights.length - 1]?.finished),
-        'seconds'
-      )} seconds`,
-      additionalIcons: info?.betrayal?.bossFights?.map((fight) => {
+    const bossFights = info.betrayal?.bossFights;
+    const hasBossFights = Array.isArray(bossFights) && bossFights.length > 0;
+    let additionalIcons: JSX.Element[] = [];
+    if (hasBossFights) {
+      const hasTimes = bossFights[0] && bossFights[0].started && bossFights[bossFights.length-1] && bossFights[bossFights.length-1].finished;
+      additionalIcons = bossFights.map((fight) => {
         return (
-          <Tooltip
-            title={`Defeated ${fight.bossName} in ${dayjs(
-              info.betrayal?.bossFights[0].started
-            ).diff(
-              dayjs(info.betrayal?.bossFights[info.betrayal?.bossFights.length - 1]?.finished),
-              'seconds'
-            )} seconds`}
-          >
+          <Tooltip title={hasTimes?`Defeated ${fight.bossName} in ${dayjs(bossFights[0].started).diff(dayjs(bossFights[bossFights.length-1].finished), 'seconds')} seconds`:`Defeated ${fight.bossName}`}>
             <img className="Run-Event__Mini-Icon" src={CatarinaIcon} alt={fight.bossName} />
           </Tooltip>
         );
-      }),
+      });
+    }
+    return {
+      condition: hasBossFights,
+      icon: CatarinaIcon,
+      alt: 'Contained a Betrayal Boss Fight.',
+      additionalIcons: additionalIcons.length > 0 ? additionalIcons : undefined,
     };
   },
   blight: (info) => {


### PR DESCRIPTION
Fix Venarius Synth Boss fight getting injected into boss data. Adapt boss Fight parsing so that it accounts for bossFights array being empty.

To Fix the data please run the following on the player sqlite db file:
```sql
UPDATE run
SET run_info = json_remove(run_info, '$.synthesis')
WHERE json_array_length(json_extract(run_info, '$.synthesis.bossFights')) = 0;
```