### PR TITLE
Fix Linux native dependency installation

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder elfutils
+          sudo apt-get install -y flatpak flatpak-builder elfutils libxcb1-dev
       - name: Install flathub dependencies
         run: |
           flatpak remote-add -u --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder elfutils
+          sudo apt-get install -y flatpak flatpak-builder elfutils libxcb1-dev
       - name: Install flathub dependencies
         run: |
           flatpak remote-add -u --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/test/main/runtime/LinuxBuildWorkflowContract.spec.ts
+++ b/test/main/runtime/LinuxBuildWorkflowContract.spec.ts
@@ -1,0 +1,19 @@
+const fs = jest.requireActual('node:fs') as typeof import('node:fs');
+const path = jest.requireActual('node:path') as typeof import('node:path');
+
+const rootDir = path.resolve(__dirname, '../../..');
+
+describe('Linux build workflow contract', () => {
+  it.each(['build-linux.yml', 'release.yml'])(
+    'installs the native headers required by electron-overlay-window in %s',
+    (workflowName) => {
+      const workflow = fs.readFileSync(
+        path.join(rootDir, '.github', 'workflows', workflowName),
+        'utf8'
+      );
+
+      expect(workflow).toContain('libxcb1-dev');
+      expect(workflow.lastIndexOf('libxcb1-dev')).toBeLessThan(workflow.lastIndexOf('npm ci'));
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Fix the Linux packaging workflows after the v1.11.0 release run failed during `npm ci`.

The `electron-overlay-window` native addon includes `<xcb/xcb.h>` and links against `libxcb`, but the Ubuntu jobs did not install the corresponding development headers. This adds `libxcb1-dev` to both Linux workflow paths before npm rebuilds native modules.

## Failure

- Failed run: https://github.com/Qt-dev/exile-diary/actions/runs/29795517980
- Failed job: `build-linux`
- Failure: `fatal error: xcb/xcb.h: No such file or directory`

## Verification

- Added a workflow contract test covering both `.github/workflows/build-linux.yml` and `.github/workflows/release.yml`
- Both workflow files parse as valid YAML
- `npm run test:main`: 54 suites passed, 356 tests passed
