### PR TITLE
Harden runtime startup and restore map-end triggers

### DIFF
--- a/.workflow/ultracode/runtime-db-api-hardening/eval-contract.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/eval-contract.md
@@ -1,0 +1,41 @@
+# Eval contract
+
+## Goal
+Deliver a backwards-compatible hardening of profile database initialization and GGG/profile request flow across Electron main, the runtime sidecar, and the renderer.
+
+## Success criteria
+- Migrations are atomic and the version marker is committed last.
+- Required schema is checked before the runtime becomes DB-ready.
+- Known empty, interrupted databases can recover without deleting non-empty data.
+- Profile persistence and relaunch/switch happen only after DB readiness.
+- Character selection reuses the character DTO already returned by GGG.
+- The renderer receives deterministic transition results and does not depend on a 30-second runtime timeout.
+
+## Integration surfaces
+- SQLite manager and repositories.
+- Settings/profile transition behavior.
+- Runtime-sidecar commands, responses, readiness, and health.
+- Renderer preload API and character selection/settings flows.
+- GGG request scheduling and caching.
+
+## Downstream consumers
+Runtime services, DB repositories, Electron main listeners, renderer route loaders, character store, packaged-sidecar smoke tests.
+
+## Required checks
+- DB and migration regression tests with real or faithful SQLite behavior.
+- Settings/profile, GGGAPI, runtime client/service, and renderer tests.
+- Main and renderer TypeScript checks.
+- Main test suite and production build.
+
+## Deliverables
+- Atomic migration and schema readiness implementation.
+- Explicit profile transition path and safe relaunch/hot-transition behavior.
+- Coalesced character API access without redundant profile validation fetch.
+- Typed runtime lifecycle/error contracts where needed.
+- Workflow integration notes and final audit.
+
+## Blocking conditions
+- Existing non-empty DBs would be rebuilt or discarded automatically.
+- Existing profile/settings files require an incompatible migration.
+- Sidecar cannot distinguish control readiness from DB readiness.
+- Required focused tests fail.

--- a/.workflow/ultracode/runtime-db-api-hardening/final-audit.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/final-audit.md
@@ -1,0 +1,30 @@
+# Final audit
+
+Status: passed with a repository formatting baseline warning.
+
+Contract results:
+
+- Clean DB bootstrap is atomic, validated, and cannot expose background DB work early.
+- Interrupted empty bootstrap is backed up and retried; any detected user data prevents automatic replacement.
+- DB task failures reject callers and cannot wedge the queue.
+- Profile transitions are staged, serialized, persisted, and restarted behind a stable barrier.
+- Sidecar request admission is closed during a real profile switch, while unchanged settings saves remain available.
+- GGG character access has one process owner, single-flight behavior, bounded caching, and HTTP timeouts.
+- OAuth does not perform implicit character selection or restart the sidecar after token persistence.
+
+Evidence:
+
+- 375/375 main tests passed.
+- 19/19 renderer tests passed.
+- Main and renderer TypeScript checks passed.
+- Production build passed.
+- `git diff --check` passed.
+- Independent final re-audit reported no remaining blocker.
+
+Non-blocking notes:
+
+- Live authenticated GGG calls were not run.
+- Renderer tests retain existing React deprecation/future-flag warnings.
+- `npm run format:check` reports the repository's existing 332-file formatting baseline; a repo-wide rewrite was intentionally avoided.
+- `npm install` reported two high-severity dependency audit findings; dependency upgrades are outside this scope.
+

--- a/.workflow/ultracode/runtime-db-api-hardening/final-report.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/final-report.md
@@ -1,0 +1,10 @@
+# Final report
+
+Implemented a readiness-driven sidecar architecture for database bootstrap, profile changes, and GGG API traffic.
+
+The sidecar now waits for a validated schema before starting background services, publishes lifecycle state, and rejects DB/API work during real profile transitions. SQLite migrations run atomically with the version update last. Queue failures no longer deadlock later calls, and conservative recovery preserves any database containing user data.
+
+Profile selection is the single source of character identity. It prepares the target DB before publishing settings, serializes rapid selections, waits for durable persistence, and restarts only the runtime sidecar. OAuth only persists and refreshes authentication. Renderer character requests route through the sidecar, where identical GGG calls are coalesced and time-bounded.
+
+All required automated tests, typechecks, the production build, diff hygiene, and the final independent audit passed. Changes remain uncommitted for review.
+

--- a/.workflow/ultracode/runtime-db-api-hardening/integration.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/integration.md
@@ -1,0 +1,39 @@
+# Integration
+
+## Accepted
+
+- Shared runtime initialization promise and lifecycle contract.
+- Atomic DB migrations, schema validation, and conservative empty-DB recovery.
+- Explicit profile identity across settings and DB boundaries.
+- Sidecar-owned GGG access with single-flight requests and bounded timeouts.
+- Save barrier plus controlled sidecar restart for profile changes.
+- Explicit character picker ownership after OAuth.
+
+## Rejected
+
+- Full Electron relaunch for profile changes.
+- OAuth callback auto-selection of the current character.
+- Automatic reset of any database that contains user data.
+
+## Conflicts
+
+None.
+
+## Decisions
+
+The parent agent owned shared contracts, implementation, and compatibility decisions. Read-only agents supplied independent DB/runtime and API/IPC discovery, followed by a final diff audit.
+
+## Final changes
+
+See `results/03-implementation.md`.
+
+## Verification still needed
+
+No required automated checks remain. Live OAuth/profile switching against GGG is intentionally not run because it requires user credentials and external state.
+
+## Remaining risks
+
+- Live behavior still depends on GGG availability and rate-limit headers.
+- A damaged non-empty DB is preserved and reported rather than modified; manual recovery may be required.
+- Renderer tests emit pre-existing React deprecation/future-flag warnings.
+- Dependency installation reported two high-severity audit findings; dependency remediation was outside this change.

--- a/.workflow/ultracode/runtime-db-api-hardening/orchestration.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/orchestration.md
@@ -1,0 +1,28 @@
+# Orchestration
+
+## Parent critical path
+Own shared contracts, DB migration changes, runtime/profile coordination, integration, and final verification.
+
+## Packets
+- 01 DB/runtime audit: read-only.
+- 02 GGG/profile/IPC audit: read-only.
+- 03 implementation: parent.
+- 04 final review: optional read-only second wave.
+
+## Delegation
+Use two parallel native agents for independent discovery, then at most one review agent after integration.
+
+## Agents
+Agents may inspect `main` sources and tests but must not edit files.
+
+## Delegation limits
+Maximum three agents and two waves.
+
+## Wait points
+Wait for discovery before finalizing public contracts; do not wait before local DB implementation work.
+
+## Fallback
+If agents fail, the parent performs the packet using the same evidence requirements.
+
+## Verification order
+Focused tests, typechecks, full main tests, build, diff audit.

--- a/.workflow/ultracode/runtime-db-api-hardening/packets/01-db-runtime-audit.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/packets/01-db-runtime-audit.md
@@ -1,0 +1,28 @@
+# Packet 01-db-runtime-audit: DB and runtime lifecycle audit
+
+## Objective
+Trace the exact migration interruption and runtime readiness hazards and recommend the smallest safe implementation.
+
+## Context
+Issue #462 reports `area_info` missing after clean install; profile saves currently trigger background DB initialization and relaunch.
+
+## Sources
+`src/main/db`, `SettingsManager.ts`, runtime-sidecar sources, and matching tests.
+
+## Ownership
+Read-only agent.
+
+## Do
+Inspect transaction/version ordering, DB path context, sidecar readiness/health, profile-change relaunch, and test gaps. Cite files and lines.
+
+## Do not
+Do not edit files or duplicate the API audit.
+
+## Expected output
+Evidence-backed hazards, required invariants, and focused tests.
+
+## Verification
+Source references and executable test recommendations.
+
+## Handoff format
+Summary, evidence, risks, recommended parent action.

--- a/.workflow/ultracode/runtime-db-api-hardening/packets/02-api-ipc-audit.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/packets/02-api-ipc-audit.md
@@ -1,0 +1,28 @@
+# Packet 02-api-ipc-audit: GGG, profile, and IPC audit
+
+## Objective
+Trace duplicate GGG requests during OAuth/profile selection and characterize timeout/IPC coupling.
+
+## Context
+GGGAPI is imported in main and runtime; character save re-resolves the selected character.
+
+## Sources
+`GGGAPI.ts`, auth/deep-link flow, renderer services/routes, runtime contracts/client, and tests.
+
+## Ownership
+Read-only agent.
+
+## Do
+Map calls, caches/limiters, process ownership, timeout behavior, and backwards-compatible consolidation options. Cite files and lines.
+
+## Do not
+Do not edit files or audit SQLite internals.
+
+## Expected output
+Call budget, contract recommendations, test gaps, and integration risks.
+
+## Verification
+Source references and focused test recommendations.
+
+## Handoff format
+Summary, evidence, risks, recommended parent action.

--- a/.workflow/ultracode/runtime-db-api-hardening/plan.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/plan.md
@@ -1,0 +1,50 @@
+# Runtime DB and API hardening
+
+## Goal
+Make clean-install database setup, runtime-sidecar readiness, profile changes, and GGG API access deterministic and recoverable.
+
+## Success criteria
+- A profile DB cannot expose repositories before its schema is complete.
+- Interrupted migrations cannot advance `user_version` or leave a silently accepted partial schema.
+- Saving or switching a profile does not kill an in-progress migration.
+- Selecting a character does not make a redundant character-list request.
+- Runtime IPC reports lifecycle state and typed failures instead of timing out generically.
+
+## Current context
+`main` is v1.11.2. Profile saves start DB initialization in the background and immediately emit a change that schedules an app relaunch. GGG caches and limiters are process-local.
+
+## Constraints
+- Preserve existing settings and DB filenames.
+- Keep OAuth secrets in the credential store.
+- Do not commit, push, publish, or deploy.
+- Avoid destructive recovery for non-empty user databases.
+
+## Risk level
+High: migrations, auth/profile flow, process lifecycle, IPC, and renderer behavior are coupled.
+
+## Approval gates
+The user explicitly approved local implementation. No production migration, publishing, credential access, or destructive user-data operation is authorized.
+
+## Mode
+Delegated Ultracode workflow: parent owns implementation/integration; two read-only agents independently audit DB/runtime and API/IPC surfaces.
+
+## Work packets
+- 01: DB/runtime lifecycle audit (read-only agent).
+- 02: GGG/profile/IPC duplication audit (read-only agent).
+- 03: Parent implementation and focused tests.
+- 04: Independent post-change review if capacity and time permit.
+
+## Eval contract
+Full contract in `eval-contract.md`.
+
+## Integration policy
+The parent validates every finding against source, owns shared contracts, and rejects recommendations that require incompatible settings or DB format changes.
+
+## Verification plan
+- Targeted DB, SettingsManager, GGGAPI, runtime-sidecar, service, and renderer tests.
+- Main and renderer typechecks.
+- Full main test suite and build when targeted checks pass.
+- Diff and independent audit against the contract.
+
+## Completion criteria
+All required contract deliverables exist, required checks pass or are reported honestly, and final audit records remaining risk.

--- a/.workflow/ultracode/runtime-db-api-hardening/results/01-db-runtime-audit.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/results/01-db-runtime-audit.md
@@ -1,0 +1,16 @@
+# DB/runtime audit result
+
+The clean-install failure was traced to a readiness race in the runtime sidecar: an immediate readiness subscription could begin initialization, while a second caller observed only an `in progress` boolean and returned early. Background run tracking could then query `area_info` while migrations were incomplete. A thrown DB task also failed to release the serialized task queue, turning the original schema error into later IPC timeouts.
+
+The audit also found non-atomic schema changes, version pragmas interleaved with DDL, profile DB paths depending on mutable global settings, and a full Electron relaunch racing the settings write.
+
+Accepted recommendations:
+
+- Use one shared initialization promise and explicit lifecycle states.
+- Perform pending migrations in one transaction with the final schema version written last.
+- Always release the DB queue on task failure.
+- Validate the final schema before starting background services.
+- Pass character and league explicitly to DB initialization.
+- Replace full-app relaunch with a save barrier and controlled sidecar restart.
+- Preserve non-empty databases on failure; back up and rebuild only empty partial databases.
+

--- a/.workflow/ultracode/runtime-db-api-hardening/results/02-api-ipc-audit.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/results/02-api-ipc-audit.md
@@ -1,0 +1,15 @@
+# API/IPC audit result
+
+The authentication and profile-selection paths had multiple owners for GGG character requests. A clean OAuth flow could issue roughly three physical character-list calls, while a profile switch could issue up to four logical calls across the main process, renderer, and sidecar. Process-local caches could not coalesce those calls.
+
+Accepted recommendations:
+
+- Make the runtime sidecar the renderer's sole GGG API owner.
+- Remove OAuth callback profile auto-selection; let the explicit character picker own selection.
+- Pass the selected profile DTO into DB initialization instead of resolving it through another API call.
+- Coalesce identical in-flight requests and cache character lists briefly.
+- Share the character snapshot used by inventory and passive-tree consumers.
+- Apply bounded HTTP timeouts and account-scoped request keys.
+- Refresh sidecar authentication in place after token persistence instead of restarting it.
+- Fix character-picker assignment and empty-list handling.
+

--- a/.workflow/ultracode/runtime-db-api-hardening/results/03-implementation.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/results/03-implementation.md
@@ -1,0 +1,27 @@
+# Implementation result
+
+Implemented the accepted DB, lifecycle, API, and profile-switch changes on `codex/runtime-db-api-hardening`.
+
+Key behavior changes:
+
+- DB tasks reject correctly and always advance the queue.
+- Pending SQLite migrations are atomic and schema validation gates runtime startup.
+- Known `area_info` partial-schema installs are repaired.
+- Empty interrupted databases are retained as timestamped backups and rebuilt; databases with user data are never reset automatically.
+- Runtime initialization is single-flight and exposes lifecycle state through health/events.
+- Profile changes await explicit-profile DB preparation and durable settings persistence before a controlled sidecar restart.
+- Renderer character queries route through the sidecar; OAuth no longer performs hidden profile discovery.
+- GGG requests use single-flight coalescing, short caches, account-scoped character snapshots, rate limiting, and a 15-second HTTP timeout.
+- Authentication refresh is performed in place; logout still restarts the isolated runtime.
+
+Verification completed:
+
+- Focused final regression suite: 42 passed.
+- Full main suite: 375 passed.
+- Full renderer suite: 19 passed.
+- Renderer and main TypeScript checks passed.
+- Production build passed.
+- `git diff --check` passed.
+
+The repository-wide Prettier check remains red on 332 pre-existing files, including most of `src` and `test`; no bulk formatting rewrite was applied.
+

