### PR TITLE
Fix town map OCR detection

### DIFF
--- a/.workflow/ultracode/town-map-ocr-guard/final-report.md
+++ b/.workflow/ultracode/town-map-ocr-guard/final-report.md
@@ -1,0 +1,38 @@
+# Final report
+
+## Outcome
+
+Complete. Packaged town/hub classification is fixed and OCR/run state handling is safe when no active run exists.
+
+## What changed
+
+- Default-imported and typed world-area data.
+- Added a testable classification predicate using curated hubs and extracted flags.
+- Made map-start detection depend on SQLite row changes.
+- Guarded current-run stat writes when no run exists.
+- Added classification, event-gating, DB, and build-contract regressions.
+
+## Verification
+
+- Focused main tests: pass, 4 suites and 60 tests.
+- Full main tests: pass, 60 suites and 407 tests.
+- Main typecheck: pass.
+- Production build: pass.
+- Built classifier probe: Karui Shores, Rogue Harbour, Kingsmarch, Alpine Hideout, and Aspirants' Plaza true; Dunes false.
+- Diff whitespace check: pass.
+
+## Final audit
+
+All plan deliverables exist. Both delegated read-only packets were integrated. Every required inline eval-contract check passed.
+
+## Skipped checks
+
+Packaged installer smoke and live-game launch were skipped because packaging paths, startup, preload, and windowing were not changed.
+
+## Remaining risks
+
+A no-run OCR completion can still show parsed OCR output even though persistence is skipped. This is a pre-existing UI-message limitation, not a crash or data-corruption path.
+
+## Next useful step
+
+Review the diff, then release through the repository's normal workflow if desired.

--- a/.workflow/ultracode/town-map-ocr-guard/integration.md
+++ b/.workflow/ultracode/town-map-ocr-guard/integration.md
@@ -1,0 +1,34 @@
+# Integration
+
+## Accepted
+
+- Default import for `worldAreas.json`.
+- Curated hub override plus duplicate-safe flag matching.
+- SQLite `changes` as the active-run start signal.
+- Missing-run stat persistence as a logged false/no-op.
+- Focused source tests plus real production bundle execution.
+
+## Rejected
+
+- Expanding the change into the unused `setCurrentAreaInfo` fallback.
+- Refactoring OCR completion messaging or runtime method contracts.
+
+## Conflicts
+
+None.
+
+## Decisions
+
+Parent owned all edits and extracted classification into a TypeScript helper so it can be tested without transforming legacy mixed-module `Utils.js`.
+
+## Final changes
+
+Area classification is stable across source and production bundles; town entries are gated; zero-row starts are false; missing-run stat writes are skipped.
+
+## Verification still needed
+
+None.
+
+## Remaining risks
+
+No live-game session was run. A late/manual OCR with no run still reports OCR output in the UI, but persistence safely no-ops instead of crashing.

--- a/.workflow/ultracode/town-map-ocr-guard/orchestration.md
+++ b/.workflow/ultracode/town-map-ocr-guard/orchestration.md
@@ -1,0 +1,37 @@
+# Orchestration
+
+## Parent critical path
+
+Implement the import/classification correction, truthful run-start result, missing-run persistence guard, tests, and final verification.
+
+## Packets
+
+- `01-test-discovery`: read-only test seam and fixture discovery.
+- `02-risk-review`: read-only independent failure-chain and edge-case review.
+- `03-implementation`: parent-owned source and test edits.
+- `04-integration-verification`: parent-owned integration and checks.
+
+## Delegation
+
+One read-only discovery wave with two agents. No agent owns source edits.
+
+## Agents
+
+- Agent 1: focused test discovery.
+- Agent 2: independent risk review.
+
+## Delegation limits
+
+Two agents, one wave. No write-capable agents.
+
+## Wait points
+
+Agent results are required before finalizing tests, but do not block initial parent implementation.
+
+## Fallback
+
+If an agent fails, the parent completes its packet through direct source inspection.
+
+## Verification order
+
+Targeted tests, main typecheck, production build, bundled behavior probe, diff audit.

