### PR TITLE
Fix runtime sidecar Day.js setup

### DIFF
--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -8,6 +8,7 @@ import Constants from '../../helpers/constants';
 import OldDB from '../db';
 import Utils from './Utils';
 import minMax from 'dayjs/plugin/minMax'; // ES 2015
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import EventParser from './EventParser';
 import LogProcessor from './LogProcessor';
 import ItemPricer from './ItemPricer';
@@ -18,6 +19,7 @@ const logger = require('electron-log');
 const EventEmitter = require('events');
 
 dayjs.extend(minMax);
+dayjs.extend(isSameOrAfter);
 
 type ParsedEvent = {
   timestamp: string;

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -218,6 +218,30 @@ describe('RunParser', () => {
     });
   });
 
+  describe('getItemStats', () => {
+    it('compares inventory timestamps without relying on main process dayjs setup', async () => {
+      const itemStats = { count: 2, value: 12.5, importantDrops: {} };
+      jest
+        .spyOn(RunParser, 'getLastInventoryTimestamp')
+        .mockResolvedValue('2026-07-22T10:00:00.000Z');
+      jest.spyOn(RunParser, 'generateItemStats').mockResolvedValue(itemStats);
+
+      await expect(
+        RunParser.getItemStats(
+          { run_id: 123, name: 'Dunes Map' },
+          '2026-07-22T09:00:00.000Z',
+          '2026-07-22T09:59:55.000Z'
+        )
+      ).resolves.toEqual(itemStats);
+
+      expect(RunParser.generateItemStats).toHaveBeenCalledWith(
+        '123',
+        '2026-07-22T09:00:00.000Z',
+        '2026-07-22T09:59:55.000Z'
+      );
+    });
+  });
+
   describe('tryProcess explicit completion', () => {
     beforeEach(() => {
       jest.restoreAllMocks();


### PR DESCRIPTION
## Summary

- register the Day.js `isSameOrAfter` plugin inside `RunParser`
- add regression coverage for the inventory timestamp gate used during map completion
- preserve the existing inventory timestamp and retry behavior

## Root cause

`RunParser` relied on `src/main/index.ts` to register `isSameOrAfter`. Map processing now runs in a separate runtime-sidecar process, so that main-process Day.js configuration was never applied there. Completing a map therefore threw `isSameOrAfter is not a function` before item stats could finish.

## Impact

Map completion in the runtime sidecar can proceed through inventory timestamp validation and finish counting the map.

## Validation

- `npm run test:main -- test/main/modules/RunParser.spec.ts` (16 tests passed)
- full main Jest suite (394 tests passed)
- `npm run typecheck:main`
- `npm run build:app`
- `git diff --check`