--- a/.workflow/ultracode/runtime-db-api-hardening/results/04-final-diff-audit.md
+++ b/.workflow/ultracode/runtime-db-api-hardening/results/04-final-diff-audit.md
@@ -1,0 +1,8 @@
+# Final diff audit result
+
+The first review identified four transition/recovery risks. The implementation was revised to stage and serialize profile commits, gate sidecar requests while switching, reject persistence barriers on save failure, coalesce restart requests, and conservatively scan every independent data-bearing table before empty-DB recovery.
+
+A second review found that unchanged-profile Settings submissions could leave the lifecycle stuck in `switching`, and that rate refresh was duplicated immediately before restart. Both were corrected by comparing character/league identity before switching and deferring rates to replacement startup.
+
+The final targeted re-audit found no remaining blocking or high-confidence correctness issue in transition, persistence, lifecycle gating, DB recovery, request deduplication, or rate-refresh behavior.
+

--- a/.workflow/ultracode/runtime-db-api-hardening/state.json
+++ b/.workflow/ultracode/runtime-db-api-hardening/state.json
@@ -1,0 +1,39 @@
+{
+  "title": "Runtime DB and API hardening",
+  "slug": "runtime-db-api-hardening",
+  "created_at": "2026-07-22T09:54:11.3430809-07:00",
+  "updated_at": "2026-07-22T10:23:46.6900356-07:00",
+  "status": "complete",
+  "mode": "delegated",
+  "baseline_ref": "4f8dfcca143b99765619048f871356618b162075",
+  "risk_level": "high",
+  "eval_contract": { "level": "full", "path": "eval-contract.md", "status": "passed" },
+  "approval": { "required": false, "granted": null, "notes": "Local implementation explicitly requested." },
+  "delegation": {
+    "native_agent_available": true,
+    "native_agent_planned": true,
+    "native_agent_used": true,
+    "agent_count": 3,
+    "wave_count": 2,
+    "no_delegation_reason": "",
+    "notes": "Two discovery audits and one iterative final diff audit completed read-only."
+  },
+  "packets": [
+    { "id": "01-db-runtime-audit", "status": "completed", "owner": "read-only-agent", "write_scope": [], "result_path": "results/01-db-runtime-audit.md" },
+    { "id": "02-api-ipc-audit", "status": "completed", "owner": "read-only-agent", "write_scope": [], "result_path": "results/02-api-ipc-audit.md" },
+    { "id": "03-implementation", "status": "completed", "owner": "parent", "write_scope": ["src", "test", "scripts"], "result_path": "results/03-implementation.md" },
+    { "id": "04-final-diff-audit", "status": "completed", "owner": "read-only-agent", "write_scope": [], "result_path": "results/04-final-diff-audit.md" }
+  ],
+  "verification": {
+    "status": "passed_with_baseline_warning",
+    "checks": [
+      { "name": "focused tests", "command": "npm run test:main -- <affected tests>", "required": true, "status": "passed", "evidence": "42 tests passed in final focused run" },
+      { "name": "typecheck", "command": "npm run typecheck", "required": true, "status": "passed", "evidence": "renderer and main TypeScript checks passed" },
+      { "name": "main tests", "command": "npm run test:main", "required": true, "status": "passed", "evidence": "56 suites, 375 tests passed" },
+      { "name": "renderer tests", "command": "npm run test:renderer", "required": true, "status": "passed", "evidence": "8 files, 19 tests passed" },
+      { "name": "build", "command": "npm run build", "required": true, "status": "passed", "evidence": "electron-vite production build passed" },
+      { "name": "diff hygiene", "command": "git diff --check", "required": true, "status": "passed", "evidence": "no whitespace errors" },
+      { "name": "format baseline", "command": "npm run format:check", "required": false, "status": "baseline_failed", "evidence": "332 existing files reported; no bulk rewrite performed" }
+    ]
+  }
+}