--- a/.workflow/ultracode/town-map-ocr-guard/packets/01-test-discovery.md
+++ b/.workflow/ultracode/town-map-ocr-guard/packets/01-test-discovery.md
@@ -1,0 +1,45 @@
+# Packet 01-test-discovery: Focused regression test discovery
+
+## Objective
+
+Identify the narrowest existing test seams for area classification, entered-map emission, zero-row run updates, and missing active runs.
+
+## Context
+
+Karui Shores is false in the packaged classifier because of the JSON namespace shape. The implementation will also harden run-state checks.
+
+## Sources
+
+- `src/helpers/constants.ts`
+- `src/main/modules/Utils.js`
+- `src/main/modules/LogProcessor.ts`
+- `src/main/db/repositories/run.ts`
+- `test/main`
+
+## Ownership
+
+Read-only agent.
+
+## Do
+
+- Inspect relevant existing test setup and mocks.
+- Recommend exact spec files and test cases.
+- Cite paths and nearby lines.
+
+## Do not
+
+- Edit files.
+- Run destructive commands.
+- Duplicate the independent risk review.
+
+## Expected output
+
+Concise test plan with fixtures, mocking requirements, and likely pitfalls.
+
+## Verification
+
+Evidence must come from repository files.
+
+## Handoff format
+
+Summary, evidence, recommended parent action, risks.

--- a/.workflow/ultracode/town-map-ocr-guard/packets/02-risk-review.md
+++ b/.workflow/ultracode/town-map-ocr-guard/packets/02-risk-review.md
@@ -1,0 +1,49 @@
+# Packet 02-risk-review: Independent failure-chain review
+
+## Objective
+
+Independently validate the proposed root cause and identify regression risks within the confirmed failure chain.
+
+## Context
+
+The proposed change uses a default world-area import, combines curated town strings with extracted flags, checks SQLite changes, and skips stat persistence without an active run.
+
+## Sources
+
+- `electron.vite.config.ts`
+- `src/helpers/constants.ts`
+- `src/helpers/data/constants.json`
+- `src/helpers/data/worldAreas.json`
+- `src/main/modules/Utils.js`
+- `src/main/modules/LogProcessor.ts`
+- `src/main/runtime/registerRuntimeListeners.ts`
+- `src/main/db/repositories/run.ts`
+
+## Ownership
+
+Read-only agent.
+
+## Do
+
+- Validate each link in the failure chain.
+- Check duplicate-name and hub semantics.
+- Flag unintended behavior changes.
+- Recommend acceptance criteria.
+
+## Do not
+
+- Edit files.
+- Expand into unrelated runtime or OCR refactors.
+- Duplicate detailed test discovery.
+
+## Expected output
+
+Evidence-backed risk review and recommended safeguards.
+
+## Verification
+
+Use source and current build artifacts only.
+
+## Handoff format
+
+Summary, evidence, risks, recommended parent action.

--- a/.workflow/ultracode/town-map-ocr-guard/plan.md
+++ b/.workflow/ultracode/town-map-ocr-guard/plan.md
@@ -1,0 +1,67 @@
+# Town classification and OCR run guard
+
+## Goal
+
+Prevent town and hub entries from being treated as maps, and make OCR/run updates safe when no active run exists.
+
+## Success criteria
+
+- Packaged code classifies Karui Shores as a town.
+- Curated hubs such as The Rogue Harbour and Kingsmarch remain non-map areas.
+- Town entries do not emit `client-logs:entered-map` or schedule map-entry OCR.
+- A zero-row run start is reported as false.
+- OCR stat persistence does not throw when no incomplete run exists.
+
+## Current context
+
+The v1.11.4 packaged bundle puts the complete `worldAreas.json` object under a namespace default export. `Utils.getArea` scans only namespace values, so Karui Shores is missed. The log processor then emits a map-entry event, and the database layer later destructures a missing active run.
+
+## Constraints
+
+- Preserve normal map tracking and manual OCR behavior.
+- Do not modify generated area data.
+- Do not commit, push, publish, or release.
+- Preserve unrelated user changes.
+
+## Risk level
+
+Medium: the change affects area classification, automatic screenshot gating, and run-state persistence.
+
+## Approval gates
+
+No additional approval is required for scoped source changes and local verification.
+
+## Mode
+
+Delegated workflow mode. Parent owns implementation and integration; side agents provide bounded test discovery and risk review.
+
+## Work packets
+
+- `01-test-discovery`: identify focused test seams and fixtures; read-only agent.
+- `02-risk-review`: independently validate the failure chain and edge cases; read-only agent.
+- `03-implementation`: parent changes classification and database guards and adds tests.
+- `04-integration-verification`: parent integrates findings and runs required checks.
+
+## Eval contract
+
+- Outcome: towns/hubs never start map OCR, and missing-run OCR is a safe no-op.
+- Shared surfaces: `helpers/constants`, `modules/Utils`, `modules/LogProcessor`, `db/repositories/run`.
+- Required checks: targeted unit tests, main typecheck, production build, bundled classification probe.
+- Blocking conditions: normal map entry stops emitting, packaged Karui Shores remains false, or no-run OCR still throws.
+- Handoff evidence: changed-file diff plus command output recorded in the final report.
+
+## Integration policy
+
+The parent reviews all agent findings against source, owns every code edit, and rejects suggestions that expand beyond the confirmed failure chain.
+
+## Verification plan
+
+1. Run focused Utils, LogProcessor, and run-repository tests.
+2. Run `npm run typecheck:main`.
+3. Run `npm run build:app`.
+4. Probe the built Utils chunk for Karui Shores, The Rogue Harbour, Kingsmarch, a hideout, and a normal map.
+5. Inspect the final diff.
+
+## Completion criteria
+
+All required checks pass, workflow artifacts contain evidence, and no unrelated files are modified.

