### PR TITLE
Add a portable build mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "build": {
     "appId": "com.exilediary.reborn",
     "productName": "Exile Diary Reborn",
+    "afterPack": "./scripts/afterPack.js",
     "protocols": [
       {
         "name": "Exile Diary",
@@ -21,7 +22,12 @@
     ],
     "nativeRebuilder": "parallel",
     "win": {
-      "target": "nsis",
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        }
+      ],
       "artifactName": "exile-diary-reborn-setup-v${version}.${ext}",
       "icon": "./src/renderer/assets/img/icons/win/ExileDiary.ico",
       "extraResources": [
@@ -87,6 +93,7 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "benchmark": "tsc -p src/main && npx tsx test/ParserBenchmark.ts",
     "build": "npm run react:build && tsc -p src/main && set \"DEBUG=electron-builder\" && electron-builder -p never",
+    "build:portable": "npm run react:build && tsc -p src/main && set \"DEBUG=electron-builder\" && electron-builder --win zip -c.win.artifactName=\"exile-diary-reborn-portable-v${version}.${ext}\" -p never",
     "build:linux": "npm run react:build && tsc -p src/main && env DEBUG=\"@malept/flatpak-bundler\" electron-builder -p never",
     "dev": "concurrently \"cross-env BROWSER=none npm run react:start\" \"wait-on -s 1 http://localhost:3003 && tsc -p src/main -w --preserveWatchOutput\" \"wait-on -s 1 http://localhost:3003 && tsc -p src/main && electron .\""
   },

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -1,0 +1,51 @@
+/**
+ * electron-builder afterPack hook
+ * This script runs after the app is packed but before it's built into an installer/portable exe
+ * For portable builds, we create a marker file to indicate portable mode
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+exports.default = async function(context) {
+  const { packager, electronPlatformName, appOutDir, targets } = context;
+
+  console.log('AfterPack hook running...');
+  console.log('Platform:', electronPlatformName);
+  console.log('Targets:', targets.map(t => t.name).join(', '));
+
+  // Check if we're building a zip target (which we use for portable)
+  const isPortableTarget = targets.some(target => target.name === 'zip');
+
+  if (isPortableTarget) {
+    console.log('Zip target detected - creating portable marker file');
+
+    // Create a marker file in the resources directory
+    // appOutDir is the unpacked app directory (e.g., win-unpacked)
+    // We need to put the marker in the resources folder
+    const resourcesDir = path.join(appOutDir, 'resources');
+    const markerPath = path.join(resourcesDir, 'portable');
+
+    try {
+      // Ensure resources directory exists
+      if (!fs.existsSync(resourcesDir)) {
+        fs.mkdirSync(resourcesDir, { recursive: true });
+      }
+
+      fs.writeFileSync(
+        markerPath,
+        'This file indicates the app should run in portable mode.\n' +
+        'All data will be stored in the "exile-data" folder next to the executable.\n' +
+        'This marker is read from process.resourcesPath at runtime.'
+      );
+      console.log('✓ Portable marker file created:', markerPath);
+    } catch (error) {
+      console.error('✗ Failed to create portable marker:', error);
+      throw error;
+    }
+  } else {
+    console.log('Not a portable target - skipping marker creation');
+  }
+
+  console.log('AfterPack hook completed');
+};

--- a/src/main/PortableConfig.ts
+++ b/src/main/PortableConfig.ts
@@ -1,0 +1,206 @@
+import { app } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Portable Configuration Manager
+ *
+ * This module handles the detection and setup of portable mode.
+ * In portable mode, all user data is stored in an 'exile-data' folder
+ * next to the executable instead of in AppData.
+ */
+
+let isPortable = false;
+let portableDataPath: string | null = null;
+
+/**
+ * Detects if the app is running in portable mode
+ *
+ * Portable mode is detected by:
+ * 1. Checking if process.env.PORTABLE is set to 'true'
+ * 2. Checking if a 'portable' marker file exists in the app directory
+ *
+ * The marker file is created by the build script for portable builds.
+ */
+export function initPortableMode(): void {
+  // Wrap everything in try-catch to prevent crashes
+  const debugLog: string[] = [];
+  const addLog = (msg: string) => {
+    const timestamp = new Date().toISOString();
+    const logMsg = `[${timestamp}] ${msg}`;
+    console.log(`[PortableConfig] ${msg}`);
+    debugLog.push(logMsg);
+  };
+
+  try {
+    addLog('='.repeat(60));
+    addLog('PORTABLE MODE INITIALIZATION');
+    addLog('='.repeat(60));
+
+    addLog(`Node version: ${process.version}`);
+    addLog(`Platform: ${process.platform}`);
+    addLog(`process.execPath: ${process.execPath}`);
+    addLog(`process.resourcesPath: ${process.resourcesPath}`);
+    addLog(`process.cwd(): ${process.cwd()}`);
+    addLog(`__dirname: ${__dirname}`);
+
+    // Determine exe directory - ALWAYS use process.execPath (works before app.ready)
+    const exeDir = path.dirname(process.execPath);
+    addLog(`Executable directory: ${exeDir}`);
+
+    // Check if explicitly set via environment variable (for development testing)
+    if (process.env.PORTABLE === 'true') {
+      isPortable = true;
+      addLog('✓ Forced portable mode via PORTABLE=true env var');
+    } else {
+      // Check for portable marker in resources directory
+      const resourcesPath = process.resourcesPath;
+      const portableMarker = path.join(resourcesPath, 'portable');
+
+      addLog(`Looking for marker at: ${portableMarker}`);
+
+      // Check if resources directory exists
+      const resourcesExists = fs.existsSync(resourcesPath);
+      addLog(`Resources directory exists: ${resourcesExists}`);
+
+      if (resourcesExists) {
+        // List files in resources to verify
+        try {
+          const files = fs.readdirSync(resourcesPath);
+          addLog(`Files in resources directory (${files.length} total):`);
+          files.forEach(file => addLog(`  - ${file}`));
+        } catch (e) {
+          addLog(`⚠ Could not list files in resources: ${e}`);
+        }
+      }
+
+      // Check for the marker file
+      const markerExists = fs.existsSync(portableMarker);
+      addLog(`Portable marker exists: ${markerExists}`);
+
+      if (markerExists) {
+        try {
+          const markerContent = fs.readFileSync(portableMarker, 'utf8');
+          addLog(`Marker content: ${markerContent.substring(0, 50)}...`);
+        } catch (e) {
+          addLog(`⚠ Could not read marker: ${e}`);
+        }
+      }
+
+      isPortable = markerExists;
+    }
+
+    addLog('='.repeat(60));
+    if (isPortable) {
+      addLog('PORTABLE MODE: ENABLED');
+      addLog('='.repeat(60));
+
+      portableDataPath = path.join(exeDir, 'exile-data');
+      addLog(`Target data path: ${portableDataPath}`);
+
+      // Try to create the directory
+      try {
+        if (!fs.existsSync(portableDataPath)) {
+          addLog('Creating exile-data directory...');
+          fs.mkdirSync(portableDataPath, { recursive: true });
+          addLog('✓ Created exile-data directory');
+        } else {
+          addLog('✓ exile-data directory already exists');
+        }
+
+        // Test write permissions by creating a test file
+        const testFile = path.join(portableDataPath, '.write-test');
+        try {
+          fs.writeFileSync(testFile, 'test');
+          fs.unlinkSync(testFile);
+          addLog('✓ Write permissions verified');
+        } catch (e) {
+          addLog(`✗ Write test failed: ${e}`);
+        }
+      } catch (e) {
+        addLog(`✗ CRITICAL: Failed to create directory: ${e}`);
+        addLog('Falling back to installed mode');
+        isPortable = false;
+        portableDataPath = null;
+      }
+
+      // Only set userData path if directory creation succeeded
+      if (isPortable && portableDataPath) {
+        try {
+          const oldPath = app.getPath('userData');
+          addLog(`Old userData: ${oldPath}`);
+
+          app.setPath('userData', portableDataPath);
+
+          const newPath = app.getPath('userData');
+          addLog(`New userData: ${newPath}`);
+
+          if (newPath === portableDataPath) {
+            addLog('✓ userData path successfully changed');
+          } else {
+            addLog(`⚠ WARNING: Path mismatch! Expected ${portableDataPath}, got ${newPath}`);
+          }
+        } catch (e) {
+          addLog(`✗ CRITICAL: Failed to set userData path: ${e}`);
+          isPortable = false;
+          portableDataPath = null;
+        }
+      }
+    } else {
+      addLog('PORTABLE MODE: DISABLED (Installed mode)');
+      addLog('='.repeat(60));
+      try {
+        const userData = app.getPath('userData');
+        addLog(`Will use standard userData: ${userData}`);
+      } catch (e) {
+        addLog(`Cannot get userData yet (app not ready): ${e}`);
+      }
+    }
+
+    addLog('='.repeat(60));
+    addLog(`Final status: ${isPortable ? 'PORTABLE' : 'INSTALLED'}`);
+    addLog('='.repeat(60));
+
+  } catch (error) {
+    addLog('='.repeat(60));
+    addLog(`CRITICAL ERROR: ${error}`);
+    if (error instanceof Error) {
+      addLog(`Stack: ${error.stack}`);
+    }
+    addLog('='.repeat(60));
+    console.error('[PortableConfig] CRITICAL ERROR:', error);
+  } finally {
+    // ALWAYS try to write the debug log
+    try {
+      const logDir = path.dirname(process.execPath);
+      const logPath = path.join(logDir, 'portable-init.log');
+      addLog(`Writing log to: ${logPath}`);
+      fs.writeFileSync(logPath, debugLog.join('\n') + '\n', 'utf8');
+      console.log(`[PortableConfig] Debug log written to: ${logPath}`);
+    } catch (e) {
+      console.error('[PortableConfig] Failed to write debug log:', e);
+      // Try alternate location
+      try {
+        const altLogPath = path.join(process.cwd(), 'portable-init.log');
+        fs.writeFileSync(altLogPath, debugLog.join('\n') + '\n', 'utf8');
+        console.log(`[PortableConfig] Debug log written to alternate location: ${altLogPath}`);
+      } catch (e2) {
+        console.error('[PortableConfig] Could not write log to any location:', e2);
+      }
+    }
+  }
+}
+
+/**
+ * Returns whether the app is running in portable mode
+ */
+export function getIsPortable(): boolean {
+  return isPortable;
+}
+
+/**
+ * Gets the user data path (either portable or standard)
+ */
+export function getUserDataPath(): string {
+  return app.getPath('userData');
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,17 @@ import {
 } from 'electron';
 import chokidar from 'chokidar';
 import { spawn } from 'child_process';
+import { initPortableMode } from './PortableConfig';
+
+// Initialize portable mode BEFORE app is ready, but AFTER electron modules are imported
+// This sets the userData path before any other code can access it
+// CRITICAL: This must run synchronously before importing SettingsManager, DB, etc.
+try {
+  initPortableMode();
+} catch (error) {
+  console.error('CRITICAL: Failed to initialize portable mode:', error);
+  // Continue anyway - will use default AppData
+}
 
 import { autoUpdater } from 'electron-updater';
 import * as path from 'path';
@@ -1145,7 +1156,12 @@ class MainProcess {
 }
 
 app.on('ready', () => {
-  const gotTheLock = app.requestSingleInstanceLock();
+  // Use userData path as the lock key so each portable instance can run independently
+  // This allows multiple portable installations in different folders to run simultaneously
+  // while preventing duplicate instances of the same installation
+  const gotTheLock = app.requestSingleInstanceLock({
+    key: app.getPath('userData')
+  });
 
   if (!gotTheLock) {
     logger.error('Exile Diary is already started, closing the new instance.');


### PR DESCRIPTION
 Add a portable build mode that allows the application to run without install. 
One major use case here is the ability to run multiple instances if you are using a dual client setup. (Steam and Native launchers have different log paths for instance)

Detection is handled with a portable marker file to use the folder instead of the user app data folder. 