--- a/src/main/AuthManager.ts
+++ b/src/main/AuthManager.ts
@@ -146,7 +146,7 @@ const AuthManager = {
     logger.info('Logging out');
     getTokenStore().reset(storeKey);
     authSessionReadiness.setAccountReady(false);
-    SettingsManager.delete('tokenExpirationDate');
+    await SettingsManager.delete('tokenExpirationDate');
     messenger.send('oauth:logged-out');
   },
   setLogoutTimer: async (isFirstTime = false) => {

--- a/src/main/GGGAPI.ts
+++ b/src/main/GGGAPI.ts
@@ -9,6 +9,8 @@ import { getAppVersion } from './runtime/getUserDataPath';
 import { authSessionReadiness } from './auth/AuthSessionReadiness';
 import { poeApiResolutionGuard } from './runtime/poeApiHostResolution';
 const CACHE_TIME_IN_SECONDS = 10;
+const CHARACTER_LIST_CACHE_TIME_IN_SECONDS = 30;
+const CHARACTER_SNAPSHOT_CACHE_TIME_IN_SECONDS = 2;
 const MIN_TIME_BETWEEN_REQUESTS = 333; // 1 request per second as a default, will be adjusted based on API feedback
 const instance = Axios.create();
 const storage = buildMemoryStorage();
@@ -34,6 +36,7 @@ const limiters = new Bottleneck.Group({
 });
 
 let currentlyRestrictedKeys = {};
+const inFlightRequests = new Map<string, Promise<any>>();
 
 /**
  * PARSER: Converts PoE's "1:5:0,10:60:0" format into an object
@@ -150,6 +153,7 @@ const getRequestParams = (url, token) => {
     baseURL: 'https://api.pathofexile.com',
     url,
     method: 'GET',
+    timeout: 15000,
     headers: {
       'User-Agent': `OAuth exile-diary-reborn/${getAppVersion()} (contact: ${adminEmail})`,
       Authorization: `Bearer ${token}`,
@@ -158,49 +162,60 @@ const getRequestParams = (url, token) => {
 };
 
 const request = async ({ params, group, cacheTime = CACHE_TIME_IN_SECONDS, limiterId = group }) => {
-  await poeApiResolutionGuard.ensurePoeApiHostResolution();
-  const limiter = limiters.key(limiterId);
-  const scheduledId = `${group.replace('/', '')}-${uuidv4()}`;
-
-  if (currentlyRestrictedKeys && currentlyRestrictedKeys[group]) {
-    const cached = await storage.get(group);
-    if (cached && cached.data) {
-      logger.warn('âš ï¸ API Restricted: Serving STALE data from cache.');
-      return cached.data;
-    }
-    // If not even in cache, we must throw or wait
-    throw new Error('API Restricted and no cached data available.');
+  const requestKey = `${limiterId}:${group}:${params.url}`;
+  const existingRequest = inFlightRequests.get(requestKey);
+  if (existingRequest) {
+    logger.debug(`Coalescing in-flight GGG request for ${params.url}`);
+    return existingRequest;
   }
 
-  return limiter.schedule({ id: scheduledId }, async () => {
-    logger.debug('Making request to GGG API', { url: params.url, group, params });
-    if (!params.cache) {
-      logger.debug('Adding cache to request for group', group);
-      params.cache = {
-        enabled: true,
-        ttl: 1000 * cacheTime,
-      };
+  const pendingRequest = (async () => {
+    await poeApiResolutionGuard.ensurePoeApiHostResolution();
+    const limiter = limiters.key(limiterId);
+    const scheduledId = `${group.replace('/', '')}-${uuidv4()}`;
+
+    if (currentlyRestrictedKeys && currentlyRestrictedKeys[group]) {
+      const cached = await storage.get(group);
+      if (cached && cached.data) {
+        logger.warn('API Restricted: Serving stale data from cache.');
+        return cached.data;
+      }
+      throw new Error('API Restricted and no cached data available.');
     }
-    const response = await new Promise<void>((resolve) => {
-      logger.debug('Starting the Request Promise for', { url: params.url, group });
-      resolve();
-    })
-      .then(() => axios({ ...params, id: group }))
-      .then(async (response) => {
-        if (response.cached) {
-          logger.debug(`Response from cache for ${params.url}`);
-        } else {
-          logger.debug(`Response from API for ${params.url}`);
-        }
-        return response;
-      });
 
-    updateLimiterFromHeaders(limiter, response.headers);
+    return limiter.schedule({ id: scheduledId }, async () => {
+      logger.debug('Making request to GGG API', { url: params.url, group, params });
+      if (!params.cache) {
+        params.cache = {
+          enabled: true,
+          ttl: 1000 * cacheTime,
+        };
+      }
+      const response: any = await axios({ ...params, id: group });
 
-    logger.debug('Request successfully completed for', { url: params.url, group });
+      updateLimiterFromHeaders(limiter, response.headers);
+      logger.debug('Request successfully completed for', { url: params.url, group });
+      return response;
+    });
+  })();
 
-    return response;
+  inFlightRequests.set(requestKey, pendingRequest);
+  try {
+    return await pendingRequest;
+  } finally {
+    if (inFlightRequests.get(requestKey) === pendingRequest) {
+      inFlightRequests.delete(requestKey);
+    }
+  }
+};
+
+const getCharacterSnapshot = async (username: string, characterName: string, token: string) => {
+  const response: any = await request({
+    params: getRequestParams(Endpoints.character({ characterName }), token),
+    group: `getCharacter-${username}-${characterName}`,
+    cacheTime: CHARACTER_SNAPSHOT_CACHE_TIME_IN_SECONDS,
   });
+  return response.data.character;
 };
 
 const getSettings = async (needProfile = true) => {
@@ -210,6 +225,7 @@ const getSettings = async (needProfile = true) => {
   if ((!activeProfile || !activeProfile.characterName) && needProfile)
     throw new Error('Missing Active Profile');
   const token = await AuthManager.getToken();
+  if (!token) throw new Error('Missing OAuth token');
   return {
     username,
     characterName: activeProfile?.characterName,
@@ -226,6 +242,7 @@ const getAllCharacters = async () => {
     const response: any = await request({
       params: getRequestParams(Endpoints.characters(), token),
       group: `getAllCharacters-${username}`,
+      cacheTime: CHARACTER_LIST_CACHE_TIME_IN_SECONDS,
     });
     const characters = await response.data.characters;
     logger.info(`Found ${characters.length} characters from the GGG API for account: ${username}`);
@@ -240,12 +257,9 @@ const getDataForInventory = async (): Promise<Inventory> => {
   logger.info('Getting inventory and XP data from the GGG API');
   try {
     await authSessionReadiness.waitForProfileAccess();
-    const { characterName, token } = await getSettings();
-    const response: any = await request({
-      params: getRequestParams(Endpoints.character({ characterName }), token),
-      group: `getDataForInventory-${characterName}`,
-    });
-    const character = await response.data.character;
+    const { username, characterName, token } = await getSettings();
+    if (!characterName) throw new Error('Missing Active Profile');
+    const character = await getCharacterSnapshot(username, characterName, token);
     const { inventory: mainInventory, equipment, experience } = character;
     const rucksack = character.rucksack ?? [];
     const inventory = [...mainInventory, ...rucksack];
@@ -265,12 +279,10 @@ const getSkillTree = async () => {
   logger.info('Getting skill tree from the GGG API');
   try {
     await authSessionReadiness.waitForProfileAccess();
-    const { characterName, token } = await getSettings();
-    const response: any = await request({
-      params: getRequestParams(Endpoints.character({ characterName }), token),
-      group: `getSkillTree-${characterName}`,
-    });
-    const skillTree = await response.data.character.passives;
+    const { username, characterName, token } = await getSettings();
+    if (!characterName) throw new Error('Missing Active Profile');
+    const character = await getCharacterSnapshot(username, characterName, token);
+    const skillTree = await character.passives;
     logger.info(`Found skill tree for character: ${characterName}`);
     return skillTree;
   } catch (e: any) {
@@ -321,7 +333,7 @@ const APIManager = {
     const characters = await getAllCharacters();
     const { activeProfile } = SettingsManager.settings;
     const currentCharacter = characters.find((character) =>
-      activeProfile && activeProfile.charactername
+      activeProfile && activeProfile.characterName
         ? character.name === activeProfile.characterName
         : character.current
     );

--- a/src/main/SettingsManager.ts
+++ b/src/main/SettingsManager.ts
@@ -28,6 +28,20 @@ function hasValidActiveProfile(activeProfile: any) {
   );
 }
 
+function haveProfilesChanged(previousValue: any, nextValue: any) {
+  return (
+    previousValue?.characterName !== nextValue?.characterName ||
+    previousValue?.league !== nextValue?.league
+  );
+}
+
+type ActiveProfile = {
+  characterName: string;
+  league: string;
+  valid?: boolean;
+  [key: string]: unknown;
+};
+
 const DefaultSettings = {
   activeProfile: {
     characterName: null,
@@ -76,7 +90,9 @@ const DefaultSettings = {
 class SettingsManager {
   settings: any;
   saveScheduler: NodeJS.Timeout | null = null;
-  databaseInitializationPromise: Promise<void> | null = null;
+  lastSaveError: Error | null = null;
+  profileTransitionQueue: Promise<void> = Promise.resolve();
+  databaseInitializationPromises = new Map<string, Promise<void>>();
   eventEmitter = new EventEmitter();
   eventKeyMatcher: {
     [key: string]: {
@@ -115,25 +131,30 @@ class SettingsManager {
     authSessionReadiness.setProfileReady(hasValidActiveProfile(this.settings.activeProfile));
   }
 
-  async initializeDB(characterName: string) {
-    if (this.databaseInitializationPromise) {
-      return this.databaseInitializationPromise;
-    }
+  private refreshRatesInBackground(profile: ActiveProfile) {
+    void RateGetterV2.update().catch((error) => {
+      logger.warn(`Background rate refresh failed after initializing ${profile.characterName}`, error);
+    });
+  }
 
-    this.databaseInitializationPromise = (async () => {
-      logger.info(`Initializing DB for ${characterName}`);
-      const character = await this.getCharacter(characterName);
-      await DB.initDB(character.name);
-      await DB.initLeagueDB(character.league, character.name);
-      void RateGetterV2.update().catch((error) => {
-        logger.warn(`Background rate refresh failed after initializing ${character.name}`, error);
-      });
+  async initializeDB(profile: ActiveProfile, refreshRates = true) {
+    const key = `${profile.characterName}\u0000${profile.league}`;
+    const existingInitialization = this.databaseInitializationPromises.get(key);
+    if (existingInitialization) return existingInitialization;
+
+    const initialization = (async () => {
+      logger.info(`Initializing DB for ${profile.characterName} in ${profile.league}`);
+      await DB.initDB(profile.characterName, profile.league);
+      await DB.initLeagueDB(profile.league, profile.characterName);
+      if (refreshRates) this.refreshRatesInBackground(profile);
     })();
 
+    this.databaseInitializationPromises.set(key, initialization);
+
     try {
-      await this.databaseInitializationPromise;
+      await initialization;
     } finally {
-      this.databaseInitializationPromise = null;
+      this.databaseInitializationPromises.delete(key);
     }
   }
 
@@ -183,30 +204,40 @@ class SettingsManager {
     if (key !== 'mainWindowBounds' && key !== 'poesessid')
       logger.info(`Set "${key}" to ${JSON.stringify(value)}`);
     if (key === 'poesessid') logger.info(`Set ${key}`);
+    if (key === 'activeProfile') {
+      const transition = this.profileTransitionQueue.catch(() => undefined).then(async () => {
+        const previousValue = this.settings.activeProfile;
+        const profileChanged = haveProfilesChanged(previousValue, value);
+
+        if (hasValidActiveProfile(value) && profileChanged) {
+          authSessionReadiness.setProfileReady(false);
+          try {
+            await this.initializeDB(value, false);
+          } catch (error) {
+            authSessionReadiness.setProfileReady(hasValidActiveProfile(previousValue));
+            logger.error(`DB initialization failed for ${value.characterName}`, error);
+            throw error;
+          }
+        }
+
+        this.settings.activeProfile = value;
+        authSessionReadiness.setProfileReady(hasValidActiveProfile(value));
+        this.scheduleSave();
+        this.eventEmitter.emit('change', key, value, previousValue);
+      });
+      this.profileTransitionQueue = transition;
+      return transition;
+    }
+
     const previousValue = this.settings[key];
     this.settings[key] = value;
-    if (key === 'activeProfile') {
-      authSessionReadiness.setProfileReady(hasValidActiveProfile(value));
-    }
-    if (
-      key === 'activeProfile' &&
-      value.characterName &&
-      !!(
-        this.settings.activeProfile || // First active Profile
-        (this.settings.activeProfile && // New active Profile
-          value.characterName !== this.settings.activeProfile.characterName)
-      )
-      )
-      void this.initializeDB(value.characterName).catch((error) => {
-        logger.warn(`Background DB initialization failed for ${value.characterName}`, error);
-      });
-    this.eventEmitter.emit('change', key, value, previousValue);
     this.scheduleSave();
-
+    this.eventEmitter.emit('change', key, value, previousValue);
   }
 
   scheduleSave() {
     logger.info('Scheduling settings save');
+    this.lastSaveError = null;
     if (this.saveScheduler) clearTimeout(this.saveScheduler);
 
     this.saveScheduler = setTimeout(() => {
@@ -225,7 +256,12 @@ class SettingsManager {
       await fs.writeFile(tempFilePath, JSON.stringify(this.settings));
       logger.info(`Renaming ${tempFilePath} into  ${settingsPath}`);
       await fs.rename(tempFilePath, settingsPath);
+      this.lastSaveError = null;
       this.eventEmitter.emit('saved');
+    } catch (error) {
+      this.lastSaveError = error instanceof Error ? error : new Error(String(error));
+      this.eventEmitter.emit('save:error', this.lastSaveError);
+      throw error;
     } finally {
       if (this.saveScheduler) clearTimeout(this.saveScheduler);
       this.saveScheduler = null;
@@ -252,14 +288,40 @@ class SettingsManager {
     delete this.eventKeyMatcher[key];
   }
 
-  waitForSave() {
-    return new Promise((resolve) => {
+  private waitForScheduledSave() {
+    return new Promise<void>((resolve, reject) => {
       if (!this.saveScheduler) {
-        resolve(null);
+        if (this.lastSaveError) {
+          const error = this.lastSaveError;
+          this.lastSaveError = null;
+          reject(error);
+        } else {
+          resolve();
+        }
       } else {
-        this.eventEmitter.once('saved', resolve);
+        const onSaved = () => {
+          this.eventEmitter.off('save:error', onError);
+          resolve();
+        };
+        const onError = (error: Error) => {
+          this.eventEmitter.off('saved', onSaved);
+          reject(error);
+        };
+        this.eventEmitter.once('saved', onSaved);
+        this.eventEmitter.once('save:error', onError);
       }
     });
+  }
+
+  async waitForSave() {
+    while (true) {
+      const transition = this.profileTransitionQueue;
+      await transition;
+      if (transition !== this.profileTransitionQueue) continue;
+
+      await this.waitForScheduledSave();
+      if (transition === this.profileTransitionQueue && !this.saveScheduler) return;
+    }
   }
 }
 

--- a/src/main/auth/syncRuntimeAuthSession.ts
+++ b/src/main/auth/syncRuntimeAuthSession.ts
@@ -13,7 +13,7 @@ export async function saveTokenAndSyncRuntime(token: OAuthToken) {
   await refreshMainSettingsFromRuntime();
   await AuthManager.saveToken(token);
   await SettingsManager.waitForSave();
-  await RuntimeSidecarClient.restart();
+  await RuntimeSidecarClient.callRuntimeMethod<void>('auth.refreshSession');
 }
 
 export async function logoutAndSyncRuntime() {

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -640,16 +640,7 @@ class DBManager {
   constructor({ dbPath }: { dbPath: string }) {
     logger.info('Starting DB:', dbPath);
     this.db = new DatabaseConstructor(dbPath);
-    try {
-      const extensionPath = sqliteRegex.getLoadablePath();
-      this.db.loadExtension(extensionPath);
-      this.hasRegexExtension = true;
-    } catch (error) {
-      logger.warn(
-        `Failed to load sqlite regex extension for ${dbPath}. Continuing without it.`,
-        error
-      );
-    }
+    this.loadRegexExtension();
     this.eventEmitter.on('task:added', () => {
       this.runTasks();
     });
@@ -658,6 +649,20 @@ class DBManager {
     });
     this.isBusy = false;
     this.runTasks();
+  }
+
+  private loadRegexExtension() {
+    this.hasRegexExtension = false;
+    try {
+      const extensionPath = sqliteRegex.getLoadablePath();
+      this.db.loadExtension(extensionPath);
+      this.hasRegexExtension = true;
+    } catch (error) {
+      logger.warn(
+        `Failed to load sqlite regex extension for ${this.db.name}. Continuing without it.`,
+        error
+      );
+    }
   }
 
   getStatement(sql: string) {
@@ -686,17 +691,125 @@ class DBManager {
 
   runTask(task: Function): Promise<any> {
     const id = uuidv4();
-    return new Promise((resolve) => {
-      this.eventEmitter.once(`task:start:${id}`, () => {
-        // logger.info(`Running task ${id}`);
-        const result = task();
-        this.eventEmitter.emit(`task:end:${id}`);
-        resolve(result);
+    return new Promise((resolve, reject) => {
+      this.eventEmitter.once(`task:start:${id}`, async () => {
+        try {
+          resolve(await task());
+        } catch (error) {
+          reject(error);
+        } finally {
+          this.eventEmitter.emit(`task:end:${id}`);
+        }
       });
-      // logger.info(`Adding task ${id}`);
       this.tasks.push(id);
       this.eventEmitter.emit(`task:added`);
     });
+  }
+
+  private getUserVersionCommand(command: string) {
+    return /^\s*pragma\s+user_version\s*=\s*(\d+)/i.exec(command);
+  }
+
+  private async runStatementsAtomically(commands: string[]) {
+    if (!commands.length) return;
+
+    await this.runTask(() => {
+      const transaction = this.db.transaction(() => {
+        for (const command of commands) {
+          logger.debug(`Running command: ${command}`);
+          this.db.prepare(command).run();
+        }
+      });
+      transaction();
+    });
+  }
+
+  async hasTable(tableName: string) {
+    return this.runTask(() =>
+      this.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+        .get(tableName)
+    );
+  }
+
+  async ensureKnownSchemaRepairs() {
+    const version = this.db.pragma('user_version', { simple: true }) as number;
+    if (version < 14 || (await this.hasTable('area_info'))) return;
+
+    logger.warn(
+      `Repairing missing area_info table in ${this.db.name}; the database reports schema version ${version}`
+    );
+    await this.runStatementsAtomically([
+      `CREATE TABLE IF NOT EXISTS area_info (
+        id INTEGER NOT NULL,
+        run_id INTEGER NOT NULL UNIQUE,
+        name TEXT,
+        level INTEGER,
+        depth INTEGER,
+        PRIMARY KEY ("id" AUTOINCREMENT)
+      )`,
+    ]);
+  }
+
+  async validateTables(requiredTables: string[]) {
+    const missing: string[] = [];
+    for (const tableName of requiredTables) {
+      if (!(await this.hasTable(tableName))) missing.push(tableName);
+    }
+
+    if (missing.length) {
+      throw new Error(
+        `DB_SCHEMA_INVALID: ${this.db.name} is missing required tables: ${missing.join(', ')}`
+      );
+    }
+  }
+
+  async hasUserData() {
+    const checks = [
+      ['run', 'SELECT 1 FROM run LIMIT 1'],
+      ['mapruns', "SELECT 1 FROM mapruns WHERE CAST(id AS TEXT) != '-1' LIMIT 1"],
+      ['event', 'SELECT 1 FROM event LIMIT 1'],
+      ['events', 'SELECT 1 FROM events LIMIT 1'],
+      ['item', 'SELECT 1 FROM item LIMIT 1'],
+      ['items', 'SELECT 1 FROM items LIMIT 1'],
+      ['area_info', 'SELECT 1 FROM area_info LIMIT 1'],
+      ['areainfo', 'SELECT 1 FROM areainfo LIMIT 1'],
+      ['gear', 'SELECT 1 FROM gear LIMIT 1'],
+      ['filter', 'SELECT 1 FROM filter LIMIT 1'],
+      ['filters', 'SELECT 1 FROM filters LIMIT 1'],
+      ['incubator', 'SELECT 1 FROM incubator LIMIT 1'],
+      ['incubators', 'SELECT 1 FROM incubators LIMIT 1'],
+      ['last_inventory', 'SELECT 1 FROM last_inventory LIMIT 1'],
+      ['lastinv', 'SELECT 1 FROM lastinv LIMIT 1'],
+      ['passives', 'SELECT 1 FROM passives LIMIT 1'],
+      ['xp', 'SELECT 1 FROM xp LIMIT 1'],
+      ['league', 'SELECT 1 FROM league LIMIT 1'],
+      ['leagues', 'SELECT 1 FROM leagues LIMIT 1'],
+      ['graftblood', 'SELECT 1 FROM graftblood LIMIT 1'],
+      ['stashes', 'SELECT 1 FROM stashes LIMIT 1'],
+      ['fullrates', 'SELECT 1 FROM fullrates LIMIT 1'],
+    ] as const;
+
+    for (const [tableName, query] of checks) {
+      if (!(await this.hasTable(tableName))) continue;
+      const row = await this.runTask(() => this.db.prepare(query).get());
+      if (row) return true;
+    }
+    return false;
+  }
+
+  async resetEmptyDatabaseWithBackup() {
+    if (!fs.existsSync(this.db.name) || (await this.hasUserData())) return false;
+
+    const dbPath = this.db.name;
+    const backupPath = `${dbPath}.incomplete-${Date.now()}.bak`;
+    logger.warn(`Backing up incomplete empty database ${dbPath} to ${backupPath}`);
+    this.db.close();
+    fs.renameSync(dbPath, backupPath);
+    this.statements.clear();
+    this.db = new DatabaseConstructor(dbPath);
+    this.loadRegexExtension();
+    return true;
   }
 
   init: Function = async (sqlList: string[][], maintSqlList: string[] = []) => {
@@ -706,31 +819,38 @@ class DBManager {
       version = this.db.pragma('user_version', { simple: true }) as number;
     } catch (err) {
       logger.error('Error reading database version: ' + err);
-      return;
+      if (err && typeof err === 'object') {
+        (err as { code?: string }).code = 'DB_VERSION_READ_FAILED';
+      }
+      throw err;
     }
 
-    let migrationCounter = 0;
+    const migrationCommands: string[] = [];
+    let targetVersion = version;
+    for (const [index, sqlPatch] of sqlList.entries()) {
+      if (version !== 0 && index <= version) continue;
 
-    for (const sqlPatch of sqlList) {
-      const index = sqlList.indexOf(sqlPatch);
-      if (version === 0 || index > version) {
-        logger.debug(`Running initialization SQL for ${this.db.name} - version ${index}`);
-        logger.debug(`SQL commands: ${JSON.stringify(sqlPatch)}`);
-        for (const command of sqlList[index]) {
-          logger.debug(`Running command: ${command}`);
-          await this.runTask(() => this.db.prepare(command).run());
-          migrationCounter++;
+      logger.debug(`Queueing initialization SQL for ${this.db.name} - version ${index}`);
+      logger.debug(`SQL commands: ${JSON.stringify(sqlPatch)}`);
+      for (const command of sqlPatch) {
+        const versionMatch = this.getUserVersionCommand(command);
+        if (versionMatch) {
+          targetVersion = Math.max(targetVersion, Number(versionMatch[1]));
+        } else {
+          migrationCommands.push(command);
         }
       }
     }
 
-    for (const command of maintSqlList) {
-      await this.runTask(() => this.db.prepare(command).run());
-      migrationCounter++;
+    if (targetVersion > version) {
+      migrationCommands.push(`pragma user_version = ${targetVersion}`);
     }
 
+    await this.runStatementsAtomically(migrationCommands);
+    await this.runStatementsAtomically(maintSqlList);
+
     logger.info(
-      `Initialization complete for ${this.db.name} - ${migrationCounter} migrations applied`
+      `Initialization complete for ${this.db.name} - ${migrationCommands.length} migration commands applied`
     );
     return null;
   };
@@ -739,6 +859,24 @@ class DBManager {
 // Map of all the DB Managers that have been instantiated, by path
 const DBConnections = new Map<string, DBManager>();
 
+const RequiredCharacterTables = [
+  'run',
+  'event',
+  'mapmod',
+  'area_info',
+  'gear',
+  'filter',
+  'incubator',
+  'item',
+  'league',
+  'last_inventory',
+  'passives',
+  'xp',
+  'graftblood',
+];
+
+const RequiredLeagueTables = ['characters', 'fullrates', 'stashes'];
+
 // External interface for DB
 const DB = {
   getLeagueDbPath: (league: string) => {
@@ -746,19 +884,11 @@ const DB = {
   },
 
   getCharacterDbPath: (characterName?: string, league?: string, oldVersion?: true) => {
+    const settings = getSettings();
+    if (!characterName) characterName = settings?.activeProfile?.characterName;
+    if (!league) league = settings?.activeProfile?.league;
     if (!characterName || !league) {
-      const settings = getSettings();
-      if (
-        !settings ||
-        !settings.activeProfile ||
-        !settings.activeProfile.characterName ||
-        !settings.activeProfile.characterName
-      ) {
-        // logger.error("No active profile selected, can't get DB");
-        return null;
-      }
-      characterName = settings.activeProfile.characterName;
-      league = settings.activeProfile.league;
+      return null;
     }
     if (oldVersion) {
       return path.join(getUserDataPath(), `${characterName}.db`);
@@ -790,6 +920,23 @@ const DB = {
     const manager: DBManager = DBConnections.get(dbPath) || new DBManager({ dbPath });
     DBConnections.set(dbPath, manager);
 
+    return manager;
+  },
+
+  getCharacterManager: (characterName?: string, league?: string) => {
+    const dbPath = DB.getCharacterDbPath(characterName, league);
+    if (!dbPath) return null;
+
+    const oldPath = characterName
+      ? DB.getCharacterDbPath(characterName, league, true)
+      : null;
+    if (oldPath && fs.existsSync(oldPath) && !fs.existsSync(dbPath)) {
+      logger.info(`Found the old pattern in db name, copying ${oldPath} to ${dbPath}`);
+      fs.copyFileSync(oldPath, dbPath);
+    }
+
+    const manager: DBManager = DBConnections.get(dbPath) || new DBManager({ dbPath });
+    DBConnections.set(dbPath, manager);
     return manager;
   },
 
@@ -834,12 +981,21 @@ const DB = {
     return DB.runMany(query, params, league);
   },
 
-  initDB: async (char: string) => {
-    const manager = DB.getManager(undefined, char);
+  initDB: async (char: string, league?: string) => {
+    const manager = DB.getCharacterManager(char, league);
     if (!manager) return null;
 
     const { init, maintenance } = Migrations.character;
-    await manager.init(init, maintenance);
+    try {
+      await manager.init(init, maintenance);
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'DB_VERSION_READ_FAILED') throw error;
+      const reset = await manager.resetEmptyDatabaseWithBackup();
+      if (!reset) throw error;
+      await manager.init(init, maintenance);
+    }
+    await manager.ensureKnownSchemaRepairs();
+    await manager.validateTables(RequiredCharacterTables);
   },
 
   initLeagueDB: async (league: string, characterName: string) => {
@@ -848,6 +1004,7 @@ const DB = {
 
     const { init, maintenance } = Migrations.league;
     await manager.init(init, maintenance);
+    await manager.validateTables(RequiredLeagueTables);
 
     const activeProfile = SettingsManager.get('activeProfile');
 

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -986,16 +986,19 @@ const DB = {
     if (!manager) return null;
 
     const { init, maintenance } = Migrations.character;
-    try {
+    const initializeAndValidate = async () => {
       await manager.init(init, maintenance);
+      await manager.ensureKnownSchemaRepairs();
+      await manager.validateTables(RequiredCharacterTables);
+    };
+    try {
+      await initializeAndValidate();
     } catch (error) {
       if ((error as { code?: string })?.code === 'DB_VERSION_READ_FAILED') throw error;
       const reset = await manager.resetEmptyDatabaseWithBackup();
       if (!reset) throw error;
-      await manager.init(init, maintenance);
+      await initializeAndValidate();
     }
-    await manager.ensureKnownSchemaRepairs();
-    await manager.validateTables(RequiredCharacterTables);
   },
 
   initLeagueDB: async (league: string, characterName: string) => {

--- a/src/main/deepLinks/authCallback.ts
+++ b/src/main/deepLinks/authCallback.ts
@@ -51,15 +51,6 @@ type AuthCallbackDeps = {
   verifyState: (state: string) => boolean;
 };
 
-function hasValidActiveProfile(activeProfile: ActiveProfile) {
-  return !!(
-    activeProfile &&
-    activeProfile.valid &&
-    activeProfile.characterName &&
-    activeProfile.league
-  );
-}
-
 export function findExileDiaryProtocolUrl(values: string[]) {
   return values.find((value) =>
     EXILE_DIARY_PROTOCOL_SCHEMES.some((scheme) => value.startsWith(scheme))
@@ -156,41 +147,6 @@ export async function processAuthCallbackUrl(rawUrl: string, deps: AuthCallbackD
 
   deps.sendAuthSuccess();
   logger.info('OAuth callback emitted auth success', { rawUrl });
-
-  if (!hasValidActiveProfile(deps.getActiveProfile())) {
-    void (async () => {
-      try {
-        const character = await deps.getCurrentCharacter();
-        if (!character?.name || !character?.league) {
-          logger.warn('OAuth callback profile seed failed', {
-            hasCharacter: !!character,
-            reason: 'missing-character',
-            rawUrl,
-          });
-          return;
-        }
-
-        await deps.saveSettings({
-          activeProfile: {
-            characterName: character.name,
-            league: character.league,
-            valid: true,
-          },
-        });
-        logger.info('OAuth callback seeded active profile from current character', {
-          characterName: character.name,
-          league: character.league,
-          rawUrl,
-        });
-      } catch (error) {
-        logger.warn('OAuth callback profile seed failed', {
-          error,
-          rawUrl,
-          reason: 'profile-seed-failed',
-        });
-      }
-    })();
-  }
 
   return {
     ok: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import AuthManager from './AuthManager';
 
 // Old stuff
 import ScreenshotWatcher from './modules/ImageParser/ScreenshotWatcher';
+import { createExplicitMapEndRequest } from './modules/mapEnd';
 import * as OCRWatcher from './modules/ImageParser/OCRWatcher';
 import {
   invokeChannels,
@@ -286,8 +287,9 @@ class MainProcess {
       },
       triggerRunParse: () => {
         logger.info('Run parse shortcut pressed');
-        const event = { timestamp: dayjs().toISOString() };
-        void this.runtimeBridge.runTracking.tryProcess({ event });
+        void this.runtimeBridge.runTracking
+          .tryProcess(createExplicitMapEndRequest(dayjs().toISOString(), 'shortcut'))
+          .catch((error) => logger.error('Run parse shortcut failed', error));
       },
       triggerScreenshot: () => {
         logger.info('Screenshot shortcut pressed');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,6 @@ import { autoUpdater } from 'electron-updater';
 import * as path from 'path';
 import logger from 'electron-log';
 import SettingsManager from './SettingsManager';
-import GGGAPI from './GGGAPI';
 import RendererLogger from './RendererLogger';
 import { OverlayController, OVERLAY_WINDOW_OPTS } from 'electron-overlay-window';
 import dayjs from 'dayjs';
@@ -248,7 +247,9 @@ class MainProcess {
           processProtocolUrl: async (protocolUrl: string) => {
             await processAuthCallbackUrl(protocolUrl, {
               getActiveProfile: () => this.runtimeBridge.settings.get('activeProfile'),
-              getCurrentCharacter: () => GGGAPI.getCurrentCharacter(),
+              getCurrentCharacter: async () => {
+                throw new Error('Profile selection is handled by the character selection route');
+              },
               getOauthToken: (code) => AuthManager.getOauthToken(code),
               getState: () => AuthManager.getState(),
               saveSettings: (settings) =>

--- a/src/main/modules/ClientTxtWatcher.ts
+++ b/src/main/modules/ClientTxtWatcher.ts
@@ -6,6 +6,7 @@ import fs from 'fs/promises';
 import Utils from './Utils';
 import SettingsManager from '../SettingsManager';
 import LogProcessor from './LogProcessor';
+import { isMapEndSignal } from './mapEnd';
 
 let tail: Tail | undefined;
 const emitter = new EventEmitter();
@@ -43,17 +44,7 @@ export function start() {
 
   tail = new Tail(`${settings.clientTxt}`, tailOptions);
 
-  tail.on('line', async (line: string) => {
-    const lowerCaseLine = line.toLowerCase();
-
-    const stringPatterns = {
-      end: [
-        `] @to ${settings.activeProfile.characterName.toLowerCase()}: end`,
-        `] ${settings.activeProfile.characterName.toLowerCase()}: end`,
-      ],
-      generating: ['generating'],
-    };
-
+  tail.on('line', (line: string) => {
     if (process.platform === 'linux') {
       line = JSON.stringify(line).replace(/(\\r\\n|\\n|\\r)/, '');
       line = JSON.parse(line);
@@ -67,6 +58,7 @@ export function start() {
 
     const { timestamp: originalTimestamp, line: content } = lineMatch.groups;
     const timestamp = dayjs(originalTimestamp, 'YYYY/MM/DD HH:mm:ss').toISOString();
+    const lowerCaseContent = content.toLocaleLowerCase();
 
     if (line.includes('] : AFK mode is now ON. Autoreply')) {
       logger.info('Setting AFK mode to ON');
@@ -79,23 +71,21 @@ export function start() {
       global.afk = false;
     }
 
-    if (stringPatterns.end.some((pattern) => lowerCaseLine.endsWith(pattern))) {
-      LogProcessor.schedule(async () => {
-        LogProcessor.processEnd(timestamp, content);
-      });
-    } else if (stringPatterns.generating.some((pattern) => lowerCaseLine.includes(pattern))) {
-      LogProcessor.schedule(async () => {
-        LogProcessor.processGeneration(timestamp, content);
-      });
+    let scheduledTask: Promise<unknown>;
+    if (isMapEndSignal(content, settings.activeProfile.characterName)) {
+      scheduledTask = LogProcessor.schedule(() => LogProcessor.processEnd(timestamp, content));
+    } else if (lowerCaseContent.includes('generating')) {
+      scheduledTask = LogProcessor.schedule(() =>
+        LogProcessor.processGeneration(timestamp, content)
+      );
     } else if (line.includes('Connecting to instance server at')) {
-      LogProcessor.schedule(async () => {
-        LogProcessor.processNewInstance(timestamp, content);
-      });
+      scheduledTask = LogProcessor.schedule(() =>
+        LogProcessor.processNewInstance(timestamp, content)
+      );
     } else {
-      LogProcessor.schedule(async () => {
-        LogProcessor.processOther(timestamp, content);
-      });
+      scheduledTask = LogProcessor.schedule(() => LogProcessor.processOther(timestamp, content));
     }
+    void scheduledTask.catch((error) => logger.error('Failed to process client log line', error));
   });
 
   tail.on('error', (error) => {

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -9,10 +9,11 @@ import InventoryGetter from './InventoryGetter';
 import ItemParser from './ItemParser';
 import EventParser from './EventParser';
 import Utils from './Utils';
+import { createExplicitMapEndRequest } from './mapEnd';
 
 const logger = Logger.scope('LogProcessor');
 
-class LogProcessorScheduler {
+export class LogProcessorScheduler {
   tasks: string[] = [];
   isBusy: boolean = true;
   eventEmitter: EventEmitter = new EventEmitter();
@@ -46,12 +47,15 @@ class LogProcessorScheduler {
 
   runTask(task: Function): Promise<any> {
     const id = uuidv4();
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.eventEmitter.once(`task:start:${id}`, async () => {
-        // logger.info(`Running task ${id}`);
-        const result = await task();
-        this.eventEmitter.emit(`task:end:${id}`);
-        resolve(result);
+        try {
+          resolve(await task());
+        } catch (error) {
+          reject(error);
+        } finally {
+          this.eventEmitter.emit(`task:end:${id}`);
+        }
       });
       // logger.info(`Adding task ${id}`);
       this.tasks.push(id);
@@ -265,9 +269,12 @@ const LogProcessor = {
   processEnd: async (timestamp: string, line: string) => {
     logger.debug('LogProcessor.processEnd', timestamp, line);
     try {
-      await RunParser.tryProcess({ event: { timestamp, server: lastInstanceServer } });
+      return await RunParser.tryProcess(
+        createExplicitMapEndRequest(timestamp, 'chat', lastInstanceServer)
+      );
     } catch (err) {
       logger.error(`Error processing last map run: ${err}`);
+      return false;
     }
   },
   processNewInstance: async (timestamp: string, line: string) => {

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -13,6 +13,7 @@ import LogProcessor from './LogProcessor';
 import ItemPricer from './ItemPricer';
 import XPTracker from './XPTracker';
 import GraftbloodTracker from './GraftbloodTracker';
+import type { RunProcessRequest } from './mapEnd';
 const logger = require('electron-log');
 const EventEmitter = require('events');
 
@@ -944,9 +945,10 @@ const RunParser = {
    * If no map run is processed, it returns undefined.
    * @throws Will log an error if processing fails.
    */
-  tryProcess: async (parameters: { event: ParsedEvent } | null) => {
+  tryProcess: async (parameters: RunProcessRequest | null) => {
     let event: ParsedEvent;
     let wasGivenEvent: boolean = false;
+    const isExplicitEnd = parameters?.reason === 'explicit-end';
     logger.debug('RunParser.tryProcess', parameters);
     if (parameters && parameters.event) {
       event = parameters.event;
@@ -1024,13 +1026,22 @@ const RunParser = {
         return false;
       }
       // Check if the server of the event matches the first event's server ??
-      else if (wasGivenEvent && event.server && event.server === mapFirstEvent.server) {
+      else if (
+        !isExplicitEnd &&
+        wasGivenEvent &&
+        event.server &&
+        event.server === mapFirstEvent.server
+      ) {
         logger.debug(`Still in same area ${event.area}, not processing`);
         return false;
       }
 
       // Check if the area is the same as the last one entered, but not the same server (since the case above it handles it)
-      else if (wasGivenEvent && event.area === [...mapEvents].reverse()[0].area) {
+      else if (
+        !isExplicitEnd &&
+        wasGivenEvent &&
+        event.area === [...mapEvents].reverse()[0].area
+      ) {
         logger.debug('Same Area, this is probably a mirage');
         return false;
       }

--- a/src/main/modules/mapEnd.ts
+++ b/src/main/modules/mapEnd.ts
@@ -1,0 +1,38 @@
+export type RunProcessReason = 'automatic' | 'explicit-end';
+export type ExplicitMapEndSource = 'chat' | 'shortcut';
+
+export type RunProcessRequest = {
+  event: {
+    timestamp: string;
+    area?: string;
+    server?: string;
+  };
+  reason?: RunProcessReason;
+  source?: ExplicitMapEndSource;
+};
+
+export function createExplicitMapEndRequest(
+  timestamp: string,
+  source: ExplicitMapEndSource,
+  server?: string
+): RunProcessRequest {
+  return {
+    event: {
+      timestamp,
+      ...(server ? { server } : {}),
+    },
+    reason: 'explicit-end',
+    source,
+  };
+}
+
+export function isMapEndSignal(content: string, activeCharacterName: string) {
+  const normalizedCharacterName = activeCharacterName.trim().toLocaleLowerCase();
+  if (!normalizedCharacterName) return false;
+
+  const taggedWhisper = /^@(?:to|from)(?:\s+<[^>]*>)?\s+(.+?):\s*end\s*$/i.exec(content);
+  const legacyMessage = /^(.+?):\s*end\s*$/i.exec(content);
+  const signaledCharacter = taggedWhisper?.[1] ?? legacyMessage?.[1];
+
+  return signaledCharacter?.trim().toLocaleLowerCase() === normalizedCharacterName;
+}

--- a/src/main/runtime/RuntimeSidecar.ts
+++ b/src/main/runtime/RuntimeSidecar.ts
@@ -20,6 +20,7 @@ import {
   runtimeRendererMethodKeys,
   runtimeSidecarEventNames,
   type RuntimeMethodKey,
+  type RuntimeLifecycleSnapshot,
   type RuntimeRendererMethodKey,
   type RuntimeSidecarEvent,
   type RuntimeSidecarReadyMessage,
@@ -39,7 +40,31 @@ const runtimeCore = createRuntimeCore();
 
 let runtimeStarted = false;
 let runtimeStateInitialized = false;
-let runtimeStateInitializationInProgress = false;
+let runtimeStateInitializationPromise: Promise<void> | null = null;
+let runtimeLifecycle: RuntimeLifecycleSnapshot = {
+  state: 'booting',
+  generation: 0,
+};
+
+function isProfileIdentityChange(nextProfile: any) {
+  const currentProfile = SettingsManager.get('activeProfile');
+  return (
+    currentProfile?.characterName !== nextProfile?.characterName ||
+    currentProfile?.league !== nextProfile?.league
+  );
+}
+
+function setRuntimeLifecycle(
+  state: RuntimeLifecycleSnapshot['state'],
+  partial: Partial<Omit<RuntimeLifecycleSnapshot, 'state'>> = {}
+) {
+  runtimeLifecycle = {
+    ...runtimeLifecycle,
+    ...partial,
+    state,
+  };
+  sendEvent(runtimeSidecarEventNames.runtimeStateChanged, runtimeLifecycle);
+}
 
 function sendMessage(
   message: RuntimeSidecarReadyMessage | RuntimeSidecarResponse | RuntimeSidecarEvent
@@ -91,7 +116,24 @@ const rendererMethodHandlers = runtimeRendererMethodKeys.reduce((handlers, metho
 }, {} as Record<RuntimeRendererMethodKey, (...args: any[]) => Promise<unknown>>);
 
 const runtimeMethodHandlers: Record<RuntimeMethodKey, (...args: any[]) => Promise<unknown>> = {
-  'settings.set': async (key, value) => SettingsManager.set(key, value),
+  'auth.refreshSession': async () => {
+    await SettingsManager.reload();
+    await syncAuthSessionReadiness();
+    await initializeAndStartBackgroundRuntime(
+      ensureRuntimeStateInitialized,
+      startBackgroundRuntime
+    );
+  },
+  'settings.set': async (key, value) => {
+    const isProfileTransition = key === 'activeProfile' && isProfileIdentityChange(value);
+    if (isProfileTransition) setRuntimeLifecycle('switching');
+    try {
+      return await SettingsManager.set(key, value);
+    } catch (error) {
+      if (isProfileTransition) setRuntimeLifecycle(runtimeStateInitialized ? 'ready' : 'failed');
+      throw error;
+    }
+  },
   'settings.waitForSave': async () => SettingsManager.waitForSave(),
   'runTracking.refreshTracking': async () => runtimeCore.runTracking.refreshTracking(),
   'runTracking.setCurrentMapStats': async (stats) =>
@@ -111,8 +153,9 @@ const runtimeMethodHandlers: Record<RuntimeMethodKey, (...args: any[]) => Promis
 async function initializeRuntimeState() {
   await SettingsManager.initialize();
   await syncAuthSessionReadiness();
+  await ensureRuntimeStateInitialized();
   authSessionReadiness.subscribe((state) => {
-    if (state.profileReady) {
+    if (state.profileReady && !runtimeStateInitialized) {
       void initializeAndStartBackgroundRuntime(
         ensureRuntimeStateInitialized,
         startBackgroundRuntime
@@ -121,54 +164,75 @@ async function initializeRuntimeState() {
       });
     }
   });
-  await ensureRuntimeStateInitialized();
 }
 
 async function ensureRuntimeStateInitialized() {
-  if (runtimeStateInitialized || runtimeStateInitializationInProgress) {
+  if (runtimeStateInitialized) {
     return;
   }
+
+  if (runtimeStateInitializationPromise) return runtimeStateInitializationPromise;
 
   if (!authSessionReadiness.getState().profileReady) {
     sidecarLogger.info(
       'Runtime DB initialization is waiting for an authenticated session with an active profile'
+    );
+    setRuntimeLifecycle(
+      authSessionReadiness.getState().accountReady ? 'needs-profile' : 'needs-auth'
     );
     return;
   }
 
   if (!SettingsManager.get('username')) {
     sidecarLogger.info('Runtime DB initialization is waiting for an authenticated account name');
+    setRuntimeLifecycle('needs-auth');
     return;
   }
 
-  runtimeStateInitializationInProgress = true;
-
-  try {
+  runtimeStateInitializationPromise = (async () => {
     const character = await SettingsManager.getCharacter();
     if (!character?.name || !character?.league) {
-      sidecarLogger.warn(
-        'Runtime DB initialization did not receive a valid current character; waiting for a valid profile'
-      );
-      return;
+      setRuntimeLifecycle('needs-profile');
+      throw new Error('Runtime DB initialization requires a valid active profile');
     }
 
-    await SettingsManager.initializeDB(character.name);
-    await League.addLeague(character.league);
-    sidecarLogger.info(
-      `Runtime DB initialized. Character: ${character.name}, League: ${character.league}`
-    );
-
-    IgnoreManager.initialize(sidecarLogger, () => {
-      sidecarLogger.debug('Runtime ignore settings updated');
+    setRuntimeLifecycle('preparing', {
+      generation: runtimeLifecycle.generation + 1,
+      profile: { characterName: character.name, league: character.league },
+      error: undefined,
     });
-    runtimeStateInitialized = true;
-  } catch (error) {
-    sidecarLogger.error(
-      `Could not set runtime DB up. (Current Account: ${SettingsManager.get('username')})`
-    );
-    sidecarLogger.error(error);
+
+    try {
+      await SettingsManager.initializeDB({
+        characterName: character.name,
+        league: character.league,
+        valid: true,
+      });
+      await League.addLeague(character.league);
+      sidecarLogger.info(
+        `Runtime DB initialized. Character: ${character.name}, League: ${character.league}`
+      );
+
+      IgnoreManager.initialize(sidecarLogger, () => {
+        sidecarLogger.debug('Runtime ignore settings updated');
+      });
+      runtimeStateInitialized = true;
+      setRuntimeLifecycle('ready');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setRuntimeLifecycle('failed', { error: message });
+      sidecarLogger.error(
+        `Could not set runtime DB up. (Current Account: ${SettingsManager.get('username')})`
+      );
+      sidecarLogger.error(error);
+      throw error;
+    }
+  })();
+
+  try {
+    await runtimeStateInitializationPromise;
   } finally {
-    runtimeStateInitializationInProgress = false;
+    runtimeStateInitializationPromise = null;
   }
 }
 
@@ -306,15 +370,43 @@ async function handleRequest(message: RuntimeSidecarRequest) {
         startedAt,
         uptimeSeconds: Number(process.uptime().toFixed(3)),
         runtimeStarted,
+        runtimeLifecycle,
       };
     case 'shutdown':
       return {
         status: 'stopped',
       };
     case 'renderer-method':
-      return rendererMethodHandlers[message.payload.method](...message.payload.args);
-    case 'runtime-method':
+      if (
+        runtimeLifecycle.state === 'switching' &&
+        message.payload.method !== 'saveSettings'
+      ) {
+        throw new Error('Runtime profile switch is in progress; retry this request shortly');
+      }
+      const isProfileTransition =
+        message.payload.method === 'saveSettings' &&
+        message.payload.args[0]?.activeProfile &&
+        isProfileIdentityChange(message.payload.args[0].activeProfile);
+      if (isProfileTransition) {
+        setRuntimeLifecycle('switching');
+      }
+      try {
+        return await rendererMethodHandlers[message.payload.method](...message.payload.args);
+      } catch (error) {
+        if (isProfileTransition) {
+          setRuntimeLifecycle(runtimeStateInitialized ? 'ready' : 'failed');
+        }
+        throw error;
+      }
+    case 'runtime-method': {
+      const allowedDuringSwitch = ['settings.set', 'settings.waitForSave'].includes(
+        message.payload.method
+      );
+      if (runtimeLifecycle.state === 'switching' && !allowedDuringSwitch) {
+        throw new Error('Runtime profile switch is in progress; retry this request shortly');
+      }
       return runtimeMethodHandlers[message.payload.method](...message.payload.args);
+    }
   }
 }
 

--- a/src/main/runtime/RuntimeSidecarClient.ts
+++ b/src/main/runtime/RuntimeSidecarClient.ts
@@ -24,8 +24,9 @@ export const pricesEmitter = new EventEmitter();
 export const statsEmitter = new EventEmitter();
 
 const isDev = Boolean(process.env.ELECTRON_RENDERER_URL);
-const StartupTimeoutMs = 20000;
+const StartupTimeoutMs = 120000;
 const RequestTimeoutMs = 30000;
+const ProfileTransitionTimeoutMs = 120000;
 const HealthCheckIntervalMs = 15000;
 const HealthCheckTimeoutMs = 5000;
 const RestartDelayMs = 500;
@@ -518,11 +519,14 @@ export async function callRendererMethod<T = unknown>(
   method: RuntimeRendererMethodKey,
   args: any[] = []
 ) {
-  return sendRequest<T>('renderer-method', { method, args });
+  const timeoutMs = method === 'saveSettings' ? ProfileTransitionTimeoutMs : RequestTimeoutMs;
+  return sendRequest<T>('renderer-method', { method, args }, timeoutMs);
 }
 
 export async function callRuntimeMethod<T = unknown>(method: RuntimeMethodKey, args: any[] = []) {
-  return sendRequest<T>('runtime-method', { method, args });
+  const timeoutMs =
+    method === 'auth.refreshSession' ? ProfileTransitionTimeoutMs : RequestTimeoutMs;
+  return sendRequest<T>('runtime-method', { method, args }, timeoutMs);
 }
 
 export async function stop() {

--- a/src/main/runtime/createRuntimeSidecarBridge.ts
+++ b/src/main/runtime/createRuntimeSidecarBridge.ts
@@ -3,6 +3,7 @@ import SettingsManager from '../SettingsManager';
 import ScreenshotWatcher from '../modules/ImageParser/ScreenshotWatcher';
 import * as OCRWatcher from '../modules/ImageParser/OCRWatcher';
 import * as RuntimeSidecarClient from './RuntimeSidecarClient';
+import type { RunProcessRequest } from '../modules/mapEnd';
 
 const searchCallbackEmitter = new EventEmitter();
 
@@ -56,7 +57,7 @@ export function createRuntimeSidecarBridge() {
         RuntimeSidecarClient.callRuntimeMethod<void>('runTracking.refreshTracking'),
       setCurrentMapStats: (stats: Record<string, any>) =>
         RuntimeSidecarClient.callRuntimeMethod<void>('runTracking.setCurrentMapStats', [stats]),
-      tryProcess: (payload: { event: Record<string, any> } | null) =>
+      tryProcess: (payload: RunProcessRequest | null) =>
         RuntimeSidecarClient.callRuntimeMethod<boolean>('runTracking.tryProcess', [payload]),
       tryUpdateCurrentArea: () =>
         RuntimeSidecarClient.callRuntimeMethod<boolean>('runTracking.tryUpdateCurrentArea'),

--- a/src/main/runtime/registerRuntimeListeners.ts
+++ b/src/main/runtime/registerRuntimeListeners.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, nativeImage } from 'electron';
+import { BrowserWindow, ipcMain, nativeImage } from 'electron';
 import logger from 'electron-log';
 import dayjs, { Dayjs } from 'dayjs';
 import AuthManager from '../AuthManager';
@@ -10,6 +10,7 @@ import { createRuntimeCore, RuntimeCore } from '../runtime-core/RuntimeCore';
 import { createOverlayPublisher } from '../runtime-core/services/createOverlayPublisher';
 import { createRuntimeSidecarBridge, RuntimeSidecarBridge } from './createRuntimeSidecarBridge';
 import { haveActiveProfilesChanged } from './haveActiveProfilesChanged';
+import * as RuntimeSidecarClient from './RuntimeSidecarClient';
 
 type RegisterRuntimeListenersDependencies = {
   mainWindow: BrowserWindow;
@@ -426,6 +427,7 @@ function registerSettingsListeners(
   runtime: RuntimeCore | RuntimeSidecarBridge,
   overlayPublisher: ReturnType<typeof createOverlayPublisher>
 ) {
+  let profileRestartPromise: Promise<void> | null = null;
   runtime.settings.registerListener('filters', (settings) => {
     deps.sendToMain(rendererEventChannels.settingsFiltersUpdated, settings);
   });
@@ -439,24 +441,39 @@ function registerSettingsListeners(
   });
   runtime.settings.registerListener('activeProfile', (newProfile, oldProfile) => {
     if (haveActiveProfilesChanged(newProfile, oldProfile)) {
-      logger.debug('Active profile changed, relaunching the app');
-      setTimeout(() => {
-        overlayPublisher.log({
-          messages: [
-            {
-              text: 'Active profile changed, relaunching the app to load data for the new profile when the settings finish saving in a few seconds...',
-            },
-          ],
-        });
-      }, 1000);
-      runtime.settings
+      if (profileRestartPromise) return;
+      logger.debug('Active profile changed, restarting the runtime sidecar');
+      overlayPublisher.log({
+        messages: [
+          {
+            text: 'Active profile changed. Preparing the runtime for the new profile...',
+          },
+        ],
+      });
+      profileRestartPromise = runtime.settings
         .waitForSave()
-        .then(() => {
-          app.relaunch();
-          app.quit();
+        .then(async () => {
+          await RuntimeSidecarClient.restart();
+          if (!deps.mainWindow.webContents.isDestroyed()) {
+            deps.mainWindow.webContents.reload();
+          }
+          if (!deps.overlayWindow.webContents.isDestroyed()) {
+            deps.overlayWindow.webContents.reload();
+          }
         })
         .catch((error) => {
-          logger.error('Error waiting for settings save', error);
+          logger.error('Error switching the runtime to the new active profile', error);
+          overlayPublisher.log({
+            messages: [
+              {
+                text: 'Unable to finish switching profiles. Restart Exile Diary to retry.',
+                type: 'error',
+              },
+            ],
+          });
+        })
+        .finally(() => {
+          profileRestartPromise = null;
         });
     }
   });

--- a/src/main/services/RendererAppService.ts
+++ b/src/main/services/RendererAppService.ts
@@ -6,7 +6,6 @@ import {
 } from '../../shared/contracts/runtimeSidecar';
 import * as RuntimeSidecarClient from '../runtime/RuntimeSidecarClient';
 import AuthManager from '../AuthManager';
-import GGGAPI from '../GGGAPI';
 import { logoutAndSyncRuntime } from '../auth/syncRuntimeAuthSession';
 
 const rendererRuntime = runtimeRendererMethodKeys.reduce((service, method) => {
@@ -32,8 +31,8 @@ export const RendererAppService = {
   },
 
   async getCharacters() {
-    logger.info('Loading characters directly from the main process GGGAPI');
-    return GGGAPI.getAllCharacters();
+    logger.info('Loading characters through the runtime sidecar GGG gateway');
+    return RuntimeSidecarClient.callRendererMethod('getCharacters');
   },
 
   async isAuthenticated() {

--- a/src/main/shortcuts/GlobalShortcutController.ts
+++ b/src/main/shortcuts/GlobalShortcutController.ts
@@ -1,4 +1,7 @@
 import { globalShortcut } from 'electron';
+import Logger from 'electron-log';
+
+const logger = Logger.scope('global-shortcuts');
 
 type ShortcutDefinition = {
   accelerator: string;
@@ -20,7 +23,10 @@ export class GlobalShortcutController {
 
   registerAll() {
     for (const shortcut of this.getShortcutDefinitions()) {
-      globalShortcut.register(shortcut.accelerator, shortcut.callback);
+      const registered = globalShortcut.register(shortcut.accelerator, shortcut.callback);
+      if (registered === false) {
+        logger.warn(`Unable to register shortcut ${shortcut.accelerator}; it may be in use`);
+      }
     }
   }
 

--- a/src/renderer/routes/CharacterSelect.tsx
+++ b/src/renderer/routes/CharacterSelect.tsx
@@ -14,16 +14,19 @@ const CharacterSelect = () => {
   const navigate = useNavigate();
   const { characters } = useLoaderData() as any;
   const [character, setCharacter] = React.useState(
-    characters.find((character) => character.current)
+    characters.find((character) => character.current) ?? characters[0] ?? null
   );
   const [isSaving, setIsSaving] = React.useState(false);
   const handleChange = (event: SelectChangeEvent<{ value: any }>) => {
-    setCharacter(characters.find((character) => (character.name = event.target.value)));
+    setCharacter(
+      characters.find((character) => character.name === event.target.value) ?? null
+    );
   };
 
   const saveCharacter = async () => {
     logger.info('Saving active character from Login');
-    await setIsSaving(true);
+    if (!character) return;
+    setIsSaving(true);
     const data = {
       activeProfile: {
         characterName: character.name,
@@ -46,7 +49,7 @@ const CharacterSelect = () => {
         </div>
         <FormControl className="Character-Select__Form">
           <FormControl size="small">
-            <Select id="character" value={character.name} onChange={handleChange}>
+            <Select id="character" value={character?.name ?? ''} onChange={handleChange}>
               {characters.map((character: any) => (
                 <MenuItem key={character.name} value={character.name}>
                   {character.name}
@@ -56,7 +59,12 @@ const CharacterSelect = () => {
             <FormHelperText>Pick a character to track</FormHelperText>
           </FormControl>
 
-          <Button variant="contained" color="primary" onClick={saveCharacter} disabled={isSaving}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={saveCharacter}
+            disabled={isSaving || !character}
+          >
             Validate
           </Button>
         </FormControl>

--- a/src/shared/contracts/runtimeSidecar.ts
+++ b/src/shared/contracts/runtimeSidecar.ts
@@ -30,6 +30,7 @@ export const runtimeRendererMethodKeys = [
 export type RuntimeRendererMethodKey = (typeof runtimeRendererMethodKeys)[number];
 
 export const runtimeMethodKeys = [
+  'auth.refreshSession',
   'settings.set',
   'settings.waitForSave',
   'runTracking.refreshTracking',
@@ -45,6 +46,26 @@ export const runtimeMethodKeys = [
 ] as const;
 
 export type RuntimeMethodKey = (typeof runtimeMethodKeys)[number];
+
+export type RuntimeLifecycleState =
+  | 'booting'
+  | 'needs-auth'
+  | 'needs-profile'
+  | 'preparing'
+  | 'ready'
+  | 'switching'
+  | 'degraded'
+  | 'failed';
+
+export type RuntimeLifecycleSnapshot = {
+  state: RuntimeLifecycleState;
+  profile?: {
+    characterName: string;
+    league: string;
+  };
+  generation: number;
+  error?: string;
+};
 
 export const runtimeSidecarEventNames = {
   rendererLog: 'renderer-log',
@@ -67,6 +88,7 @@ export const runtimeSidecarEventNames = {
   stashTabsUpdatedFull: 'stash-tabs-updated-full',
   netWorthUpdated: 'net-worth-updated',
   runtimeStarted: 'runtime-started',
+  runtimeStateChanged: 'runtime-state-changed',
 } as const;
 
 export type RuntimeSidecarEventName =

--- a/test/main/GGGAPI.spec.ts
+++ b/test/main/GGGAPI.spec.ts
@@ -118,6 +118,53 @@ describe('GGGAPI auth gating', () => {
     expect(waitForProfileAccess).not.toHaveBeenCalled();
     expect(getToken).toHaveBeenCalledTimes(1);
     expect(ensurePoeApiHostResolution).toHaveBeenCalledTimes(1);
+    expect(axiosRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 15000, url: '/character' })
+    );
+  });
+
+  it('coalesces concurrent character-list requests', async () => {
+    axiosRequest.mockResolvedValue({
+      cached: false,
+      headers: {},
+      data: {
+        characters: [{ name: 'AtlasRunner', current: true, league: 'Mirage' }],
+      },
+    });
+
+    const GGGAPI = (await import('../../src/main/GGGAPI')).default;
+    const [first, second] = await Promise.all([
+      GGGAPI.getAllCharacters(),
+      GGGAPI.getAllCharacters(),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(axiosRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares a concurrent character snapshot between inventory and passive-tree consumers', async () => {
+    axiosRequest.mockResolvedValue({
+      cached: false,
+      headers: {},
+      data: {
+        character: {
+          inventory: [],
+          equipment: [],
+          experience: 123,
+          passives: { hashes: [1], jewel_data: {} },
+        },
+      },
+    });
+
+    const GGGAPI = (await import('../../src/main/GGGAPI')).default;
+    const [inventory, passives] = await Promise.all([
+      GGGAPI.getDataForInventory(),
+      GGGAPI.getSkillTree(),
+    ]);
+
+    expect(inventory.experience).toBe(123);
+    expect(passives.hashes).toEqual([1]);
+    expect(axiosRequest).toHaveBeenCalledTimes(1);
   });
 
   it('waits only for account access when resolving the current character', async () => {

--- a/test/main/SettingsManager.spec.ts
+++ b/test/main/SettingsManager.spec.ts
@@ -89,6 +89,8 @@ describe('SettingsManager character bootstrap', () => {
 
     expect(character).toEqual({ name: 'Alice', league: 'Settlers' });
     expect(getAllCharacters).toHaveBeenCalledTimes(1);
+    expect(initDB).not.toHaveBeenCalled();
+    expect(initLeagueDB).not.toHaveBeenCalled();
     expect(getCurrentCharacter).not.toHaveBeenCalled();
     expect(setProfileReady).toHaveBeenCalledWith(true);
     expect(SettingsManager.settings.activeProfile).toEqual({
@@ -99,7 +101,7 @@ describe('SettingsManager character bootstrap', () => {
     await SettingsManager.save();
   });
 
-  it('starts the rate refresh in the background after initializing the character database', async () => {
+  it('defers the rate refresh until the replacement runtime starts', async () => {
     getAllCharacters.mockResolvedValue([
       { name: 'Alice', league: 'Settlers' },
       { name: 'Bob', league: 'Hardcore Settlers' },
@@ -117,16 +119,32 @@ describe('SettingsManager character bootstrap', () => {
       valid: true,
     })).resolves.toBeUndefined();
 
-    expect(getAllCharacters).toHaveBeenCalledTimes(1);
+    expect(getAllCharacters).not.toHaveBeenCalled();
+    expect(initDB).toHaveBeenCalledWith('Alice', 'Settlers');
+    expect(initLeagueDB).toHaveBeenCalledWith('Settlers', 'Alice');
     expect(SettingsManager.settings.activeProfile).toEqual({
       characterName: 'Alice',
       league: 'Settlers',
       valid: true,
     });
+    expect(rateGetterUpdate).not.toHaveBeenCalled();
     await SettingsManager.save();
   });
 
-  it('does not wait for DB initialization to finish before resolving activeProfile saves', async () => {
+  it('refreshes rates when the active runtime initializes an existing profile', async () => {
+    rateGetterUpdate.mockResolvedValue(undefined);
+    const SettingsManager = (await import('../../src/main/SettingsManager')).default as any;
+
+    await SettingsManager.initializeDB({
+      characterName: 'Alice',
+      league: 'Settlers',
+      valid: true,
+    });
+
+    expect(rateGetterUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for DB initialization before resolving activeProfile saves', async () => {
     getAllCharacters.mockResolvedValue([
       { name: 'Alice', league: 'Settlers' },
       { name: 'Bob', league: 'Hardcore Settlers' },
@@ -162,17 +180,111 @@ describe('SettingsManager character bootstrap', () => {
     });
 
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(settled).toBe(true);
+    expect(settled).toBe(false);
     expect(initDB).toHaveBeenCalledTimes(1);
     expect(initLeagueDB).toHaveBeenCalledTimes(0);
 
     resolveInitDB?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(initLeagueDB).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
     resolveInitLeagueDB?.();
     await savePromise;
 
-    expect(initLeagueDB).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(true);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(rateGetterUpdate).toHaveBeenCalledTimes(1);
+    expect(rateGetterUpdate).not.toHaveBeenCalled();
+    await SettingsManager.save();
+  });
+
+  it('keeps the previous profile visible until the target database is ready', async () => {
+    let resolveInitDB: (() => void) | undefined;
+    initDB.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInitDB = resolve;
+      })
+    );
+
+    const SettingsManager = (await import('../../src/main/SettingsManager')).default as any;
+    SettingsManager.settings = {
+      activeProfile: { characterName: 'Old', league: 'Standard', valid: true },
+    };
+
+    const transition = SettingsManager.set('activeProfile', {
+      characterName: 'Alice',
+      league: 'Settlers',
+      valid: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(SettingsManager.settings.activeProfile.characterName).toBe('Old');
+    expect(setProfileReady).toHaveBeenLastCalledWith(false);
+
+    resolveInitDB?.();
+    await transition;
+    expect(SettingsManager.settings.activeProfile.characterName).toBe('Alice');
+    expect(setProfileReady).toHaveBeenLastCalledWith(true);
+    await SettingsManager.save();
+  });
+
+  it('serializes concurrent profile transitions without rolling back a newer selection', async () => {
+    const resolvers = new Map<string, () => void>();
+    initDB.mockImplementation(
+      (characterName: string) =>
+        new Promise<void>((resolve) => {
+          resolvers.set(characterName, resolve);
+        })
+    );
+
+    const SettingsManager = (await import('../../src/main/SettingsManager')).default as any;
+    SettingsManager.settings = {
+      activeProfile: { characterName: 'Old', league: 'Standard', valid: true },
+    };
+
+    const first = SettingsManager.set('activeProfile', {
+      characterName: 'Alice',
+      league: 'Settlers',
+      valid: true,
+    });
+    const second = SettingsManager.set('activeProfile', {
+      characterName: 'Bob',
+      league: 'Hardcore',
+      valid: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(initDB).toHaveBeenCalledTimes(1);
+
+    resolvers.get('Alice')?.();
+    await first;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(initDB).toHaveBeenCalledTimes(2);
+    expect(SettingsManager.settings.activeProfile.characterName).toBe('Alice');
+
+    resolvers.get('Bob')?.();
+    await second;
+    expect(SettingsManager.settings.activeProfile.characterName).toBe('Bob');
+    await SettingsManager.save();
+  });
+
+  it('does not reinitialize the database when the active profile identity is unchanged', async () => {
+    const SettingsManager = (await import('../../src/main/SettingsManager')).default as any;
+    SettingsManager.settings = {
+      activeProfile: {
+        characterName: 'Alice',
+        league: 'Settlers',
+        valid: true,
+      },
+    };
+
+    await SettingsManager.set('activeProfile', {
+      characterName: 'Alice',
+      league: 'Settlers',
+      valid: true,
+      leagueOverride: 'Standard',
+    });
+
+    expect(initDB).not.toHaveBeenCalled();
+    expect(initLeagueDB).not.toHaveBeenCalled();
     await SettingsManager.save();
   });
 
@@ -196,6 +308,19 @@ describe('SettingsManager character bootstrap', () => {
       tempSettingsJsonPath,
       path.join('/mock-user-data', 'settings.json')
     );
+  });
+
+  it('rejects save waiters when settings persistence fails', async () => {
+    mockRename.mockRejectedValueOnce(new Error('rename failed'));
+    const SettingsManager = (await import('../../src/main/SettingsManager')).default as any;
+    SettingsManager.settings = { forceDebugMode: false };
+
+    await SettingsManager.set('forceDebugMode', true);
+    const waitForSave = SettingsManager.waitForSave();
+    const save = SettingsManager.save();
+
+    await expect(waitForSave).rejects.toThrow('rename failed');
+    await expect(save).rejects.toThrow('rename failed');
   });
 
   it('reloads the latest persisted settings without scheduling a write', async () => {

--- a/test/main/auth/syncRuntimeAuthSession.spec.ts
+++ b/test/main/auth/syncRuntimeAuthSession.spec.ts
@@ -37,7 +37,7 @@ describe('runtime auth session synchronization', () => {
     callRuntimeMethod.mockResolvedValue(undefined);
   });
 
-  it('persists new OAuth credentials before restarting the runtime sidecar', async () => {
+  it('persists new OAuth credentials before refreshing the runtime session', async () => {
     const { saveTokenAndSyncRuntime } = await import(
       '../../../src/main/auth/syncRuntimeAuthSession'
     );
@@ -53,7 +53,8 @@ describe('runtime auth session synchronization', () => {
     expect(callRuntimeMethod).toHaveBeenCalledWith('settings.waitForSave');
     expect(reload).toHaveBeenCalledTimes(1);
     expect(waitForSave).toHaveBeenCalledTimes(1);
-    expect(restart).toHaveBeenCalledTimes(1);
+    expect(restart).not.toHaveBeenCalled();
+    expect(callRuntimeMethod).toHaveBeenCalledWith('auth.refreshSession');
     expect(callRuntimeMethod.mock.invocationCallOrder[0]).toBeLessThan(
       reload.mock.invocationCallOrder[0]
     );
@@ -63,9 +64,10 @@ describe('runtime auth session synchronization', () => {
     expect(saveToken.mock.invocationCallOrder[0]).toBeLessThan(
       waitForSave.mock.invocationCallOrder[0]
     );
-    expect(waitForSave.mock.invocationCallOrder[0]).toBeLessThan(
-      restart.mock.invocationCallOrder[0]
+    const refreshCall = callRuntimeMethod.mock.calls.findIndex(
+      ([method]) => method === 'auth.refreshSession'
     );
+    expect(refreshCall).toBeGreaterThan(-1);
   });
 
   it('clears main-process auth before restarting the runtime sidecar', async () => {

--- a/test/main/db/index.spec.ts
+++ b/test/main/db/index.spec.ts
@@ -10,6 +10,7 @@ jest.mock('electron-log', () => ({
 const fsMock = {
   existsSync: jest.fn(),
   copyFileSync: jest.fn(),
+  renameSync: jest.fn(),
 };
 
 jest.mock('fs', () => ({
@@ -51,6 +52,7 @@ jest.mock('uuid', () => ({
 const dbConstructorMock = jest.fn((dbPath: string) => {
   const db = {
     name: dbPath,
+    close: jest.fn(),
     loadExtension: jest.fn(),
     pragma: jest.fn(() => 0),
     prepare: jest.fn((sql: string) => {
@@ -142,6 +144,7 @@ describe('db/index', () => {
     dbConstructorMock.mockClear();
     const failingDb = {
       name: 'D:\\mock-user-data\\ActiveChar.Mercenaries.db',
+      close: jest.fn(),
       loadExtension: jest.fn(() => {
         throw Object.assign(new Error('extension load failed'), { code: 'ERR_DLOPEN_FAILED' });
       }),
@@ -233,6 +236,18 @@ describe('db/index', () => {
     expect(seen).toEqual([1, 2, 3]);
   });
 
+  it('releases the task queue after a task throws', async () => {
+    const DB = loadDbModule();
+    const manager = DB.getManager(undefined, 'ActiveChar');
+
+    await expect(
+      manager.runTask(() => {
+        throw new Error('query failed');
+      })
+    ).rejects.toThrow('query failed');
+    await expect(manager.runTask(() => 42)).resolves.toBe(42);
+  });
+
   it('initDB applies only missing migrations and maintenance', async () => {
     const DB = loadDbModule();
     const manager = DB.getManager(undefined, 'ActiveChar');
@@ -249,20 +264,53 @@ describe('db/index', () => {
         sql.includes('CREATE INDEX IF NOT EXISTS "graftblood_timestamp"')
       )
     ).toBe(true);
-    expect(preparedSql.some((sql: string) => sql.includes('pragma user_version = 17'))).toBe(true);
+    expect(preparedSql.some((sql: string) => sql.includes('pragma user_version = 18'))).toBe(true);
     expect(preparedSql.some((sql: string) => sql.includes('delete from incubator'))).toBe(true);
+    expect(manager.db.transaction).toHaveBeenCalled();
   });
 
-  it('initDB exits without preparing statements when pragma read fails', async () => {
+  it('initDB rejects when the schema version cannot be read', async () => {
     const DB = loadDbModule();
     const manager = DB.getManager(undefined, 'ActiveChar');
     manager.db.pragma.mockImplementation(() => {
       throw new Error('pragma failed');
     });
 
-    await DB.initDB('ActiveChar');
+    await expect(DB.initDB('ActiveChar')).rejects.toThrow('pragma failed');
 
     expect(manager.db.prepare).not.toHaveBeenCalled();
+  });
+
+  it('backs up and rebuilds an empty database after an interrupted migration', async () => {
+    const DB = loadDbModule();
+    const manager = DB.getManager(undefined, 'ActiveChar');
+    manager.db.transaction.mockImplementationOnce(() => () => {
+      throw new Error('interrupted migration');
+    });
+    jest.spyOn(manager, 'hasUserData').mockResolvedValue(false);
+    fsMock.existsSync.mockReturnValue(true);
+
+    await expect(DB.initDB('ActiveChar', 'Mercenaries')).resolves.toBeUndefined();
+
+    expect(manager.db).not.toBe(getFirstDbInstance());
+    expect(fsMock.renameSync).toHaveBeenCalledWith(
+      expect.stringContaining('ActiveChar.Mercenaries.db'),
+      expect.stringMatching(/ActiveChar\.Mercenaries\.db\.incomplete-\d+\.bak$/)
+    );
+  });
+
+  it('preserves and reports a failed database when it contains user data', async () => {
+    const DB = loadDbModule();
+    const manager = DB.getManager(undefined, 'ActiveChar');
+    manager.db.transaction.mockImplementationOnce(() => () => {
+      throw new Error('migration failed');
+    });
+    jest.spyOn(manager, 'hasUserData').mockResolvedValue(true);
+    fsMock.existsSync.mockReturnValue(true);
+
+    await expect(DB.initDB('ActiveChar', 'Mercenaries')).rejects.toThrow('migration failed');
+
+    expect(fsMock.renameSync).not.toHaveBeenCalled();
   });
 
   it('initLeagueDB inserts active profile character when character name is not provided', async () => {

--- a/test/main/db/index.spec.ts
+++ b/test/main/db/index.spec.ts
@@ -299,6 +299,27 @@ describe('db/index', () => {
     );
   });
 
+  it('backs up and rebuilds an empty current-version database with an invalid schema', async () => {
+    const DB = loadDbModule();
+    const manager = DB.getManager(undefined, 'ActiveChar');
+    manager.db.pragma.mockReturnValue(18);
+    manager.db.prepare.mockImplementation((sql: string) => ({
+      all: jest.fn(),
+      get: jest.fn(() => (sql.includes("name = ?") ? undefined : { sql })),
+      run: jest.fn(),
+    }));
+    jest.spyOn(manager, 'hasUserData').mockResolvedValue(false);
+    fsMock.existsSync.mockReturnValue(true);
+
+    await expect(DB.initDB('ActiveChar', 'Mercenaries')).resolves.toBeUndefined();
+
+    expect(manager.db).not.toBe(getFirstDbInstance());
+    expect(fsMock.renameSync).toHaveBeenCalledWith(
+      expect.stringContaining('ActiveChar.Mercenaries.db'),
+      expect.stringMatching(/ActiveChar\.Mercenaries\.db\.incomplete-\d+\.bak$/)
+    );
+  });
+
   it('preserves and reports a failed database when it contains user data', async () => {
     const DB = loadDbModule();
     const manager = DB.getManager(undefined, 'ActiveChar');

--- a/test/main/deepLinks/AuthCallback.spec.ts
+++ b/test/main/deepLinks/AuthCallback.spec.ts
@@ -76,7 +76,7 @@ describe('auth callback deep links', () => {
     });
   });
 
-  it('completes the auth flow and seeds the active profile when needed', async () => {
+  it('completes the auth flow and leaves profile selection to the character picker', async () => {
     const getOauthToken = jest.fn(async () => ({ access_token: 'token' }));
     const saveToken = jest.fn(async () => undefined);
     const sendAuthSuccess = jest.fn();
@@ -99,14 +99,8 @@ describe('auth callback deep links', () => {
     expect(getOauthToken).toHaveBeenCalledWith('abc');
     expect(saveToken).toHaveBeenCalledWith({ access_token: 'token' });
     expect(sendAuthSuccess).toHaveBeenCalledTimes(1);
-    expect(getCurrentCharacter).toHaveBeenCalledTimes(1);
-    expect(saveSettings).toHaveBeenCalledWith({
-      activeProfile: {
-        characterName: 'Alice',
-        league: 'Settlers',
-        valid: true,
-      },
-    });
+    expect(getCurrentCharacter).not.toHaveBeenCalled();
+    expect(saveSettings).not.toHaveBeenCalled();
   });
 
   it('skips profile seeding when an active profile already exists', async () => {
@@ -178,7 +172,7 @@ describe('auth callback deep links', () => {
     expect(saveSettings).not.toHaveBeenCalled();
   });
 
-  it('does not wait for profile seeding before completing auth success', async () => {
+  it('does not start background profile seeding after auth success', async () => {
     let resolveCharacter: (() => void) | undefined;
     const characterPromise = new Promise<{ name: string; league: string }>((resolve) => {
       resolveCharacter = () => resolve({ name: 'Alice', league: 'Settlers' });
@@ -201,20 +195,14 @@ describe('auth callback deep links', () => {
 
     await expect(callbackPromise).resolves.toEqual({ ok: true });
     expect(sendAuthSuccess).toHaveBeenCalledTimes(1);
-    expect(getCurrentCharacter).toHaveBeenCalledTimes(1);
+    expect(getCurrentCharacter).not.toHaveBeenCalled();
     expect(saveSettings).not.toHaveBeenCalled();
 
     resolveCharacter?.();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(saveSettings).toHaveBeenCalledWith({
-      activeProfile: {
-        characterName: 'Alice',
-        league: 'Settlers',
-        valid: true,
-      },
-    });
+    expect(saveSettings).not.toHaveBeenCalled();
   });
 
   it('fails when the callback URL is invalid', async () => {

--- a/test/main/modules/ClientTxtWatcher.spec.ts
+++ b/test/main/modules/ClientTxtWatcher.spec.ts
@@ -1,0 +1,72 @@
+const tailHandlers = new Map<string, (...args: any[]) => unknown>();
+const tailWatch = jest.fn();
+const tailUnwatch = jest.fn();
+const mockSchedule = jest.fn((task: () => unknown) => Promise.resolve(task()));
+const mockProcessEnd = jest.fn().mockResolvedValue(true);
+const mockProcessGeneration = jest.fn().mockResolvedValue(undefined);
+const mockProcessNewInstance = jest.fn().mockResolvedValue(undefined);
+const mockProcessOther = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('tail', () => ({
+  Tail: jest.fn(() => ({
+    on: jest.fn((eventName: string, handler: (...args: any[]) => unknown) => {
+      tailHandlers.set(eventName, handler);
+    }),
+    watch: tailWatch,
+    unwatch: tailUnwatch,
+  })),
+}));
+
+jest.mock('../../../src/main/SettingsManager', () => ({
+  __esModule: true,
+  default: {
+    getAll: jest.fn(() => ({
+      clientTxt: 'C:\\Path of Exile\\logs\\Client.txt',
+      activeProfile: { characterName: 'AtlasRunner' },
+    })),
+  },
+}));
+
+jest.mock('../../../src/main/modules/Utils', () => ({
+  __esModule: true,
+  default: { poeRunning: jest.fn().mockResolvedValue(false) },
+}));
+
+jest.mock('fs/promises', () => ({
+  stat: jest.fn().mockResolvedValue({ mtime: new Date() }),
+}));
+
+jest.mock('../../../src/main/modules/LogProcessor', () => ({
+  __esModule: true,
+  default: {
+    schedule: mockSchedule,
+    processEnd: mockProcessEnd,
+    processGeneration: mockProcessGeneration,
+    processNewInstance: mockProcessNewInstance,
+    processOther: mockProcessOther,
+  },
+}));
+
+describe('ClientTxtWatcher map-end ingestion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tailHandlers.clear();
+  });
+
+  it('routes a tagged self-whisper to map-end processing', async () => {
+    const ClientTxtWatcher = await import('../../../src/main/modules/ClientTxtWatcher');
+    ClientTxtWatcher.start();
+    const lineHandler = tailHandlers.get('line');
+
+    await lineHandler?.(
+      '2026/07/22 10:00:00 123456 [INFO Client 1234] @To <Mercenaries> AtlasRunner: end'
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockProcessEnd).toHaveBeenCalledWith(
+      expect.any(String),
+      '@To <Mercenaries> AtlasRunner: end'
+    );
+    expect(mockProcessOther).not.toHaveBeenCalled();
+  });
+});

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -1,0 +1,100 @@
+let uuidCounter = 0;
+const mockTryProcess = jest.fn();
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => `log-task-${++uuidCounter}`),
+}));
+
+jest.mock('../../../src/main/modules/RunParser', () => ({
+  __esModule: true,
+  default: { tryProcess: mockTryProcess },
+}));
+jest.mock('../../../src/main/db/run', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../../src/main/SettingsManager', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../../src/main/modules/SkillTreeWatcher', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../../src/main/modules/InventoryGetter', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../../src/main/modules/ItemParser', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../../src/main/modules/EventParser', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../../src/main/modules/Utils', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+describe('LogProcessorScheduler', () => {
+  beforeEach(() => {
+    uuidCounter = 0;
+    mockTryProcess.mockReset();
+  });
+
+  it('keeps asynchronous client-log work in submission order', async () => {
+    const { LogProcessorScheduler } = await import('../../../src/main/modules/LogProcessor');
+    const scheduler = new LogProcessorScheduler();
+    const seen: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+
+    const first = scheduler.runTask(async () => {
+      seen.push('first:start');
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      seen.push('first:end');
+    });
+    const second = scheduler.runTask(async () => {
+      seen.push('second');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(seen).toEqual(['first:start']);
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(seen).toEqual(['first:start', 'first:end', 'second']);
+  });
+
+  it('releases the queue after a failed client-log task', async () => {
+    const { LogProcessorScheduler } = await import('../../../src/main/modules/LogProcessor');
+    const scheduler = new LogProcessorScheduler();
+
+    const failed = scheduler.runTask(async () => {
+      throw new Error('parse failed');
+    });
+    const next = scheduler.runTask(async () => 42);
+
+    await expect(failed).rejects.toThrow('parse failed');
+    await expect(next).resolves.toBe(42);
+  });
+
+  it('marks chat completion as an explicit map end', async () => {
+    mockTryProcess.mockResolvedValue(true);
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+
+    await expect(
+      LogProcessor.processEnd('2026-07-22T10:00:00.000Z', '@To AtlasRunner: end')
+    ).resolves.toBe(true);
+
+    expect(mockTryProcess).toHaveBeenCalledWith({
+      event: {
+        timestamp: '2026-07-22T10:00:00.000Z',
+      },
+      reason: 'explicit-end',
+      source: 'chat',
+    });
+  });
+});

--- a/test/main/modules/MapEnd.spec.ts
+++ b/test/main/modules/MapEnd.spec.ts
@@ -1,0 +1,29 @@
+import { createExplicitMapEndRequest, isMapEndSignal } from '../../../src/main/modules/mapEnd';
+
+describe('map-end signals', () => {
+  it.each([
+    '@To <Mercenaries> AtlasRunner: end',
+    '@From <Mercenaries> AtlasRunner: END',
+    '@To AtlasRunner: end',
+    'AtlasRunner: end',
+  ])('recognizes an explicit end signal for the active character: %s', (content) => {
+    expect(isMapEndSignal(content, 'AtlasRunner')).toBe(true);
+  });
+
+  it.each([
+    '@To <Mercenaries> AnotherRunner: end',
+    '@To <Mercenaries> AtlasRunner: ending',
+    '@To <Mercenaries> AtlasRunner: end now',
+    'The Maven: end',
+  ])('rejects unrelated or inexact chat content: %s', (content) => {
+    expect(isMapEndSignal(content, 'AtlasRunner')).toBe(false);
+  });
+
+  it('creates the same explicit completion contract used by chat and shortcuts', () => {
+    expect(createExplicitMapEndRequest('2026-07-22T10:00:00.000Z', 'shortcut')).toEqual({
+      event: { timestamp: '2026-07-22T10:00:00.000Z' },
+      reason: 'explicit-end',
+      source: 'shortcut',
+    });
+  });
+});

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -6,6 +6,7 @@ import SettingsManager from '../../../src/main/SettingsManager';
 import Utils from '../../../src/main/modules/Utils';
 import { get } from '../../../src/main/db/settings';
 import logger from 'electron-log';
+import RunsDB from '../../../src/main/db/run';
 
 jest.mock('../../../src/main/db', () => ({
   get: jest.fn(),
@@ -13,13 +14,28 @@ jest.mock('../../../src/main/db', () => ({
   transaction: jest.fn(),
   run: jest.fn(),
 }));
+jest.mock('../../../src/main/db/run', () => ({
+  __esModule: true,
+  default: {
+    getLastMapGeneratedEvent: jest.fn(),
+    updateLastEvent: jest.fn(),
+  },
+}));
 jest.mock('../../../src/main/GGGAPI', () => ({
   getDataForInventory: jest
     .fn()
     .mockReturnValue(Promise.resolve({ inventory: [], equipment: [], experience: 0 })),
 }));
 jest.mock('../../../src/main/SettingsManager', () => ({}));
-jest.mock('../../../src/main/modules/Utils', () => ({}));
+jest.mock('../../../src/main/modules/Utils', () => ({
+  __esModule: true,
+  default: {
+    isTown: jest.fn(),
+    isLabArea: jest.fn(),
+    isVaalArea: jest.fn(),
+    isLabTrial: jest.fn(),
+  },
+}));
 jest.mock('../../../src/main/modules/ItemPricer', () => ({
   price: jest.fn().mockReturnValue(Promise.resolve({ value: 0, count: 0, importantDrops: {} })),
 }));
@@ -199,6 +215,87 @@ describe('RunParser', () => {
 
       const parsedItems = await RunParser.parseItems(items);
       expect(parsedItems).toEqual(expectedItems);
+    });
+  });
+
+  describe('tryProcess explicit completion', () => {
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      (RunsDB.getLastMapGeneratedEvent as jest.Mock).mockResolvedValue({
+        event_text: JSON.stringify({ areaName: 'Dunes Map' }),
+      });
+      (RunsDB.updateLastEvent as jest.Mock).mockResolvedValue(undefined);
+      (Utils.isTown as jest.Mock).mockReturnValue(false);
+      (Utils.isLabArea as jest.Mock).mockReturnValue(false);
+      (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
+      (Utils.isLabTrial as jest.Mock).mockReturnValue(false);
+      jest.spyOn(RunParser, 'getLatestUnusedMapEnteredEvents').mockResolvedValue([
+        {
+          timestamp: '2026-07-22T09:00:00.000Z',
+          area: 'Dunes Map',
+          server: '127.0.0.1:6112',
+        },
+      ]);
+      jest.spyOn(RunParser, 'processRun').mockResolvedValue({
+        name: 'Dunes Map',
+        gained: 0,
+        xp: 0,
+        kills: 0,
+        firstEvent: '2026-07-22T09:00:00.000Z',
+        lastEvent: '2026-07-22T10:00:00.000Z',
+      });
+      jest.spyOn(RunParser, 'resetRunData').mockImplementation(() => undefined);
+    });
+
+    it('keeps the same-instance guard for automatic processing', async () => {
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6112',
+          },
+        })
+      ).resolves.toBe(false);
+
+      expect(RunParser.processRun).not.toHaveBeenCalled();
+    });
+
+    it('completes the current run when explicitly requested in the same instance', async () => {
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6112',
+          },
+          reason: 'explicit-end',
+          source: 'shortcut',
+        })
+      ).resolves.toBe(true);
+
+      expect(RunParser.processRun).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z');
+    });
+
+    it('retains special-zone safeguards for explicit completion', async () => {
+      (RunsDB.getLastMapGeneratedEvent as jest.Mock).mockResolvedValue({
+        event_text: JSON.stringify({ areaName: 'Azurite Mine' }),
+      });
+      jest.spyOn(RunParser, 'getLatestUnusedMapEnteredEvents').mockResolvedValue([
+        {
+          timestamp: '2026-07-22T09:00:00.000Z',
+          area: 'Azurite Mine',
+          server: '127.0.0.1:6112',
+        },
+      ]);
+
+      await expect(
+        RunParser.tryProcess({
+          event: { timestamp: '2026-07-22T10:00:00.000Z' },
+          reason: 'explicit-end',
+          source: 'shortcut',
+        })
+      ).resolves.toBe(false);
+
+      expect(RunParser.processRun).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/main/services/RendererAppService.spec.ts
+++ b/test/main/services/RendererAppService.spec.ts
@@ -83,14 +83,14 @@ describe('RendererAppService auth ownership', () => {
     expect(callRendererMethod).not.toHaveBeenCalledWith('logout', expect.anything());
   });
 
-  it('gets characters through the main process GGGAPI instead of the runtime sidecar', async () => {
-    getAllCharacters.mockResolvedValue([{ name: 'Alice', league: 'Settlers' }]);
+  it('gets characters through the runtime sidecar GGG gateway', async () => {
+    callRendererMethod.mockResolvedValue([{ name: 'Alice', league: 'Settlers' }]);
 
     const { RendererAppService } = await import('../../../src/main/services/RendererAppService');
     const result = await RendererAppService.getCharacters();
 
     expect(result).toEqual([{ name: 'Alice', league: 'Settlers' }]);
-    expect(getAllCharacters).toHaveBeenCalledTimes(1);
-    expect(callRendererMethod).not.toHaveBeenCalledWith('getCharacters', expect.anything());
+    expect(getAllCharacters).not.toHaveBeenCalled();
+    expect(callRendererMethod).toHaveBeenCalledWith('getCharacters');
   });
 });

--- a/test/main/shortcuts/GlobalShortcutController.spec.ts
+++ b/test/main/shortcuts/GlobalShortcutController.spec.ts
@@ -1,3 +1,11 @@
+const shortcutLoggerWarn = jest.fn();
+jest.mock('electron-log', () => ({
+  __esModule: true,
+  default: {
+    scope: jest.fn(() => ({ warn: shortcutLoggerWarn })),
+  },
+}));
+
 describe('GlobalShortcutController', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -92,5 +100,28 @@ describe('GlobalShortcutController', () => {
 
     expect(electron.globalShortcut.unregisterAll).toHaveBeenCalledTimes(1);
     expect(electron.globalShortcut.register).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports shortcut registration conflicts', async () => {
+    const electron = await import('electron');
+    (electron.globalShortcut.register as jest.Mock).mockReturnValueOnce(false);
+    const { GlobalShortcutController } = await import(
+      '../../../src/main/shortcuts/GlobalShortcutController'
+    );
+    const controller = new GlobalShortcutController({
+      getShortcut: () => null,
+      isRunParseScreenshotEnabled: () => false,
+      areCustomScreenshotsEnabled: () => false,
+      toggleOverlayPersistence: jest.fn(),
+      toggleOverlayMovement: jest.fn(() => false),
+      triggerRunParse: jest.fn(),
+      triggerScreenshot: jest.fn(),
+    });
+
+    controller.registerAll();
+
+    expect(shortcutLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Unable to register shortcut')
+    );
   });
 });


### PR DESCRIPTION
## What

- make database startup idempotent and initialize settings only after the runtime database is ready
- serialize and coalesce GGG API work during setup and character switching
- establish explicit runtime-sidecar readiness and typed request boundaries
- restore chat and global-shortcut map-end signals through one explicit completion contract
- keep client-log tasks ordered even when an earlier task fails

## Why

Clean installs could race database setup, while setup and character changes could fan out enough GGG API work to make the sidecars and renderer time out. Separately, explicit map-end signals were being subjected to automatic area-transition guards, so both the configured shortcut and chat `end` signal could be ignored.

## Impact

Database ownership and lifecycle are centralized in the runtime sidecar, API refreshes are bounded and stale work is superseded, and callers receive readiness/failure information instead of racing startup. Explicit map completion now bypasses only the guards intended for automatic transitions while retaining special-zone protections.

## Checks

- `npm run test:main` (59 suites, 392 tests)
- `npm test` renderer suite (8 files, 19 tests)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