--- a/.workflow/ultracode/town-map-ocr-guard/results/01-test-discovery.md
+++ b/.workflow/ultracode/town-map-ocr-guard/results/01-test-discovery.md
@@ -1,0 +1,44 @@
+# Result 01-test-discovery: Focused regression test discovery
+
+## Summary
+
+The narrow seams are a pure area-classification test, `LogProcessor.processOther` plus its emitter, repository tests using the existing DB mock, and the electron-vite build contract.
+
+## Evidence
+
+- Classification data and predicate: `src/helpers/constants.ts`, `src/main/modules/areaClassification.ts`, and `src/main/modules/Utils.js`.
+- Entry emission gate: `src/main/modules/LogProcessor.ts`.
+- Run update and missing-run seams: `src/main/db/repositories/run.ts` and `src/main/db/index.ts`.
+- Focused tests: `UtilsAreaClassification.spec.ts`, `LogProcessorScheduler.spec.ts`, `run.spec.ts`, and `ElectronViteBuildContract.spec.ts`.
+
+## Handoff
+
+Handoff:
+
+- Summary: Keep all four focused test groups and execute a real production bundle probe.
+- Changed surfaces: None; read-only packet.
+- Contracts satisfied: Test seams cover classification, emission, SQLite changes, and no-run persistence.
+- Assumptions: The production probe is required because source transforms do not reproduce the old Rollup namespace shape.
+- Local checks: Source inspection only.
+- Integration evidence: Parent implemented and ran the recommended checks.
+- Risks: A static import contract alone is syntax-sensitive, so it is paired with bundle execution.
+
+## Files changed
+
+None.
+
+## Decisions
+
+Accepted the recommended focused test seams.
+
+## Risks
+
+`setCurrentAreaInfo` has an unused synthetic run-id fallback, but it is outside this confirmed call chain.
+
+## Verification run
+
+Read-only source inspection.
+
+## Open questions
+
+None blocking.

