### PR TITLE
Fix file picker

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -799,6 +799,11 @@ class MainProcess {
       return SettingsManager.get('overlayPosition');
     });
 
+    ipcMain.handle('open-file-dialog', async (event, options) => {
+      const result = await dialog.showOpenDialog(this.mainWindow, options);
+      return result;
+    });
+
     ipcMain.on('overlay:set-position', (event, { x, y }) => {
       SettingsManager.set('overlayPosition', { x, y });
     });

--- a/src/renderer/components/Settings/MainSettings/MainSettings.tsx
+++ b/src/renderer/components/Settings/MainSettings/MainSettings.tsx
@@ -71,7 +71,6 @@ const MainSettings = ({ settings, store, runStore }) => {
     e.preventDefault();
     
     try {
-      // Use Electron's native file dialog
       const result = await ipcRenderer.invoke('open-file-dialog', {
         title: 'Select Path of Exile Client.txt file',
         filters: [
@@ -94,9 +93,19 @@ const MainSettings = ({ settings, store, runStore }) => {
   // Screenshot Folder Location
   const [screenshotLocation, setScreenshotLocation] = React.useState(settings.screenshotDir);
   const screenshotLocationRef = useRef(screenshotLocation);
-  const handleOpenScreenshotLocation = (e) => {
+  const handleOpenScreenshotLocation = async (e) => {
     e.preventDefault();
-    setScreenshotLocation(path.join(e.target.files[0].path));
+    try {
+      const result = await ipcRenderer.invoke('open-file-dialog', {
+        title: 'Select Screenshot Folder',
+        properties: ['openDirectory']
+      });
+      if (result && !result.canceled && result.filePaths.length > 0) {
+        setScreenshotLocation(result.filePaths[0]);
+      }
+    } catch (error) {
+      console.error('Error opening directory dialog:', error);
+    }
   };
 
   // League Override
@@ -262,16 +271,9 @@ const MainSettings = ({ settings, store, runStore }) => {
             component="label"
             variant="contained"
             sx={{ marginTop: '7px', marginBottom: '10px', padding: '2px 15px' }}
+            onClick={handleOpenScreenshotLocation}
           >
             Find PoE Screenshot Folder
-            <input
-              hidden
-              webkitdirectory=""
-              directory=""
-              type="file"
-              ref={screenshotLocationRef}
-              onInput={handleOpenScreenshotLocation}
-            />
           </Button>
         </div>
         <div className="Settings__Row">

--- a/src/renderer/components/Settings/MainSettings/MainSettings.tsx
+++ b/src/renderer/components/Settings/MainSettings/MainSettings.tsx
@@ -67,10 +67,28 @@ const MainSettings = ({ settings, store, runStore }) => {
   // Client File Location
   const [clientFileLocation, setClientFileLocation] = React.useState(settings.clientTxt);
   const clientFileLocationRef = useRef(clientFileLocation);
-  const handleOpenClientLocation = (e) => {
+  const handleOpenClientLocation = async (e) => {
     e.preventDefault();
-    const { path: filePath, name } = e.target.files[0];
-    setClientFileLocation(filePath.endsWith(name) ? filePath : path.join(filePath, name));
+    
+    try {
+      // Use Electron's native file dialog
+      const result = await ipcRenderer.invoke('open-file-dialog', {
+        title: 'Select Path of Exile Client.txt file',
+        filters: [
+          { name: 'Text Files', extensions: ['txt'] },
+          { name: 'All Files', extensions: ['*'] }
+        ],
+        properties: ['openFile']
+      });
+      
+      if (result && !result.canceled && result.filePaths.length > 0) {
+        const filePath = result.filePaths[0];
+        console.log('Selected file path:', filePath);
+        setClientFileLocation(filePath);
+      }
+    } catch (error) {
+      console.error('Error opening file dialog:', error);
+    }
   };
 
   // Screenshot Folder Location
@@ -223,18 +241,11 @@ const MainSettings = ({ settings, store, runStore }) => {
             onChange={(e) => setClientFileLocation(e.target.value)}
           />
           <Button
-            component="label"
             variant="contained"
             sx={{ marginTop: '7px', marginBottom: '10px', padding: '2px 15px' }}
+            onClick={handleOpenClientLocation}
           >
             Find Path of Exile Log folder
-            <input
-              hidden
-              accept=".txt, text/plain"
-              type="file"
-              ref={clientFileLocationRef}
-              onInput={handleOpenClientLocation}
-            />
           </Button>
         </div>
         <div className="Settings__Row">


### PR DESCRIPTION
using IPC request to get around issues when running on windows that leverage nodeIntegration: True. Using the native electron file picker here instead. This fixes issues with path joins too.