--- a/.workflow/ultracode/town-map-ocr-guard/results/02-risk-review.md
+++ b/.workflow/ultracode/town-map-ocr-guard/results/02-risk-review.md
@@ -1,0 +1,45 @@
+# Result 02-risk-review: Independent failure-chain review
+
+## Summary
+
+The review independently reproduced the packaged classification failure and validated the planned safeguards.
+
+## Evidence
+
+- The old built artifact classified Karui Shores, The Rogue Harbour, and Kingsmarch as non-towns.
+- Numeric JSON IDs such as `2_11_endgame_town` were reachable only through the namespace default object.
+- Curated town strings are required for intentionally unflagged hubs including Rogue Harbour and Kingsmarch.
+- SQLite `DB.run` returns a result with `changes`, making `changes > 0` the correct run-start signal.
+- OCR persistence reaches `setCurrentRunStats`, where a missing active run previously threw.
+
+## Handoff
+
+Handoff:
+
+- Summary: Use default JSON import, curated strings plus duplicate-safe flag matching, truthful SQLite changes, and a no-run guard.
+- Changed surfaces: None; read-only packet.
+- Contracts satisfied: Root cause and secondary error chain validated.
+- Assumptions: Curated hub names are intentionally non-map areas.
+- Local checks: Existing bundle probe and source inspection.
+- Integration evidence: Parent rebuilt and executed the post-change bundle classifier.
+- Risks: A no-run OCR completion can still display its OCR result even though persistence is skipped; it no longer crashes.
+
+## Files changed
+
+None.
+
+## Decisions
+
+Accepted duplicate-safe `.some()` semantics and added an Aspirants' Plaza fixture.
+
+## Risks
+
+Name-level classification affects duplicate area names, but inspected mixed-flag duplicates are staging/hideout cases where suppression is intended.
+
+## Verification run
+
+Read-only source and current-artifact inspection.
+
+## Open questions
+
+None blocking.

--- a/.workflow/ultracode/town-map-ocr-guard/results/03-implementation.md
+++ b/.workflow/ultracode/town-map-ocr-guard/results/03-implementation.md
@@ -1,0 +1,52 @@
+# Result 03-implementation: Classification and run guards
+
+## Summary
+
+Implemented stable world-area imports, a testable non-map hub predicate, truthful active-run detection, and safe OCR persistence without an active run.
+
+## Evidence
+
+- `worldAreas.json` is a default import with an explicit container type.
+- `isTownArea` combines curated town strings with duplicate-safe area flags.
+- `Utils.isTown` delegates to the tested predicate.
+- `updateCurrentRunFirstEvent` returns true only when SQLite changed a row.
+- `setCurrentRunStats` returns false instead of destructuring a missing run.
+
+## Handoff
+
+Handoff:
+
+- Summary: Confirmed failure chain is corrected and hardened.
+- Changed surfaces: Constants, area classification, Utils, run repository, focused tests.
+- Contracts satisfied: Town suppression, normal map preservation, zero-row false, missing-run no-op.
+- Assumptions: Existing curated `townstrings` remain authoritative overrides.
+- Local checks: Focused tests, typecheck, build, bundle probe, full main suite.
+- Integration evidence: All required checks passed.
+- Risks: OCR UI messaging does not distinguish skipped persistence.
+
+## Files changed
+
+- `src/helpers/constants.ts`
+- `src/main/modules/areaClassification.ts`
+- `src/main/modules/Utils.js`
+- `src/main/db/repositories/run.ts`
+- `test/main/modules/UtilsAreaClassification.spec.ts`
+- `test/main/modules/LogProcessorScheduler.spec.ts`
+- `test/main/db/run.spec.ts`
+- `test/main/runtime/ElectronViteBuildContract.spec.ts`
+
+## Decisions
+
+Extracted the predicate into TypeScript because Jest does not transform the legacy mixed-module `Utils.js` directly.
+
+## Risks
+
+No known blocking risk.
+
+## Verification run
+
+All checks recorded in the final report.
+
+## Open questions
+
+None.

--- a/.workflow/ultracode/town-map-ocr-guard/results/04-integration-verification.md
+++ b/.workflow/ultracode/town-map-ocr-guard/results/04-integration-verification.md
@@ -1,0 +1,46 @@
+# Result 04-integration-verification: Integration and verification
+
+## Summary
+
+Agent findings were integrated, all required checks passed, and the built artifact now exhibits the intended classifications.
+
+## Evidence
+
+- Focused tests: 4 suites, 60 tests passed.
+- Main typecheck: passed.
+- Production build: passed.
+- Built classifier: hubs/hideout/plaza true; Dunes false.
+- Full main suite: 60 suites, 407 tests passed.
+- `git diff --check`: passed.
+
+## Handoff
+
+Handoff:
+
+- Summary: Implementation is ready for review.
+- Changed surfaces: Classification, log-entry test coverage, DB run guards.
+- Contracts satisfied: All inline eval-contract checks.
+- Assumptions: No packaged installer smoke is required because packaging paths were not changed.
+- Local checks: All planned checks plus full main suite.
+- Integration evidence: Production bundle executed directly.
+- Risks: No live Path of Exile session was used.
+
+## Files changed
+
+See result 03.
+
+## Decisions
+
+Did not change the unused `setCurrentAreaInfo` fallback because it is outside the reported OCR path.
+
+## Risks
+
+Manual/live-game confirmation remains useful but is not required to prove this deterministic bundle regression.
+
+## Verification run
+
+Complete.
+
+## Open questions
+
+None.

--- a/.workflow/ultracode/town-map-ocr-guard/state.json
+++ b/.workflow/ultracode/town-map-ocr-guard/state.json
@@ -1,0 +1,97 @@
+{
+  "title": "Town classification and OCR run guard",
+  "slug": "town-map-ocr-guard",
+  "created_at": "2026-07-23T08:07:52.4443852-07:00",
+  "updated_at": "2026-07-23T08:14:42.1422539-07:00",
+  "status": "complete",
+  "mode": "delegated",
+  "baseline_ref": "469035fdea03a30902c968fb557e539f59521c11",
+  "risk_level": "medium",
+  "eval_contract": {
+    "level": "inline",
+    "path": null,
+    "status": "checked"
+  },
+  "approval": {
+    "required": false,
+    "granted": null,
+    "notes": "User explicitly requested implementation."
+  },
+  "delegation": {
+    "native_agent_available": true,
+    "native_agent_planned": true,
+    "native_agent_used": true,
+    "agent_count": 2,
+    "wave_count": 1,
+    "no_delegation_reason": "",
+    "notes": "Two bounded read-only packets."
+  },
+  "packets": [
+    {
+      "id": "01-test-discovery",
+      "status": "complete",
+      "owner": "read-only-agent",
+      "write_scope": [],
+      "result_path": "results/01-test-discovery.md"
+    },
+    {
+      "id": "02-risk-review",
+      "status": "complete",
+      "owner": "read-only-agent",
+      "write_scope": [],
+      "result_path": "results/02-risk-review.md"
+    },
+    {
+      "id": "03-implementation",
+      "status": "complete",
+      "owner": "parent",
+      "write_scope": [
+        "src/helpers/constants.ts",
+        "src/main/modules/Utils.js",
+        "src/main/db/repositories/run.ts",
+        "test/main"
+      ],
+      "result_path": "results/03-implementation.md"
+    },
+    {
+      "id": "04-integration-verification",
+      "status": "complete",
+      "owner": "parent",
+      "write_scope": [],
+      "result_path": "results/04-integration-verification.md"
+    }
+  ],
+  "verification": {
+    "status": "complete",
+    "checks": [
+      {
+        "name": "targeted tests",
+        "command": "npm run test:main -- --runTestsByPath test/main/modules/UtilsAreaClassification.spec.ts test/main/modules/LogProcessorScheduler.spec.ts test/main/db/run.spec.ts test/main/runtime/ElectronViteBuildContract.spec.ts",
+        "required": true,
+        "status": "pass",
+        "evidence": "4 suites passed; 60 tests passed."
+      },
+      {
+        "name": "main typecheck",
+        "command": "npm run typecheck:main",
+        "required": true,
+        "status": "pass",
+        "evidence": "TypeScript completed with no errors."
+      },
+      {
+        "name": "production build",
+        "command": "npm run build:app",
+        "required": true,
+        "status": "pass",
+        "evidence": "electron-vite main, preload, renderer, and asset sync completed."
+      },
+      {
+        "name": "bundled classification probe",
+        "command": "node -e <built Utils classification assertions>",
+        "required": true,
+        "status": "pass",
+        "evidence": "Karui/Rogue/Kingsmarch/hideout/plaza=true and Dunes=false."
+      }
+    ]
+  }
+}

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -5,12 +5,22 @@ import * as mapMods from './data/mapMods.json';
 import * as uniqueIcons from './data/uniqueIcons.json';
 import * as uniques from './data/uniques.json';
 import * as items from './data/items.json';
-import * as worldAreas from './data/worldAreas.json';
+import worldAreas from './data/worldAreas.json';
 import * as events from './data/events.json';
 import areas from './data/areas.json';
 
 type ConstantContainer = {
   mapMods: string[];
+  townstrings: string[];
+  worldAreas: Record<
+    string,
+    {
+      name: string;
+      isTown: boolean;
+      isHideout: boolean;
+      isLabyrinthAirlock: boolean;
+    }
+  >;
   areas: {
     [key: string]: string[];
   };

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -116,11 +116,15 @@ const Runs = {
     }
   },
 
-  getLatestUncompletedRun: async (): Promise<{
-    id: number;
-    first_event: string;
-    last_event: string;
-  }> => {
+  getLatestUncompletedRun: async (): Promise<
+    | {
+        id: number;
+        first_event: string;
+        last_event: string;
+      }
+    | null
+    | undefined
+  > => {
     logger.info('Getting run ID from DB');
     const query = `
       SELECT id, first_event, last_event FROM run
@@ -496,7 +500,13 @@ const Runs = {
     iiq: number;
     pack_size: number;
   }) => {
-    const { id: runId } = await Runs.getLatestUncompletedRun();
+    const currentRun = await Runs.getLatestUncompletedRun();
+    if (!currentRun) {
+      logger.warn('Skipping current run stats update because there is no active run');
+      return false;
+    }
+
+    const { id: runId } = currentRun;
     logger.info(
       `Setting current run stats for ${runId}: IIR: ${iir}, IIQ: ${iiq}, Pack Size: ${pack_size}`
     );
@@ -572,8 +582,8 @@ const Runs = {
       AND completed = 0
     `;
     try {
-      await DB.run(query);
-      return true;
+      const result = await DB.run(query);
+      return (result?.changes ?? 0) > 0;
     } catch (err) {
       logger.error(err);
       logger.error(`Error updating current run first event: ${JSON.stringify(err)}`);

--- a/src/main/modules/Utils.js
+++ b/src/main/modules/Utils.js
@@ -3,6 +3,7 @@ const Query = require('querystring');
 const Constants = require('../../helpers/constants').default;
 const ItemCategoryParser = require('../../helpers/item').default;
 const ItemData = require('./ItemData');
+const { isTownArea } = require('./areaClassification');
 const logger = require('electron-log');
 const dayjs = require('dayjs');
 const zlib = require('zlib');
@@ -22,12 +23,7 @@ const Utils = {
   },
 
   isTown: (name) => {
-    const area = Utils.getArea(name);
-    if (area) {
-      return area.isTown || area.isHideout || area.isLabyrinthAirlock;
-    }
-
-    return false;
+    return isTownArea(name);
   },
 
   isVaalArea: (name) => {

--- a/src/main/modules/areaClassification.ts
+++ b/src/main/modules/areaClassification.ts
@@ -1,0 +1,11 @@
+import Constants from '../../helpers/constants';
+
+export function isTownArea(name: string): boolean {
+  if (Constants.townstrings.includes(name)) {
+    return true;
+  }
+
+  return Object.values(Constants.worldAreas).some(
+    (area) => area.name === name && (area.isTown || area.isHideout || area.isLabyrinthAirlock)
+  );
+}

--- a/test/main/db/run.spec.ts
+++ b/test/main/db/run.spec.ts
@@ -42,13 +42,12 @@ describe('Runs', () => {
       expect(result).toBe(mockResult);
     });
 
-    it('should return 0 when no runs exist', async () => {
-      const emptyResult = { id: 0, first_event: null, last_event: null };
-      mockDB.get.mockResolvedValue(emptyResult);
+    it('should return undefined when no runs exist', async () => {
+      mockDB.get.mockResolvedValue(undefined);
 
       const result = await Runs.getLatestUncompletedRun();
 
-      expect(result).toEqual(emptyResult);
+      expect(result).toBeUndefined();
     });
 
     it('should handle database query failure', async () => {
@@ -617,6 +616,49 @@ describe('Runs', () => {
       expect(expectedQuery).toContain('event_text');
       expect(expectedQuery).toContain('timestamp');
       expect(expectedQuery).toContain('server');
+    });
+  });
+
+  describe('updateCurrentRunFirstEvent', () => {
+    it('returns true when an active run was updated', async () => {
+      mockDB.run.mockResolvedValue({ changes: 1, lastInsertRowid: 0 });
+
+      await expect(Runs.updateCurrentRunFirstEvent()).resolves.toBe(true);
+    });
+
+    it('returns false when no active run was updated', async () => {
+      mockDB.run.mockResolvedValue({ changes: 0, lastInsertRowid: 0 });
+
+      await expect(Runs.updateCurrentRunFirstEvent()).resolves.toBe(false);
+    });
+  });
+
+  describe('setCurrentRunStats', () => {
+    it('skips the update when there is no active run', async () => {
+      jest.spyOn(Runs, 'getLatestUncompletedRun').mockResolvedValue(undefined);
+      mockDB.run.mockClear();
+
+      await expect(Runs.setCurrentRunStats({ iir: 10, iiq: 20, pack_size: 30 })).resolves.toBe(
+        false
+      );
+
+      expect(mockDB.run).not.toHaveBeenCalled();
+    });
+
+    it('updates the active run when one exists', async () => {
+      jest
+        .spyOn(Runs, 'getLatestUncompletedRun')
+        .mockResolvedValue({ id: 42, first_event: 'first', last_event: 'last' });
+      mockDB.run.mockResolvedValue({ changes: 1, lastInsertRowid: 0 });
+
+      await expect(Runs.setCurrentRunStats({ iir: 10, iiq: 20, pack_size: 30 })).resolves.toBe(
+        true
+      );
+
+      expect(mockDB.run).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE run SET'),
+        [10, 20, 30, 42]
+      );
     });
   });
 });

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -1,5 +1,11 @@
 let uuidCounter = 0;
 const mockTryProcess = jest.fn();
+const mockInsertEvent = jest.fn();
+const mockSaveNewTree = jest.fn();
+const mockGetInventoryDiffs = jest.fn();
+const mockInsertItems = jest.fn();
+const mockGetEventByQuote = jest.fn();
+const mockIsTown = jest.fn();
 jest.mock('uuid', () => ({
   v4: jest.fn(() => `log-task-${++uuidCounter}`),
 }));
@@ -10,37 +16,52 @@ jest.mock('../../../src/main/modules/RunParser', () => ({
 }));
 jest.mock('../../../src/main/db/run', () => ({
   __esModule: true,
-  default: {},
+  default: { insertEvent: mockInsertEvent },
 }));
 jest.mock('../../../src/main/SettingsManager', () => ({
   __esModule: true,
-  default: {},
+  default: {
+    getAll: jest.fn(() => ({
+      activeProfile: { characterName: 'AtlasRunner' },
+    })),
+  },
 }));
 jest.mock('../../../src/main/modules/SkillTreeWatcher', () => ({
   __esModule: true,
-  default: {},
+  default: { saveNewTree: mockSaveNewTree },
 }));
 jest.mock('../../../src/main/modules/InventoryGetter', () => ({
   __esModule: true,
-  default: {},
+  default: { getInventoryDiffs: mockGetInventoryDiffs },
 }));
 jest.mock('../../../src/main/modules/ItemParser', () => ({
   __esModule: true,
-  default: {},
+  default: { insertItems: mockInsertItems },
 }));
 jest.mock('../../../src/main/modules/EventParser', () => ({
   __esModule: true,
-  default: {},
+  default: { getEventByQuote: mockGetEventByQuote },
 }));
 jest.mock('../../../src/main/modules/Utils', () => ({
   __esModule: true,
-  default: {},
+  default: { isTown: mockIsTown },
 }));
 
 describe('LogProcessorScheduler', () => {
   beforeEach(() => {
     uuidCounter = 0;
     mockTryProcess.mockReset();
+    mockInsertEvent.mockReset().mockResolvedValue(true);
+    mockSaveNewTree.mockReset().mockResolvedValue(undefined);
+    mockGetInventoryDiffs.mockReset().mockResolvedValue(null);
+    mockInsertItems.mockReset().mockResolvedValue(undefined);
+    mockGetEventByQuote.mockReset().mockReturnValue(undefined);
+    mockIsTown.mockReset();
+  });
+
+  afterEach(async () => {
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+    LogProcessor.emitter.removeAllListeners('client-logs:entered-map');
   });
 
   it('keeps asynchronous client-log work in submission order', async () => {
@@ -95,6 +116,37 @@ describe('LogProcessorScheduler', () => {
       },
       reason: 'explicit-end',
       source: 'chat',
+    });
+  });
+
+  it('does not emit a map entry for a town', async () => {
+    mockIsTown.mockReturnValue(true);
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+    const enteredMap = jest.fn();
+    LogProcessor.emitter.on('client-logs:entered-map', enteredMap);
+
+    await LogProcessor.processOther('2026-07-23T11:04:10.000Z', ': You have entered Karui Shores.');
+
+    expect(mockIsTown).toHaveBeenCalledWith('Karui Shores');
+    expect(enteredMap).not.toHaveBeenCalled();
+  });
+
+  it('emits a map entry for a non-town area', async () => {
+    mockIsTown.mockReturnValue(false);
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+    const enteredMap = jest.fn();
+    LogProcessor.emitter.on('client-logs:entered-map', enteredMap);
+
+    await LogProcessor.processOther('2026-07-23T11:04:10.000Z', ': You have entered Dunes.');
+
+    expect(enteredMap).toHaveBeenCalledWith({
+      area: 'Dunes',
+      event: {
+        timestamp: '2026-07-23T11:04:10.000Z',
+        area: 'Dunes',
+        server: '',
+      },
+      mode: 'automatic',
     });
   });
 });

--- a/test/main/modules/UtilsAreaClassification.spec.ts
+++ b/test/main/modules/UtilsAreaClassification.spec.ts
@@ -1,0 +1,22 @@
+import { isTownArea } from '../../../src/main/modules/areaClassification';
+
+describe('Utils area classification', () => {
+  it.each(['Karui Shores', 'The Rogue Harbour', 'Kingsmarch'])(
+    'treats the non-map hub %s as a town',
+    (area) => {
+      expect(isTownArea(area)).toBe(true);
+    }
+  );
+
+  it('treats hideouts as towns for map tracking', () => {
+    expect(isTownArea('Alpine Hideout')).toBe(true);
+  });
+
+  it('treats labyrinth staging areas as towns for map tracking', () => {
+    expect(isTownArea("Aspirants' Plaza")).toBe(true);
+  });
+
+  it('does not classify a map area as a town', () => {
+    expect(isTownArea('Dunes')).toBe(false);
+  });
+});

--- a/test/main/runtime/ElectronViteBuildContract.spec.ts
+++ b/test/main/runtime/ElectronViteBuildContract.spec.ts
@@ -72,6 +72,16 @@ describe('electron-vite build contract', () => {
     expect(sidecarBridge).not.toContain("require('./RuntimeSidecarClient')");
   });
 
+  it('imports world-area JSON as its default object for production bundling', () => {
+    const constantsSource = fs.readFileSync(
+      path.join(rootDir, 'src', 'helpers', 'constants.ts'),
+      'utf8'
+    );
+
+    expect(constantsSource).toContain("import worldAreas from './data/worldAreas.json';");
+    expect(constantsSource).not.toContain("import * as worldAreas from './data/worldAreas.json';");
+  });
+
   it('keeps copied runtime assets in their expected post-build locations', () => {
     const syncScript = fs.readFileSync(
       path.join(rootDir, 'scripts', 'sync-electron-assets.mjs'),


### PR DESCRIPTION
## Summary

- classify towns, hideouts, labyrinth staging areas, and curated hubs consistently in production bundles
- prevent town entries from emitting map-entry OCR events
- only treat a run as started when SQLite updates a row
- skip OCR stat persistence safely when no active run exists

## Root cause

The production Rollup bundle wrapped `worldAreas.json` as a module namespace. Area IDs that could not become named exports, including the Karui Shores ID, were only available beneath the namespace default object. `Utils.isTown()` scanned the wrong level and treated Karui Shores as a map. The resulting automatic OCR later attempted to persist stats without an active run.

## Impact

Town and hub transitions no longer start map OCR, while normal map entry tracking remains unchanged. Missing-run OCR persistence is now a safe no-op instead of throwing.

## Validation

- `npm run test:main` — 60 suites, 407 tests passed
- `npm run typecheck:main`
- `npm run build:app`
- production-bundle classification probe for Karui Shores, Rogue Harbour, Kingsmarch, Alpine Hideout, Aspirants' Plaza, and Dunes
- focused regression suite — 4 suites, 60 tests passed