### PR TITLE
Fix map-end accounting and stash tab loading

### DIFF
--- a/src/main/GGGAPI.ts
+++ b/src/main/GGGAPI.ts
@@ -350,7 +350,8 @@ const getAllStashTabs = async () => {
     const { username, league, token } = await getSettings();
     const response: any = await request({
       params: getRequestParams(Endpoints.stashes({ league }), token),
-      group: `getAllStashTabs-${username}`,
+      group: `getAllStashTabs-${username}-${league}`,
+      limiterId: `getAllStashTabs-${username}`,
     });
     const stashes = await response.data.stashes;
     logger.info(`Found ${response.data.stashes.length} stashes for account: ${username}`);

--- a/src/main/GGGAPI.ts
+++ b/src/main/GGGAPI.ts
@@ -210,6 +210,9 @@ const request = async ({
       const response: any = await axios({ ...params, id: group });
 
       updateLimiterFromHeaders(limiter, response.headers);
+      if (fresh) {
+        await storage.remove(group);
+      }
       logger.debug('Request successfully completed for', { url: params.url, group });
       return response;
     });

--- a/src/main/GGGAPI.ts
+++ b/src/main/GGGAPI.ts
@@ -30,6 +30,11 @@ type Inventory = {
   experience: number;
 };
 
+type InventoryRequestOptions = {
+  fresh?: boolean;
+  throwOnError?: boolean;
+};
+
 const limiters = new Bottleneck.Group({
   maxConcurrent: 1,
   minTime: MIN_TIME_BETWEEN_REQUESTS,
@@ -161,8 +166,14 @@ const getRequestParams = (url, token) => {
   };
 };
 
-const request = async ({ params, group, cacheTime = CACHE_TIME_IN_SECONDS, limiterId = group }) => {
-  const requestKey = `${limiterId}:${group}:${params.url}`;
+const request = async ({
+  params,
+  group,
+  cacheTime = CACHE_TIME_IN_SECONDS,
+  limiterId = group,
+  fresh = false,
+}) => {
+  const requestKey = `${limiterId}:${group}:${params.url}:${fresh ? 'fresh' : 'cached'}`;
   const existingRequest = inFlightRequests.get(requestKey);
   if (existingRequest) {
     logger.debug(`Coalescing in-flight GGG request for ${params.url}`);
@@ -175,6 +186,9 @@ const request = async ({ params, group, cacheTime = CACHE_TIME_IN_SECONDS, limit
     const scheduledId = `${group.replace('/', '')}-${uuidv4()}`;
 
     if (currentlyRestrictedKeys && currentlyRestrictedKeys[group]) {
+      if (fresh) {
+        throw new Error('API Restricted; a fresh response is required.');
+      }
       const cached = await storage.get(group);
       if (cached && cached.data) {
         logger.warn('API Restricted: Serving stale data from cache.');
@@ -185,7 +199,9 @@ const request = async ({ params, group, cacheTime = CACHE_TIME_IN_SECONDS, limit
 
     return limiter.schedule({ id: scheduledId }, async () => {
       logger.debug('Making request to GGG API', { url: params.url, group, params });
-      if (!params.cache) {
+      if (fresh) {
+        params.cache = { enabled: false };
+      } else if (!params.cache) {
         params.cache = {
           enabled: true,
           ttl: 1000 * cacheTime,
@@ -209,11 +225,17 @@ const request = async ({ params, group, cacheTime = CACHE_TIME_IN_SECONDS, limit
   }
 };
 
-const getCharacterSnapshot = async (username: string, characterName: string, token: string) => {
+const getCharacterSnapshot = async (
+  username: string,
+  characterName: string,
+  token: string,
+  fresh = false
+) => {
   const response: any = await request({
     params: getRequestParams(Endpoints.character({ characterName }), token),
     group: `getCharacter-${username}-${characterName}`,
     cacheTime: CHARACTER_SNAPSHOT_CACHE_TIME_IN_SECONDS,
+    fresh,
   });
   return response.data.character;
 };
@@ -253,13 +275,20 @@ const getAllCharacters = async () => {
   }
 };
 
-const getDataForInventory = async (): Promise<Inventory> => {
+const getDataForInventory = async (
+  options: InventoryRequestOptions = {}
+): Promise<Inventory> => {
   logger.info('Getting inventory and XP data from the GGG API');
   try {
     await authSessionReadiness.waitForProfileAccess();
     const { username, characterName, token } = await getSettings();
     if (!characterName) throw new Error('Missing Active Profile');
-    const character = await getCharacterSnapshot(username, characterName, token);
+    const character = await getCharacterSnapshot(
+      username,
+      characterName,
+      token,
+      options.fresh
+    );
     const { inventory: mainInventory, equipment, experience } = character;
     const rucksack = character.rucksack ?? [];
     const inventory = [...mainInventory, ...rucksack];
@@ -271,6 +300,7 @@ const getDataForInventory = async (): Promise<Inventory> => {
     };
   } catch (e: any) {
     logger.error(`Error while getting inventory from the GGG API: ${e.message}`);
+    if (options.throwOnError) throw e;
     return { inventory: [], equipment: [], experience: 0 };
   }
 };
@@ -343,8 +373,10 @@ const APIManager = {
     const characters = await getAllCharacters();
     return characters ?? [];
   },
-  getDataForInventory: async (): Promise<Inventory> => {
-    const inventory = await getDataForInventory();
+  getDataForInventory: async (
+    options: InventoryRequestOptions = {}
+  ): Promise<Inventory> => {
+    const inventory = await getDataForInventory(options);
     return inventory;
   },
   getSkillTree: async () => {

--- a/src/main/GGGAPI.ts
+++ b/src/main/GGGAPI.ts
@@ -354,7 +354,7 @@ const getAllStashTabs = async () => {
     return stashes;
   } catch (e: any) {
     logger.error(`Error while getting stashes from the GGG API: ${e.message}`);
-    return [];
+    throw e;
   }
 };
 

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -571,9 +571,20 @@ const Migrations = {
         `pragma user_version = 17`,
       ],
       [`ALTER TABLE item ADD COLUMN valuation TEXT`, `pragma user_version = 18`],
+      [
+        `CREATE TABLE IF NOT EXISTS deferred_run (
+          run_id INTEGER PRIMARY KEY NOT NULL,
+          last_event TEXT NOT NULL
+        )`,
+        `pragma user_version = 19`,
+      ],
     ],
     maintenance: [
       `delete from incubator where timestamp < (select min(timestamp) from (select timestamp from incubator order by timestamp desc limit 25))`,
+      `CREATE TABLE IF NOT EXISTS deferred_run (
+        run_id INTEGER PRIMARY KEY NOT NULL,
+        last_event TEXT NOT NULL
+      )`,
     ],
   },
   league: {
@@ -873,6 +884,7 @@ const RequiredCharacterTables = [
   'passives',
   'xp',
   'graftblood',
+  'deferred_run',
 ];
 
 const RequiredLeagueTables = ['characters', 'fullrates', 'stashes'];

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -981,6 +981,27 @@ const DB = {
     return DB.runMany(query, params, league);
   },
 
+  transactionSteps: async (
+    steps: Array<{ query: string; params?: any[] }>,
+    league: string | undefined = undefined
+  ) => {
+    const manager = DB.getManager(league);
+    if (!manager) return null;
+
+    return manager.runTask(() => {
+      const transaction = manager.db.transaction(
+        (transactionSteps: Array<{ query: string; params?: any[] }>) => {
+          let result;
+          for (const step of transactionSteps) {
+            result = manager.getStatement(step.query).run(step.params ?? []);
+          }
+          return result;
+        }
+      );
+      return transaction(steps);
+    });
+  },
+
   initDB: async (char: string, league?: string) => {
     const manager = DB.getCharacterManager(char, league);
     if (!manager) return null;

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -588,7 +588,9 @@ const Migrations = {
       `delete from incubator where timestamp < (select min(timestamp) from (select timestamp from incubator order by timestamp desc limit 25))`,
       `CREATE TABLE IF NOT EXISTS deferred_run (
         run_id INTEGER PRIMARY KEY NOT NULL,
-        last_event TEXT NOT NULL
+        last_event TEXT NOT NULL,
+        capture_required INTEGER NOT NULL DEFAULT 0,
+        closing_event_id INTEGER
       )`,
     ],
   },

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -578,6 +578,11 @@ const Migrations = {
         )`,
         `pragma user_version = 19`,
       ],
+      [
+        `ALTER TABLE deferred_run ADD COLUMN capture_required INTEGER NOT NULL DEFAULT 0`,
+        `ALTER TABLE deferred_run ADD COLUMN closing_event_id INTEGER`,
+        `pragma user_version = 20`,
+      ],
     ],
     maintenance: [
       `delete from incubator where timestamp < (select min(timestamp) from (select timestamp from incubator order by timestamp desc limit 25))`,

--- a/src/main/db/repositories/items.ts
+++ b/src/main/db/repositories/items.ts
@@ -4,15 +4,19 @@ import Logger from 'electron-log';
 const logger = Logger.scope('db/items');
 
 const Items = {
-  insertItems: (items: any[]) => {
+  insertItems: (items: any[], eventId?: number) => {
     logger.debug(`Inserting ${items.length} items`);
     logger.debug(items);
+    const params =
+      eventId === undefined
+        ? items
+        : items.map(([itemId, _eventTimestamp, ...rest]) => [itemId, eventId, ...rest]);
     const query = `
       INSERT INTO item
       (item_id, event_id, icon, name, rarity, category, identified, typeline, sockets, stack_size, raw_data, value, original_value, valuation)
-      values(?, (SELECT id FROM event WHERE event.timestamp = ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      values(?, ${eventId === undefined ? '(SELECT id FROM event WHERE event.timestamp = ?)' : '?'}, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `;
-    return DB.transaction(query, items);
+    return DB.transaction(query, params);
   },
   getMatchingItemsCount: async (itemIds: string[]): Promise<number> => {
     if (itemIds.length === 0) {

--- a/src/main/db/repositories/items.ts
+++ b/src/main/db/repositories/items.ts
@@ -5,8 +5,8 @@ const logger = Logger.scope('db/items');
 
 const directEventItemInsertQuery = `
       INSERT INTO item
-      (item_id, event_id, icon, name, rarity, category, identified, typeline, sockets, stack_size, raw_data, value, original_value, valuation)
-      values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (item_id, event_id, icon, name, rarity, category, identified, typeline, sockets, stack_size, raw_data, value, original_value, valuation, ignored)
+      values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `;
 
 const Items = {
@@ -29,11 +29,13 @@ const Items = {
     items: any[],
     eventId: number,
     inventoryTimestamp: string,
-    inventory: Record<string, any>
+    inventory: Record<string, any>,
+    ignoredItems: { id: string; status: boolean }[]
   ) => {
+    const ignoredByItemId = new Map(ignoredItems.map(({ id, status }) => [id, status]));
     const itemSteps = items.map(([itemId, _eventTimestamp, ...rest]) => ({
       query: directEventItemInsertQuery,
-      params: [itemId, eventId, ...rest],
+      params: [itemId, eventId, ...rest, ignoredByItemId.get(itemId) ? 1 : 0],
     }));
     return DB.transactionSteps([
       ...itemSteps,

--- a/src/main/db/repositories/items.ts
+++ b/src/main/db/repositories/items.ts
@@ -3,6 +3,12 @@ import Logger from 'electron-log';
 
 const logger = Logger.scope('db/items');
 
+const directEventItemInsertQuery = `
+      INSERT INTO item
+      (item_id, event_id, icon, name, rarity, category, identified, typeline, sockets, stack_size, raw_data, value, original_value, valuation)
+      values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `;
+
 const Items = {
   insertItems: (items: any[], eventId?: number) => {
     logger.debug(`Inserting ${items.length} items`);
@@ -17,6 +23,25 @@ const Items = {
       values(?, ${eventId === undefined ? '(SELECT id FROM event WHERE event.timestamp = ?)' : '?'}, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `;
     return DB.transaction(query, params);
+  },
+
+  insertItemsAndInventory: (
+    items: any[],
+    eventId: number,
+    inventoryTimestamp: string,
+    inventory: Record<string, any>
+  ) => {
+    const itemSteps = items.map(([itemId, _eventTimestamp, ...rest]) => ({
+      query: directEventItemInsertQuery,
+      params: [itemId, eventId, ...rest],
+    }));
+    return DB.transactionSteps([
+      ...itemSteps,
+      {
+        query: 'INSERT INTO last_inventory(timestamp, inventory) VALUES(?, ?)',
+        params: [inventoryTimestamp, JSON.stringify(inventory)],
+      },
+    ]);
   },
   getMatchingItemsCount: async (itemIds: string[]): Promise<number> => {
     if (itemIds.length === 0) {

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -136,6 +136,25 @@ const Runs = {
     return result;
   },
 
+  getOldestDeferredRun: async (): Promise<
+    | {
+        id: number;
+        first_event: string;
+        last_event: string;
+      }
+    | null
+    | undefined
+  > => {
+    const query = `
+      SELECT id, first_event, last_event FROM run
+      WHERE completed = 0
+        AND id < (SELECT MAX(id) FROM run WHERE completed = 0)
+      ORDER BY id ASC
+      LIMIT 1;
+    `;
+    return DB.get(query);
+  },
+
   getCurrentAreaData: async (): Promise<AreaInfo | null> => {
     logger.info('Getting current area data from DB');
     const query = `

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -628,19 +628,18 @@ const Runs = {
     const query = `
       UPDATE run
       SET first_event = (
-        SELECT timestamp FROM event, run
+        SELECT timestamp FROM event
         WHERE timestamp >= run.first_event
         AND event_type = 'entered'
+        ORDER BY timestamp
         LIMIT 1
       )
-      WHERE 
-      (
-        SELECT COUNT(*)
-          FROM event, run
-          WHERE event_type = 'entered'
-          AND timestamp >= run.first_event
-      ) = 1
-      AND completed = 0
+      WHERE id = (SELECT MAX(id) FROM run WHERE completed = 0)
+      AND EXISTS (
+        SELECT 1 FROM event
+        WHERE event_type = 'entered'
+        AND timestamp >= run.first_event
+      )
     `;
     try {
       const result = await DB.run(query);

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -136,7 +136,7 @@ const Runs = {
     return result;
   },
 
-  getOldestDeferredRun: async (): Promise<
+  getDeferredRun: async (): Promise<
     | {
         id: number;
         first_event: string;
@@ -146,13 +146,26 @@ const Runs = {
     | undefined
   > => {
     const query = `
-      SELECT id, first_event, last_event FROM run
-      WHERE completed = 0
-        AND id < (SELECT MAX(id) FROM run WHERE completed = 0)
-      ORDER BY id ASC
+      SELECT run.id, run.first_event, deferred_run.last_event
+      FROM deferred_run
+      JOIN run ON run.id = deferred_run.run_id
+      WHERE run.completed = 0
+      ORDER BY run.id ASC
       LIMIT 1;
     `;
     return DB.get(query);
+  },
+
+  markRunDeferred: async (runId: number, lastEventTimestamp: string) => {
+    return DB.run(
+      `INSERT INTO deferred_run(run_id, last_event) VALUES(?, ?)
+       ON CONFLICT(run_id) DO UPDATE SET last_event = excluded.last_event`,
+      [runId, lastEventTimestamp]
+    );
+  },
+
+  clearDeferredRun: async (runId: number) => {
+    return DB.run('DELETE FROM deferred_run WHERE run_id = ?', [runId]);
   },
 
   getCurrentAreaData: async (): Promise<AreaInfo | null> => {

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -183,6 +183,15 @@ const Runs = {
     return DB.run('DELETE FROM deferred_run WHERE run_id = ?', [runId]);
   },
 
+  completeDeferredCapture: async (runId: number, closingEventId: number) => {
+    return DB.run(
+      `UPDATE deferred_run
+       SET capture_required = 0, closing_event_id = ?
+       WHERE run_id = ?`,
+      [closingEventId, runId]
+    );
+  },
+
   getCurrentAreaData: async (): Promise<AreaInfo | null> => {
     logger.info('Getting current area data from DB');
     const query = `

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -141,12 +141,15 @@ const Runs = {
         id: number;
         first_event: string;
         last_event: string;
+        capture_required: number;
+        closing_event_id: number | null;
       }
     | null
     | undefined
   > => {
     const query = `
-      SELECT run.id, run.first_event, deferred_run.last_event
+      SELECT run.id, run.first_event, deferred_run.last_event,
+        deferred_run.capture_required, deferred_run.closing_event_id
       FROM deferred_run
       JOIN run ON run.id = deferred_run.run_id
       WHERE run.completed = 0
@@ -156,11 +159,20 @@ const Runs = {
     return DB.get(query);
   },
 
-  markRunDeferred: async (runId: number, lastEventTimestamp: string) => {
+  markRunDeferred: async (
+    runId: number,
+    lastEventTimestamp: string,
+    captureRequired = false,
+    closingEventId: number | null = null
+  ) => {
     return DB.run(
-      `INSERT INTO deferred_run(run_id, last_event) VALUES(?, ?)
-       ON CONFLICT(run_id) DO UPDATE SET last_event = excluded.last_event`,
-      [runId, lastEventTimestamp]
+      `INSERT INTO deferred_run(run_id, last_event, capture_required, closing_event_id)
+       VALUES(?, ?, ?, ?)
+       ON CONFLICT(run_id) DO UPDATE SET
+         last_event = excluded.last_event,
+         capture_required = excluded.capture_required,
+         closing_event_id = excluded.closing_event_id`,
+      [runId, lastEventTimestamp, captureRequired ? 1 : 0, closingEventId]
     );
   },
 

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -169,9 +169,12 @@ const Runs = {
       `INSERT INTO deferred_run(run_id, last_event, capture_required, closing_event_id)
        VALUES(?, ?, ?, ?)
        ON CONFLICT(run_id) DO UPDATE SET
-         last_event = excluded.last_event,
-         capture_required = excluded.capture_required,
-         closing_event_id = excluded.closing_event_id`,
+         last_event = CASE
+           WHEN deferred_run.capture_required = 1 THEN deferred_run.last_event
+           ELSE excluded.last_event
+         END,
+         capture_required = MAX(deferred_run.capture_required, excluded.capture_required),
+         closing_event_id = COALESCE(deferred_run.closing_event_id, excluded.closing_event_id)`,
       [runId, lastEventTimestamp, captureRequired ? 1 : 0, closingEventId]
     );
   },

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -438,8 +438,13 @@ const Runs = {
       VALUES(?, ?, ?, ?)
     `;
     try {
-      await DB.run(query, [event.event_type, event.event_text, event.timestamp, event.server]);
-      return true;
+      const result = await DB.run(query, [
+        event.event_type,
+        event.event_text,
+        event.timestamp,
+        event.server,
+      ]);
+      return Number(result.lastInsertRowid);
     } catch (err) {
       logger.error(`Error inserting event: ${JSON.stringify(err)}`);
       return false;

--- a/src/main/modules/InventoryGetter.ts
+++ b/src/main/modules/InventoryGetter.ts
@@ -35,12 +35,17 @@ class InventoryGetter extends EventEmitter {
     timestamp: string,
     persistDiff: (diff: Record<string, any>) => Promise<void>
   ) {
-    const previousInventory = await this.getPreviousInventory();
-    const currentInventory = await this.getCurrentInventory(timestamp);
-    const diff = this.compareInventories(previousInventory, currentInventory);
+    const { diff, currentInventory } = await this.getInventoryCapture(timestamp);
     await persistDiff(diff);
     await this.updateLastInventory(currentInventory);
     return diff;
+  }
+
+  async getInventoryCapture(timestamp: string) {
+    const previousInventory = await this.getPreviousInventory();
+    const currentInventory = await this.getCurrentInventory(timestamp);
+    const diff = this.compareInventories(previousInventory, currentInventory);
+    return { diff, currentInventory };
   }
 
   async getInventoryDiffs(timestamp: string) {

--- a/src/main/modules/InventoryGetter.ts
+++ b/src/main/modules/InventoryGetter.ts
@@ -31,10 +31,20 @@ class InventoryGetter extends EventEmitter {
     logger.info('Inventory getter started');
   }
 
-  async getInventoryDiffs(timestamp: string) {
+  async captureInventoryDiff(
+    timestamp: string,
+    persistDiff: (diff: Record<string, any>) => Promise<void>
+  ) {
     const previousInventory = await this.getPreviousInventory();
     const currentInventory = await this.getCurrentInventory(timestamp);
-    return this.compareInventories(previousInventory, currentInventory);
+    const diff = this.compareInventories(previousInventory, currentInventory);
+    await persistDiff(diff);
+    await this.updateLastInventory(currentInventory);
+    return diff;
+  }
+
+  async getInventoryDiffs(timestamp: string) {
+    return this.captureInventoryDiff(timestamp, async () => undefined);
   }
 
   compareInventories(prev: Record<string, any>, curr: Record<string, any>) {
@@ -53,7 +63,6 @@ class InventoryGetter extends EventEmitter {
       }
     });
 
-    void this.updateLastInventory(curr);
     return diff;
   }
 

--- a/src/main/modules/InventoryGetter.ts
+++ b/src/main/modules/InventoryGetter.ts
@@ -11,6 +11,7 @@ import * as GearChecker from './GearChecker';
 
 let settings: any;
 const emitter = new EventEmitter();
+let inventoryCaptureQueue: Promise<void> = Promise.resolve();
 
 class InventoryGetter extends EventEmitter {
   constructor() {
@@ -35,15 +36,37 @@ class InventoryGetter extends EventEmitter {
     timestamp: string,
     persistDiff: (diff: Record<string, any>) => Promise<void>
   ) {
-    const { diff, currentInventory } = await this.getInventoryCapture(timestamp);
-    await persistDiff(diff);
-    await this.updateLastInventory(currentInventory);
-    return diff;
+    return this.captureAndPersistInventory(timestamp, async ({ diff, currentInventory }) => {
+      await persistDiff(diff);
+      await this.updateLastInventory(currentInventory);
+    });
   }
 
-  async getInventoryCapture(timestamp: string) {
+  async captureAndPersistInventory(
+    timestamp: string,
+    persistCapture: (capture: {
+      diff: Record<string, any>;
+      currentInventory: Record<string, any>;
+    }) => Promise<void>,
+    requireFresh = false
+  ) {
+    const attempt = inventoryCaptureQueue
+      .catch(() => undefined)
+      .then(async () => {
+        const capture = await this.getInventoryCapture(timestamp, requireFresh);
+        await persistCapture(capture);
+        return capture.diff;
+      });
+    inventoryCaptureQueue = attempt.then(
+      () => undefined,
+      () => undefined
+    );
+    return attempt;
+  }
+
+  async getInventoryCapture(timestamp: string, requireFresh = false) {
     const previousInventory = await this.getPreviousInventory();
-    const currentInventory = await this.getCurrentInventory(timestamp);
+    const currentInventory = await this.getCurrentInventory(timestamp, requireFresh);
     const diff = this.compareInventories(previousInventory, currentInventory);
     return { diff, currentInventory };
   }
@@ -100,8 +123,10 @@ class InventoryGetter extends EventEmitter {
     }
   }
 
-  async getCurrentInventory(timestamp: string) {
-    const data = await GGGAPI.getDataForInventory();
+  async getCurrentInventory(timestamp: string, requireFresh = false) {
+    const data = await GGGAPI.getDataForInventory(
+      requireFresh ? { fresh: true, throwOnError: true } : undefined
+    );
     const inventory = this.getInventory(data.inventory);
     this.emit('xp', timestamp, data.experience);
     this.emit('equipment', timestamp, data.equipment);

--- a/src/main/modules/ItemParser.js
+++ b/src/main/modules/ItemParser.js
@@ -28,8 +28,8 @@ async function insertItems(items, timestamp) {
       });
     }
 
-    DB.insertItems(itemsToInsert);
-    DB.updateIgnoredItems(formattedItemsForIgnoreManager);
+    await DB.insertItems(itemsToInsert);
+    await DB.updateIgnoredItems(formattedItemsForIgnoreManager);
   }
 }
 

--- a/src/main/modules/ItemParser.js
+++ b/src/main/modules/ItemParser.js
@@ -33,6 +33,52 @@ async function insertItems(items, timestamp, eventId) {
   }
 }
 
+async function insertItemsAndInventoryBaseline(
+  items,
+  timestamp,
+  eventId,
+  inventoryTimestamp,
+  currentInventory
+) {
+  const duplicateInventory = await isDuplicateInventory(items);
+  const itemsToInsert = [];
+  const formattedItemsForIgnoreManager = [];
+
+  if (duplicateInventory) {
+    logger.info(`Duplicate items found for ${timestamp}, advancing inventory baseline only`);
+  } else {
+    logger.info(`Inserting items and inventory baseline for ${timestamp}`);
+    for (const itemKey in items) {
+      const item = new Item(items[itemKey]);
+      item.setTimestamp(timestamp);
+
+      const { value, explanation } = await ItemPricer.price(item);
+      item.setValue(value);
+      item.setValuation(explanation);
+      itemsToInsert.push(item.toDbInsertFormat(timestamp));
+      formattedItemsForIgnoreManager.push({
+        id: item.id,
+        status: IgnoreManager.isItemIgnored(item),
+      });
+    }
+  }
+
+  await DB.insertItemsAndInventory(
+    itemsToInsert,
+    eventId,
+    inventoryTimestamp,
+    currentInventory
+  );
+
+  if (formattedItemsForIgnoreManager.length > 0) {
+    try {
+      await DB.updateIgnoredItems(formattedItemsForIgnoreManager);
+    } catch (error) {
+      logger.warn(`Unable to update ignored item flags after inventory commit: ${error}`);
+    }
+  }
+}
+
 async function isDuplicateInventory(items) {
   if (items.length === 0) return false;
 
@@ -54,4 +100,5 @@ async function isDuplicateInventory(items) {
 }
 
 module.exports.insertItems = insertItems;
-export default { insertItems };
+module.exports.insertItemsAndInventoryBaseline = insertItemsAndInventoryBaseline;
+export default { insertItems, insertItemsAndInventoryBaseline };

--- a/src/main/modules/ItemParser.js
+++ b/src/main/modules/ItemParser.js
@@ -67,16 +67,9 @@ async function insertItemsAndInventoryBaseline(
     itemsToInsert,
     eventId,
     inventoryTimestamp,
-    currentInventory
+    currentInventory,
+    formattedItemsForIgnoreManager
   );
-
-  if (formattedItemsForIgnoreManager.length > 0) {
-    try {
-      await DB.updateIgnoredItems(formattedItemsForIgnoreManager);
-    } catch (error) {
-      logger.warn(`Unable to update ignored item flags after inventory commit: ${error}`);
-    }
-  }
 }
 
 async function isDuplicateInventory(items) {

--- a/src/main/modules/ItemParser.js
+++ b/src/main/modules/ItemParser.js
@@ -4,7 +4,7 @@ import IgnoreManager from '../../helpers/ignoreManager';
 const logger = require('electron-log');
 const DB = require('../db/items').default;
 
-async function insertItems(items, timestamp) {
+async function insertItems(items, timestamp, eventId) {
   const duplicateInventory = await isDuplicateInventory(items);
   if (duplicateInventory) {
     logger.info(`Duplicate items found for ${timestamp}, returning`);
@@ -28,7 +28,7 @@ async function insertItems(items, timestamp) {
       });
     }
 
-    await DB.insertItems(itemsToInsert);
+    await DB.insertItems(itemsToInsert, eventId);
     await DB.updateIgnoredItems(formattedItemsForIgnoreManager);
   }
 }

--- a/src/main/modules/ItemPricer.ts
+++ b/src/main/modules/ItemPricer.ts
@@ -225,7 +225,7 @@ class PriceMatcher {
     },
     {
       name: 'Wombgift',
-      test: (item: any) => item.typeline.endsWith('Wombgift'),
+      test: (item: any) => item.typeline?.endsWith('Wombgift'),
       calculateValue: (item: any, minItemValue: number = 0) =>
         this.getWombgiftValue(minItemValue, item),
     },
@@ -310,7 +310,7 @@ class PriceMatcher {
     },
     {
       name: 'Cluster Jewel',
-      test: (item: any) => item.baseType.includes('Cluster Jewel'),
+      test: (item: any) => item.baseType?.includes('Cluster Jewel'),
       calculateValue: (item: any, minItemValue: number = 0) =>
         this.getClusterJewelValue(minItemValue, item),
     },
@@ -333,7 +333,7 @@ class PriceMatcher {
     },
     {
       name: 'Skill Gem',
-      test: (item: any) => item.category.includes('Skill Gem'),
+      test: (item: any) => item.category?.includes('Skill Gem'),
       calculateValue: (item: any, minItemValue: number = 0) => this.getGemValue(minItemValue, item),
     },
     {

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -227,6 +227,8 @@ const LogProcessor = {
       timestamp,
     });
 
+    await RunParser.retryDeferredRun();
+
     // Special case for the very first run in DB
     const isFirstRun = await DB.isFirstRun();
     // Try to process the run if it's a town or a hideout

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -247,7 +247,7 @@ const LogProcessor = {
     // If there is a map run ongoing, we don't create a new one
     const hasOngoingMap = await RunParser.hasOngoingMapRun();
     if (
-      (isFirstRun || hasProcessed || !hasOngoingMap) &&
+      (isFirstRun || hasProcessed || RunParser.accountingDeferred || !hasOngoingMap) &&
       !area.isTown &&
       !area.isHideout &&
       !area.isLabyrinthAirlock &&

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -232,9 +232,17 @@ const LogProcessor = {
     // Try to process the run if it's a town or a hideout
     let hasProcessed = false;
     if (!area.isTown && !area.isHideout) {
-      hasProcessed = await RunParser.tryProcess({
+      const completionRequest = {
         event: { timestamp, server: lastInstanceServer },
-      });
+      };
+      for (let attempt = 1; attempt <= 3 && !hasProcessed; attempt++) {
+        hasProcessed = await RunParser.tryProcess(completionRequest);
+        if (!hasProcessed && attempt < 3) {
+          logger.warn(
+            `Map completion attempt ${attempt} failed; retrying with boundary ${timestamp}`
+          );
+        }
+      }
     }
     // If there is a map run ongoing, we don't create a new one
     const hasOngoingMap = await RunParser.hasOngoingMapRun();
@@ -332,14 +340,16 @@ const LogProcessor = {
           if (!persistedEventId) {
             throw new Error('Unable to persist the entered-area event');
           }
-          const { diff, currentInventory } =
-            await InventoryGetter.getInventoryCapture(timestamp);
-          await ItemParser.insertItemsAndInventoryBaseline(
-            diff,
+          await InventoryGetter.captureAndPersistInventory(
             timestamp,
-            persistedEventId,
-            dayjs().toISOString(),
-            currentInventory
+            ({ diff, currentInventory }) =>
+              ItemParser.insertItemsAndInventoryBaseline(
+                diff,
+                timestamp,
+                persistedEventId,
+                dayjs().toISOString(),
+                currentInventory
+              )
           );
         }
       } catch (e) {

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -227,9 +227,11 @@ const LogProcessor = {
       timestamp,
     });
 
+    let deferredRetryFailed = false;
     try {
-      await RunParser.retryDeferredRun();
+      deferredRetryFailed = !(await RunParser.retryDeferredRun());
     } catch (error) {
+      deferredRetryFailed = true;
       logger.error(`Unable to retry deferred run; continuing current generation: ${error}`);
     }
 
@@ -237,7 +239,7 @@ const LogProcessor = {
     const isFirstRun = await DB.isFirstRun();
     // Try to process the run if it's a town or a hideout
     let hasProcessed = false;
-    if (!area.isTown && !area.isHideout) {
+    if (!area.isTown && !area.isHideout && !deferredRetryFailed) {
       const completionRequest = {
         event: { timestamp, server: lastInstanceServer },
       };
@@ -249,6 +251,9 @@ const LogProcessor = {
           );
         }
       }
+    }
+    if (deferredRetryFailed) {
+      RunParser.accountingDeferred = true;
     }
     // If there is a map run ongoing, we don't create a new one
     const hasOngoingMap = await RunParser.hasOngoingMapRun();

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -253,6 +253,10 @@ const LogProcessor = {
       }
     }
     if (deferredRetryFailed) {
+      const currentRun = await DB.getLatestUncompletedRun();
+      if (currentRun) {
+        await DB.markRunDeferred(currentRun.id, timestamp);
+      }
       RunParser.accountingDeferred = true;
     }
     // If there is a map run ongoing, we don't create a new one

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -227,7 +227,11 @@ const LogProcessor = {
       timestamp,
     });
 
-    await RunParser.retryDeferredRun();
+    try {
+      await RunParser.retryDeferredRun();
+    } catch (error) {
+      logger.error(`Unable to retry deferred run; continuing current generation: ${error}`);
+    }
 
     // Special case for the very first run in DB
     const isFirstRun = await DB.isFirstRun();

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -10,6 +10,7 @@ import ItemParser from './ItemParser';
 import EventParser from './EventParser';
 import Utils from './Utils';
 import { createExplicitMapEndRequest } from './mapEnd';
+import dayjs from 'dayjs';
 
 const logger = Logger.scope('LogProcessor');
 
@@ -296,6 +297,7 @@ const LogProcessor = {
 
     if (event) {
       try {
+        let persistedEventId: number | false | null = eventId;
         if (eventId) {
           await DB.updateEvent(eventId, {
             timestamp,
@@ -304,7 +306,7 @@ const LogProcessor = {
           });
         } else {
           // Save the event to the database
-          await DB.insertEvent({
+          persistedEventId = await DB.insertEvent({
             timestamp,
             event_type: event.type,
             event_text: event.text,
@@ -327,12 +329,18 @@ const LogProcessor = {
             });
           }
           await SkillTreeWatcher.saveNewTree(timestamp); // Async but we dont care about the result here
-          await InventoryGetter.getInventoryDiffs(timestamp).then(async (diff) => {
-            // Async but we dont care about the result here
-            if (diff && Object.keys(diff).length > 0) {
-              await ItemParser.insertItems(diff, timestamp);
-            }
-          });
+          if (!persistedEventId) {
+            throw new Error('Unable to persist the entered-area event');
+          }
+          const { diff, currentInventory } =
+            await InventoryGetter.getInventoryCapture(timestamp);
+          await ItemParser.insertItemsAndInventoryBaseline(
+            diff,
+            timestamp,
+            persistedEventId,
+            dayjs().toISOString(),
+            currentInventory
+          );
         }
       } catch (e) {
         logger.error(`Error processing event: ${e}`);

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -73,6 +73,8 @@ type MapData = [
   boolean // completed
 ];
 
+let tryProcessQueue: Promise<void> = Promise.resolve();
+
 const RunParser = {
   latestGeneratedArea: {
     run_id: 0,
@@ -982,6 +984,17 @@ const RunParser = {
    * @throws Will log an error if processing fails.
    */
   tryProcess: async (parameters: RunProcessRequest | null) => {
+    const attempt = tryProcessQueue
+      .catch(() => undefined)
+      .then(() => RunParser.tryProcessOnce(parameters));
+    tryProcessQueue = attempt.then(
+      () => undefined,
+      () => undefined
+    );
+    return attempt;
+  },
+
+  tryProcessOnce: async (parameters: RunProcessRequest | null) => {
     let event: ParsedEvent;
     let wasGivenEvent: boolean = false;
     const isExplicitEnd = parameters?.reason === 'explicit-end';
@@ -1096,13 +1109,14 @@ const RunParser = {
         if (!closingEventId) {
           throw new Error('Unable to persist the explicit map-end closing event');
         }
-        await InventoryGetter.captureInventoryDiff(
+        const { diff, currentInventory } =
+          await InventoryGetter.getInventoryCapture(lastEventTimestamp);
+        await ItemParser.insertItemsAndInventoryBaseline(
+          diff,
           lastEventTimestamp,
-          async (inventoryDiff) => {
-            if (inventoryDiff && Object.keys(inventoryDiff).length > 0) {
-              await ItemParser.insertItems(inventoryDiff, lastEventTimestamp, closingEventId);
-            }
-          }
+          closingEventId,
+          dayjs().toISOString(),
+          currentInventory
         );
       }
       const runData = await RunParser.processRun(lastEventTimestamp, null, isExplicitEnd);

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -14,6 +14,8 @@ import LogProcessor from './LogProcessor';
 import ItemPricer from './ItemPricer';
 import XPTracker from './XPTracker';
 import GraftbloodTracker from './GraftbloodTracker';
+import InventoryGetter from './InventoryGetter';
+import ItemParser from './ItemParser';
 import type { RunProcessRequest } from './mapEnd';
 const logger = require('electron-log');
 const EventEmitter = require('events');
@@ -269,6 +271,11 @@ const RunParser = {
 
       const jsonData = JSON.parse(item.raw_data);
       if (jsonData && jsonData.inventoryId === 'MainInventory') {
+        const dbItem = item as Item & {
+          baseType?: string;
+          name?: string;
+          stack_size?: number;
+        };
         count++;
         if (item.category === 'Metamorph Sample') {
           const organ = item.typeline.slice(item.typeline.lastIndexOf(' ') + 1).toLowerCase();
@@ -277,7 +284,22 @@ const RunParser = {
           importantDrops[item.typeline] = (importantDrops[item.typeline] || 0) + 1;
         }
 
-        const price = await ItemPricer.price(item);
+        const pricingItem = {
+          ...jsonData,
+          ...item,
+          baseType: dbItem.baseType ?? jsonData.baseType,
+          typeline: item.typeline ?? jsonData.typeLine,
+          stack_size: dbItem.stack_size ?? jsonData.stackSize,
+        };
+        let price;
+        try {
+          price = await ItemPricer.price(pricingItem);
+        } catch (err) {
+          logger.warn(
+            `Unable to price item ${item.id} (${item.typeline || dbItem.name || 'unknown'}): ${err}`
+          );
+          price = { isVendor: false, value: 0, explanation: null };
+        }
         // logger.debug('Found price: ', price, item);
         if (price.isVendor) {
           totalValue += price.value;
@@ -402,10 +424,9 @@ const RunParser = {
       lastInventoryTimestamp =
         (await RunParser.getLastInventoryTimestamp()) ?? dayjs.unix(0).toISOString();
       if (
-        dayjs().isSameOrAfter(dayjs(lasteventTimestamp)) ||
         dayjs(lastInventoryTimestamp).isSameOrAfter(
           dayjs(lasteventTimestamp).subtract(5, 'seconds')
-        ) // Last inventory is newer than the last event + cache
+        ) // Last inventory is newer than the last event minus the API cache allowance
       ) {
         break;
       } else {
@@ -879,8 +900,11 @@ const RunParser = {
 
     // Get Item Stats
     const itemStats = await RunParser.getItemStats(areaInfo, firstEvent, lastEventTimestamp);
-    // If no item stats are found, set default values
-    const items = itemStats ? itemStats : { count: 0, value: 0, importantDrops: {} };
+    if (!itemStats) {
+      logger.warn(`Deferring run ${runId} completion until item accounting is ready`);
+      return false;
+    }
+    const items = itemStats;
 
     // Get the kill count if possible
     let killCount = await RunParser.getKillCount(firstEvent, lastEventTimestamp);
@@ -1039,11 +1063,7 @@ const RunParser = {
       }
 
       // Check if the area is the same as the last one entered, but not the same server (since the case above it handles it)
-      else if (
-        !isExplicitEnd &&
-        wasGivenEvent &&
-        event.area === [...mapEvents].reverse()[0].area
-      ) {
+      else if (!isExplicitEnd && wasGivenEvent && event.area === [...mapEvents].reverse()[0].area) {
         logger.debug('Same Area, this is probably a mirage');
         return false;
       }
@@ -1056,7 +1076,18 @@ const RunParser = {
 
     try {
       logger.debug(`Processing run for area: ${event.area} at ${lastEventTimestamp}`);
+      if (isExplicitEnd) {
+        const inventoryDiff = await InventoryGetter.getInventoryDiffs(lastEventTimestamp);
+        if (inventoryDiff && Object.keys(inventoryDiff).length > 0) {
+          const inventoryEventTimestamp = mapEvents[mapEvents.length - 1].timestamp;
+          await ItemParser.insertItems(inventoryDiff, inventoryEventTimestamp);
+        }
+      }
       const runData = await RunParser.processRun(lastEventTimestamp);
+      if (!runData) {
+        logger.warn('Run accounting is not ready; leaving the run open for a later retry');
+        return false;
+      }
       RunParser.emitter.emit('run-parser:run-processed', runData);
       RunParser.resetRunData();
     } catch (e) {

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -999,7 +999,7 @@ const RunParser = {
   retryDeferredRun: async () => {
     const persistedDeferredRun = RunParser.deferredRun
       ? null
-      : await DB.getOldestDeferredRun();
+      : await DB.getDeferredRun();
     const deferredRun =
       RunParser.deferredRun ??
       (persistedDeferredRun
@@ -1016,6 +1016,7 @@ const RunParser = {
     );
     if (!runData) return false;
 
+    await DB.clearDeferredRun(deferredRun.runId);
     RunParser.deferredRun = null;
     RunParser.emitter.emit('run-parser:run-processed', runData);
     return true;
@@ -1127,6 +1128,11 @@ const RunParser = {
 
     try {
       logger.debug(`Processing run for area: ${event.area} at ${lastEventTimestamp}`);
+      const targetRun = await DB.getLatestUncompletedRun();
+      const targetRunId = targetRun?.id ?? null;
+      if (targetRunId) {
+        await DB.markRunDeferred(targetRunId, lastEventTimestamp);
+      }
       if (isExplicitEnd) {
         const closingEventId = await RunParser.insertEvent({
           event_type: 'entered',
@@ -1150,8 +1156,6 @@ const RunParser = {
           true
         );
       }
-      const targetRun = await DB.getLatestUncompletedRun();
-      const targetRunId = targetRun?.id ?? null;
       const runData = await RunParser.processRun(
         lastEventTimestamp,
         targetRunId,
@@ -1167,6 +1171,9 @@ const RunParser = {
       }
       if (RunParser.deferredRun?.runId === targetRunId) {
         RunParser.deferredRun = null;
+      }
+      if (targetRunId) {
+        await DB.clearDeferredRun(targetRunId);
       }
       RunParser.emitter.emit('run-parser:run-processed', runData);
       RunParser.resetRunData();

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -280,7 +280,10 @@ const RunParser = {
         logger.warn(`Skipping item ${item.id} with malformed raw data: ${err}`);
         continue;
       }
-      if (jsonData && jsonData.inventoryId === 'MainInventory') {
+      if (
+        jsonData &&
+        (jsonData.inventoryId === 'MainInventory' || jsonData.inventoryId === 'Rucksack')
+      ) {
         const dbItem = item as Item & {
           baseType?: string;
           name?: string;
@@ -1173,10 +1176,11 @@ const RunParser = {
     // if (!lastEvent) return;
     // logger.debug('Last town event found:\n', JSON.stringify(lastEvent));
 
+    let targetRunId: number | null = null;
     try {
       logger.debug(`Processing run for area: ${event.area} at ${lastEventTimestamp}`);
       const targetRun = await DB.getLatestUncompletedRun();
-      const targetRunId = targetRun?.id ?? null;
+      targetRunId = targetRun?.id ?? null;
       if (targetRunId && !isExplicitEnd) {
         await DB.markRunDeferred(targetRunId, lastEventTimestamp, isExplicitEnd);
       }
@@ -1241,6 +1245,10 @@ const RunParser = {
       RunParser.emitter.emit('run-parser:run-processed', runData);
       RunParser.resetRunData();
     } catch (e) {
+      if (targetRunId) {
+        RunParser.accountingDeferred = true;
+        RunParser.deferredRun = { runId: targetRunId, lastEventTimestamp };
+      }
       logger.error(`Error processing run: ${e}`);
       return false;
     }

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -76,6 +76,7 @@ type MapData = [
 let tryProcessQueue: Promise<void> = Promise.resolve();
 
 const RunParser = {
+  accountingDeferred: false,
   latestGeneratedArea: {
     run_id: 0,
     level: 0,
@@ -995,6 +996,7 @@ const RunParser = {
   },
 
   tryProcessOnce: async (parameters: RunProcessRequest | null) => {
+    RunParser.accountingDeferred = false;
     let event: ParsedEvent;
     let wasGivenEvent: boolean = false;
     const isExplicitEnd = parameters?.reason === 'explicit-end';
@@ -1124,6 +1126,7 @@ const RunParser = {
       }
       const runData = await RunParser.processRun(lastEventTimestamp, null, isExplicitEnd);
       if (!runData) {
+        RunParser.accountingDeferred = true;
         logger.warn('Run accounting is not ready; leaving the run open for a later retry');
         return false;
       }

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1003,6 +1003,17 @@ const RunParser = {
   },
 
   retryDeferredRun: async () => {
+    const attempt = tryProcessQueue
+      .catch(() => undefined)
+      .then(() => RunParser.retryDeferredRunOnce());
+    tryProcessQueue = attempt.then(
+      () => undefined,
+      () => undefined
+    );
+    return attempt;
+  },
+
+  retryDeferredRunOnce: async () => {
     const persistedDeferredRun = RunParser.deferredRun
       ? null
       : await DB.getDeferredRun();
@@ -1094,7 +1105,11 @@ const RunParser = {
     }
 
     // Update the last event timestamp in the database
-    await DB.updateLastEvent(event.timestamp);
+    const updatedLastEvent = await DB.updateLastEvent(event.timestamp);
+    if (!updatedLastEvent) {
+      logger.error(`Unable to persist map completion boundary ${event.timestamp}`);
+      return false;
+    }
 
     const lastEventTimestamp = event.timestamp;
 

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -230,12 +230,18 @@ const RunParser = {
     return experience;
   },
 
-  getXPDiff: async (currentXP: number | null): Promise<number | null> => {
+  getXPDiff: async (
+    currentXP: number | null,
+    runId?: number
+  ): Promise<number | null> => {
     if (currentXP === null) return null;
     let xp: number | null = null;
     try {
-      await OldDB.get('SELECT xp FROM run ORDER BY id DESC LIMIT 1').then((row) => {
-        if (!row.xp) {
+      const query = runId
+        ? 'SELECT xp FROM run WHERE id < ? ORDER BY id DESC LIMIT 1'
+        : 'SELECT xp FROM run ORDER BY id DESC LIMIT 1';
+      await OldDB.get(query, runId ? [runId] : []).then((row) => {
+        if (!row?.xp) {
           // first map recorded - xp diff can't be determined in this case, return current XP
           xp = currentXP;
         } else {
@@ -914,7 +920,7 @@ const RunParser = {
     const xp = XPTracker.isMaxXP()
       ? Constants.MAX_XP
       : await RunParser.getXP(runId, lastEventTimestamp);
-    const xpDiff = await RunParser.getXPDiff(xp);
+    const xpDiff = await RunParser.getXPDiff(xp, runId);
 
     // Get Item Stats
     const itemStats = await RunParser.getItemStats(

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -408,38 +408,41 @@ const RunParser = {
   getItemStats: async (
     area: { run_id: number; name: string },
     firsteventTimestamp: string,
-    lasteventTimestamp: string
+    lasteventTimestamp: string,
+    waitForFreshInventory = false
   ): Promise<ItemStats | false> => {
     logger.debug(
       `Getting item stats for (${area.run_id}) ${area.name} between ${firsteventTimestamp} and ${lasteventTimestamp}`
     );
-    let lastInventoryTimestamp: string;
-    let timestampCheckCount = 0;
+    if (waitForFreshInventory) {
+      let lastInventoryTimestamp: string;
+      let timestampCheckCount = 0;
 
-    // Make sure the last inventory has been processed, wait 3s at a time until we're good
-    // Fails after 3 attempts
-    while (timestampCheckCount < 3) {
-      timestampCheckCount++;
-      logger.debug('Getting latest inventory timestamp');
-      lastInventoryTimestamp =
-        (await RunParser.getLastInventoryTimestamp()) ?? dayjs.unix(0).toISOString();
-      if (
-        dayjs(lastInventoryTimestamp).isSameOrAfter(
-          dayjs(lasteventTimestamp).subtract(5, 'seconds')
-        ) // Last inventory is newer than the last event minus the API cache allowance
-      ) {
-        break;
-      } else {
-        if (timestampCheckCount >= 3) {
-          logger.error('Unable to get the latest inventory from the DB, timestamp is too new');
-          return false;
+      // Explicit completion actively obtains a snapshot before reaching this check.
+      // Wait only for that snapshot's asynchronous last_inventory write to finish.
+      while (timestampCheckCount < 3) {
+        timestampCheckCount++;
+        logger.debug('Getting latest inventory timestamp');
+        lastInventoryTimestamp =
+          (await RunParser.getLastInventoryTimestamp()) ?? dayjs.unix(0).toISOString();
+        if (
+          dayjs(lastInventoryTimestamp).isSameOrAfter(
+            dayjs(lasteventTimestamp).subtract(5, 'seconds')
+          )
+        ) {
+          break;
         } else {
-          logger.error(
-            `Last inventory not yet processed (${dayjs(lastInventoryTimestamp)} < ${dayjs(
-              lasteventTimestamp
-            ).subtract(5, 'seconds')}), waiting 3 seconds`
-          );
-          await Utils.sleep(3000);
+          if (timestampCheckCount >= 3) {
+            logger.error('Unable to get the latest inventory from the DB, timestamp is too new');
+            return false;
+          } else {
+            logger.error(
+              `Last inventory not yet processed (${dayjs(lastInventoryTimestamp)} < ${dayjs(
+                lasteventTimestamp
+              ).subtract(5, 'seconds')}), waiting 3 seconds`
+            );
+            await Utils.sleep(3000);
+          }
         }
       }
     }
@@ -844,7 +847,11 @@ const RunParser = {
     }
   },
 
-  processRun: async (lastEventTimestamp: string, runId: number | null = null) => {
+  processRun: async (
+    lastEventTimestamp: string,
+    runId: number | null = null,
+    waitForFreshInventory = false
+  ) => {
     let mapStats = {
       iiq: 0,
       iir: 0,
@@ -899,7 +906,12 @@ const RunParser = {
     const xpDiff = await RunParser.getXPDiff(xp);
 
     // Get Item Stats
-    const itemStats = await RunParser.getItemStats(areaInfo, firstEvent, lastEventTimestamp);
+    const itemStats = await RunParser.getItemStats(
+      areaInfo,
+      firstEvent,
+      lastEventTimestamp,
+      waitForFreshInventory
+    );
     if (!itemStats) {
       logger.warn(`Deferring run ${runId} completion until item accounting is ready`);
       return false;
@@ -1083,7 +1095,7 @@ const RunParser = {
           await ItemParser.insertItems(inventoryDiff, inventoryEventTimestamp);
         }
       }
-      const runData = await RunParser.processRun(lastEventTimestamp);
+      const runData = await RunParser.processRun(lastEventTimestamp, null, isExplicitEnd);
       if (!runData) {
         logger.warn('Run accounting is not ready; leaving the run open for a later retry');
         return false;

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -77,6 +77,7 @@ let tryProcessQueue: Promise<void> = Promise.resolve();
 
 const RunParser = {
   accountingDeferred: false,
+  deferredRun: null as { runId: number; lastEventTimestamp: string } | null,
   latestGeneratedArea: {
     run_id: 0,
     level: 0,
@@ -995,6 +996,21 @@ const RunParser = {
     return attempt;
   },
 
+  retryDeferredRun: async () => {
+    const deferredRun = RunParser.deferredRun;
+    if (!deferredRun) return true;
+
+    const runData = await RunParser.processRun(
+      deferredRun.lastEventTimestamp,
+      deferredRun.runId
+    );
+    if (!runData) return false;
+
+    RunParser.deferredRun = null;
+    RunParser.emitter.emit('run-parser:run-processed', runData);
+    return true;
+  },
+
   tryProcessOnce: async (parameters: RunProcessRequest | null) => {
     RunParser.accountingDeferred = false;
     let event: ParsedEvent;
@@ -1124,11 +1140,23 @@ const RunParser = {
           true
         );
       }
-      const runData = await RunParser.processRun(lastEventTimestamp, null, isExplicitEnd);
+      const targetRun = await DB.getLatestUncompletedRun();
+      const targetRunId = targetRun?.id ?? null;
+      const runData = await RunParser.processRun(
+        lastEventTimestamp,
+        targetRunId,
+        isExplicitEnd
+      );
       if (!runData) {
         RunParser.accountingDeferred = true;
+        if (targetRunId) {
+          RunParser.deferredRun = { runId: targetRunId, lastEventTimestamp };
+        }
         logger.warn('Run accounting is not ready; leaving the run open for a later retry');
         return false;
+      }
+      if (RunParser.deferredRun?.runId === targetRunId) {
+        RunParser.deferredRun = null;
       }
       RunParser.emitter.emit('run-parser:run-processed', runData);
       RunParser.resetRunData();

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -301,7 +301,13 @@ const RunParser = {
           typeline: item.typeline ?? jsonData.typeLine,
           stack_size: dbItem.stack_size ?? jsonData.stackSize,
         };
-        const price = await ItemPricer.price(pricingItem);
+        let price;
+        try {
+          price = await ItemPricer.price(pricingItem);
+        } catch (error) {
+          logger.warn(`Skipping item ${item.id} after pricing failed: ${error}`);
+          continue;
+        }
         // logger.debug('Found price: ', price, item);
         if (price.isVendor) {
           totalValue += price.value;
@@ -1006,9 +1012,35 @@ const RunParser = {
         ? {
             runId: persistedDeferredRun.id,
             lastEventTimestamp: persistedDeferredRun.last_event,
+            captureRequired: persistedDeferredRun.capture_required === 1,
+            closingEventId: persistedDeferredRun.closing_event_id,
           }
         : null);
     if (!deferredRun) return true;
+
+    if ('captureRequired' in deferredRun && deferredRun.captureRequired) {
+      if (!deferredRun.closingEventId) {
+        throw new Error(`Deferred run ${deferredRun.runId} has no closing event`);
+      }
+      await InventoryGetter.captureAndPersistInventory(
+        deferredRun.lastEventTimestamp,
+        ({ diff, currentInventory }) =>
+          ItemParser.insertItemsAndInventoryBaseline(
+            diff,
+            deferredRun.lastEventTimestamp,
+            deferredRun.closingEventId,
+            dayjs().toISOString(),
+            currentInventory
+          ),
+        true
+      );
+      await DB.markRunDeferred(
+        deferredRun.runId,
+        deferredRun.lastEventTimestamp,
+        false,
+        deferredRun.closingEventId
+      );
+    }
 
     const runData = await RunParser.processRun(
       deferredRun.lastEventTimestamp,
@@ -1131,7 +1163,7 @@ const RunParser = {
       const targetRun = await DB.getLatestUncompletedRun();
       const targetRunId = targetRun?.id ?? null;
       if (targetRunId) {
-        await DB.markRunDeferred(targetRunId, lastEventTimestamp);
+        await DB.markRunDeferred(targetRunId, lastEventTimestamp, isExplicitEnd);
       }
       if (isExplicitEnd) {
         const closingEventId = await RunParser.insertEvent({
@@ -1142,6 +1174,14 @@ const RunParser = {
         });
         if (!closingEventId) {
           throw new Error('Unable to persist the explicit map-end closing event');
+        }
+        if (targetRunId) {
+          await DB.markRunDeferred(
+            targetRunId,
+            lastEventTimestamp,
+            true,
+            closingEventId
+          );
         }
         await InventoryGetter.captureAndPersistInventory(
           lastEventTimestamp,

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1089,10 +1089,15 @@ const RunParser = {
     try {
       logger.debug(`Processing run for area: ${event.area} at ${lastEventTimestamp}`);
       if (isExplicitEnd) {
+        await RunParser.insertEvent({
+          event_type: 'entered',
+          event_text: event.area,
+          timestamp: lastEventTimestamp,
+          server: event.server,
+        });
         const inventoryDiff = await InventoryGetter.getInventoryDiffs(lastEventTimestamp);
         if (inventoryDiff && Object.keys(inventoryDiff).length > 0) {
-          const inventoryEventTimestamp = mapEvents[mapEvents.length - 1].timestamp;
-          await ItemParser.insertItems(inventoryDiff, inventoryEventTimestamp);
+          await ItemParser.insertItems(inventoryDiff, lastEventTimestamp);
         }
       }
       const runData = await RunParser.processRun(lastEventTimestamp, null, isExplicitEnd);

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1087,17 +1087,20 @@ const RunParser = {
     try {
       logger.debug(`Processing run for area: ${event.area} at ${lastEventTimestamp}`);
       if (isExplicitEnd) {
-        await RunParser.insertEvent({
+        const closingEventId = await RunParser.insertEvent({
           event_type: 'entered',
           event_text: event.area,
           timestamp: lastEventTimestamp,
           server: event.server,
         });
+        if (!closingEventId) {
+          throw new Error('Unable to persist the explicit map-end closing event');
+        }
         await InventoryGetter.captureInventoryDiff(
           lastEventTimestamp,
           async (inventoryDiff) => {
             if (inventoryDiff && Object.keys(inventoryDiff).length > 0) {
-              await ItemParser.insertItems(inventoryDiff, lastEventTimestamp);
+              await ItemParser.insertItems(inventoryDiff, lastEventTimestamp, closingEventId);
             }
           }
         );
@@ -1198,7 +1201,7 @@ const RunParser = {
 
   insertEvent: async (event: Event) => {
     logger.debug('Inserting event:', event);
-    await DB.insertEvent(event);
+    return DB.insertEvent(event);
   },
 
   startRun: async (area: string, level: number, name: string) => {

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1048,10 +1048,8 @@ const RunParser = {
           ),
         true
       );
-      await DB.markRunDeferred(
+      await DB.completeDeferredCapture(
         deferredRun.runId,
-        deferredRun.lastEventTimestamp,
-        false,
         deferredRun.closingEventId
       );
     }
@@ -1215,12 +1213,7 @@ const RunParser = {
           true
         );
         if (targetRunId) {
-          await DB.markRunDeferred(
-            targetRunId,
-            lastEventTimestamp,
-            false,
-            closingEventId
-          );
+          await DB.completeDeferredCapture(targetRunId, closingEventId);
         }
       }
       const runData = await RunParser.processRun(
@@ -1247,7 +1240,7 @@ const RunParser = {
     } catch (e) {
       if (targetRunId) {
         RunParser.accountingDeferred = true;
-        RunParser.deferredRun = { runId: targetRunId, lastEventTimestamp };
+        RunParser.deferredRun = null;
       }
       logger.error(`Error processing run: ${e}`);
       return false;

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1162,7 +1162,7 @@ const RunParser = {
       logger.debug(`Processing run for area: ${event.area} at ${lastEventTimestamp}`);
       const targetRun = await DB.getLatestUncompletedRun();
       const targetRunId = targetRun?.id ?? null;
-      if (targetRunId) {
+      if (targetRunId && !isExplicitEnd) {
         await DB.markRunDeferred(targetRunId, lastEventTimestamp, isExplicitEnd);
       }
       if (isExplicitEnd) {
@@ -1195,6 +1195,14 @@ const RunParser = {
             ),
           true
         );
+        if (targetRunId) {
+          await DB.markRunDeferred(
+            targetRunId,
+            lastEventTimestamp,
+            false,
+            closingEventId
+          );
+        }
       }
       const runData = await RunParser.processRun(
         lastEventTimestamp,

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -997,7 +997,17 @@ const RunParser = {
   },
 
   retryDeferredRun: async () => {
-    const deferredRun = RunParser.deferredRun;
+    const persistedDeferredRun = RunParser.deferredRun
+      ? null
+      : await DB.getOldestDeferredRun();
+    const deferredRun =
+      RunParser.deferredRun ??
+      (persistedDeferredRun
+        ? {
+            runId: persistedDeferredRun.id,
+            lastEventTimestamp: persistedDeferredRun.last_event,
+          }
+        : null);
     if (!deferredRun) return true;
 
     const runData = await RunParser.processRun(

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1109,14 +1109,17 @@ const RunParser = {
         if (!closingEventId) {
           throw new Error('Unable to persist the explicit map-end closing event');
         }
-        const { diff, currentInventory } =
-          await InventoryGetter.getInventoryCapture(lastEventTimestamp);
-        await ItemParser.insertItemsAndInventoryBaseline(
-          diff,
+        await InventoryGetter.captureAndPersistInventory(
           lastEventTimestamp,
-          closingEventId,
-          dayjs().toISOString(),
-          currentInventory
+          ({ diff, currentInventory }) =>
+            ItemParser.insertItemsAndInventoryBaseline(
+              diff,
+              lastEventTimestamp,
+              closingEventId,
+              dayjs().toISOString(),
+              currentInventory
+            ),
+          true
         );
       }
       const runData = await RunParser.processRun(lastEventTimestamp, null, isExplicitEnd);

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -269,7 +269,13 @@ const RunParser = {
     for (let item of items) {
       if (!item.raw_data) continue;
 
-      const jsonData = JSON.parse(item.raw_data);
+      let jsonData;
+      try {
+        jsonData = JSON.parse(item.raw_data);
+      } catch (err) {
+        logger.warn(`Skipping item ${item.id} with malformed raw data: ${err}`);
+        continue;
+      }
       if (jsonData && jsonData.inventoryId === 'MainInventory') {
         const dbItem = item as Item & {
           baseType?: string;
@@ -291,15 +297,7 @@ const RunParser = {
           typeline: item.typeline ?? jsonData.typeLine,
           stack_size: dbItem.stack_size ?? jsonData.stackSize,
         };
-        let price;
-        try {
-          price = await ItemPricer.price(pricingItem);
-        } catch (err) {
-          logger.warn(
-            `Unable to price item ${item.id} (${item.typeline || dbItem.name || 'unknown'}): ${err}`
-          );
-          price = { isVendor: false, value: 0, explanation: null };
-        }
+        const price = await ItemPricer.price(pricingItem);
         // logger.debug('Found price: ', price, item);
         if (price.isVendor) {
           totalValue += price.value;
@@ -1095,10 +1093,14 @@ const RunParser = {
           timestamp: lastEventTimestamp,
           server: event.server,
         });
-        const inventoryDiff = await InventoryGetter.getInventoryDiffs(lastEventTimestamp);
-        if (inventoryDiff && Object.keys(inventoryDiff).length > 0) {
-          await ItemParser.insertItems(inventoryDiff, lastEventTimestamp);
-        }
+        await InventoryGetter.captureInventoryDiff(
+          lastEventTimestamp,
+          async (inventoryDiff) => {
+            if (inventoryDiff && Object.keys(inventoryDiff).length > 0) {
+              await ItemParser.insertItems(inventoryDiff, lastEventTimestamp);
+            }
+          }
+        );
       }
       const runData = await RunParser.processRun(lastEventTimestamp, null, isExplicitEnd);
       if (!runData) {

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { redirect } from 'react-router-dom';
+import { redirect, useRevalidator, useRouteError } from 'react-router-dom';
 import { createTheme } from '@mui/material/styles';
 import RunStore from './stores/runStore';
 import CharacterStore from './stores/characterStore';
@@ -73,6 +73,7 @@ export const createAppRoutes = ({
       {
         path: 'stash',
         element: <StashTabs store={stashTabStore} />,
+        errorElement: <StashRouteError />,
         loader: async () => {
           await stashTabStore.ensureLoaded();
           return {};
@@ -166,6 +167,28 @@ export const createAppRoutes = ({
 
 function SearchRoute({ createSearchDataStore }: { createSearchDataStore: () => SearchDataStore }) {
   return <Search store={createSearchDataStore()} />;
+}
+
+function StashRouteError() {
+  const error = useRouteError();
+  const revalidator = useRevalidator();
+
+  React.useEffect(() => {
+    logger.error('Unable to load stash tabs', error);
+  }, [error]);
+
+  return (
+    <div role="alert">
+      <p>Unable to load stash tabs.</p>
+      <button
+        type="button"
+        disabled={revalidator.state === 'loading'}
+        onClick={() => revalidator.revalidate()}
+      >
+        {revalidator.state === 'loading' ? 'Retrying…' : 'Retry'}
+      </button>
+    </div>
+  );
 }
 
 export const appTheme = createTheme({

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -73,6 +73,10 @@ export const createAppRoutes = ({
       {
         path: 'stash',
         element: <StashTabs store={stashTabStore} />,
+        loader: async () => {
+          await stashTabStore.ensureLoaded();
+          return {};
+        },
       },
       {
         path: 'search',

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -75,6 +75,9 @@ export const createAppRoutes = ({
         element: <StashTabs store={stashTabStore} />,
         errorElement: <StashRouteError />,
         loader: async () => {
+          if (!(await electronService.isAuthenticated())) {
+            return redirect('/login');
+          }
           await stashTabStore.ensureLoaded();
           return {};
         },

--- a/src/renderer/components/RunEvent/RunEvent.tsx
+++ b/src/renderer/components/RunEvent/RunEvent.tsx
@@ -329,12 +329,14 @@ const textPerEventType = {
 
 const generateNode = (event, runInfo, previousEvent): ReactNode => {
   const type = event.event_type;
-  const isImportant =
-    textPerEventType[type] && textPerEventType[type](event, runInfo, previousEvent);
+  const formatter = textPerEventType[type];
 
-  return isImportant
-    ? formatLine(event, textPerEventType[type](event, runInfo, previousEvent))
-    : formatLine(event, `Unknown event type: ${event.event_type}`);
+  if (!formatter) {
+    return formatLine(event, `Unknown event type: ${event.event_type}`);
+  }
+
+  const text = formatter(event, runInfo, previousEvent);
+  return text ? formatLine(event, text) : null;
 };
 
 const RunEvent = ({ event, runInfo, previousEvent }) => {

--- a/src/renderer/components/Settings/StashSettings/StashSettings.tsx
+++ b/src/renderer/components/Settings/StashSettings/StashSettings.tsx
@@ -120,9 +120,16 @@ const StashSettings = ({ store, settings }) => {
   const [refreshInterval, setRefreshInterval] = React.useState(
     settings?.netWorthCheck?.interval ?? 500
   );
+  const [refreshError, setRefreshError] = React.useState(false);
   let refreshIntervalUpdateTimeout: NodeJS.Timeout | undefined = undefined;
-  const handleStoreRefreshCallback = () => {
-    store.fetchStashTabs();
+  const handleStoreRefreshCallback = async () => {
+    setRefreshError(false);
+    try {
+      await store.fetchStashTabs();
+    } catch (error) {
+      logger.error('Unable to refresh stash tabs', error);
+      setRefreshError(true);
+    }
   };
   const handleUpdateInterval = async (e) => {
     const newInterval = e.target.value;
@@ -156,6 +163,7 @@ const StashSettings = ({ store, settings }) => {
         <Button variant="outlined" disabled={store.isLoading} onClick={handleStoreRefreshCallback}>
           Refresh Tabs
         </Button>
+        {refreshError && <div role="alert">Unable to refresh stash tabs. Please retry.</div>}
       </div>
       <List className="Stash-Settings__List">
         {store.stashTabs.map((stashTab: any) => (

--- a/src/renderer/routes/Settings.tsx
+++ b/src/renderer/routes/Settings.tsx
@@ -36,11 +36,21 @@ const Settings = ({ characterStore, stashTabStore, runStore }) => {
   const { settings } = useLoaderData() as SettingsLoaderData;
   const { revalidate } = useRevalidator();
   const [tabValue, setTabValue] = React.useState(0);
+  const [stashLoadError, setStashLoadError] = React.useState(false);
 
-  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+  const loadStashTabs = async () => {
+    setStashLoadError(false);
+    try {
+      await stashTabStore.ensureLoaded();
+    } catch {
+      setStashLoadError(true);
+    }
+  };
+
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
     if (newValue === 1) {
-      void stashTabStore.ensureLoaded();
+      void loadStashTabs();
     }
   };
 
@@ -68,7 +78,16 @@ const Settings = ({ characterStore, stashTabStore, runStore }) => {
         />
       </div>
       <div hidden={tabValue !== 1}>
-        <StashSettings store={stashTabStore} settings={settings} />
+        {stashLoadError ? (
+          <div role="alert">
+            <p>Unable to load stash tabs.</p>
+            <button type="button" onClick={() => void loadStashTabs()}>
+              Retry
+            </button>
+          </div>
+        ) : (
+          <StashSettings store={stashTabStore} settings={settings} />
+        )}
       </div>
       <div hidden={tabValue !== 2}>
         <FilterSettings settings={settings} revalidate={revalidate} />

--- a/src/renderer/routes/Settings.tsx
+++ b/src/renderer/routes/Settings.tsx
@@ -39,6 +39,9 @@ const Settings = ({ characterStore, stashTabStore, runStore }) => {
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
+    if (newValue === 1) {
+      void stashTabStore.ensureLoaded();
+    }
   };
 
   // const handleStashSettingsChange = (stashSettings) => {};

--- a/src/renderer/stores/stashTabStore.ts
+++ b/src/renderer/stores/stashTabStore.ts
@@ -13,6 +13,7 @@ export default class StashTabStore {
   value: number = 0;
   hasLoaded = false;
   private loadPromise: Promise<void> | null = null;
+  private loadedProfileKey: string | null = null;
 
   constructor() {
     makeAutoObservable(this);
@@ -31,12 +32,25 @@ export default class StashTabStore {
     this.isLoading = true;
     this.loadPromise = (async () => {
       try {
+        const settings = await electronService.getSettings();
+        const activeProfile = settings?.activeProfile;
+        const profileKey = `${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
+        if (this.loadedProfileKey !== null && this.loadedProfileKey !== profileKey) {
+          runInAction(() => {
+            this.stashTabs = [];
+            this.itemStore.createItems([]);
+            this.value = 0;
+            this.hasLoaded = false;
+          });
+        }
+
         const response = await electronService.getStashTabs();
         const stashTabs = response.stashTabs ?? [];
         this.createStashTabs(stashTabs);
         this.itemStore.createItems(response.data?.items ?? []);
         this.value = response.data?.value ?? 0;
         this.hasLoaded = stashTabs.length > 0;
+        this.loadedProfileKey = profileKey;
       } catch (error) {
         logger.error('Failed to fetch stash tabs for StashTabStore', error);
         throw error;
@@ -49,7 +63,10 @@ export default class StashTabStore {
   }
 
   async ensureLoaded() {
-    if (this.hasLoaded) return;
+    const settings = await electronService.getSettings();
+    const activeProfile = settings?.activeProfile;
+    const profileKey = `${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
+    if (this.hasLoaded && this.loadedProfileKey === profileKey) return;
     await this.fetchStashTabs();
   }
 

--- a/src/renderer/stores/stashTabStore.ts
+++ b/src/renderer/stores/stashTabStore.ts
@@ -11,25 +11,45 @@ export default class StashTabStore {
   isLoading = false;
   itemStore: ItemStore = new ItemStore([]);
   value: number = 0;
+  hasLoaded = false;
+  private loadPromise: Promise<void> | null = null;
 
   constructor() {
     makeAutoObservable(this);
-  }
-
-  async fetchStashTabs() {
-    logger.info('Fetching stash tabs for StashTabStore');
-    this.isLoading = true;
-    const { stashTabs, data } = await electronService.getStashTabs();
-    this.createStashTabs(stashTabs);
-    this.itemStore.createItems(data.items);
-    this.value = data.value;
-
     electronService.on('stashTabsUpdated', (stashTabsData) => {
       const tabs = stashTabsData.tabs;
       logger.info(`Received stash tabs update from backend for ${tabs.length} stash tabs.`);
       this.itemStore.createItems(tabs.items);
       this.value = tabs.value;
     });
+  }
+
+  async fetchStashTabs() {
+    if (this.loadPromise) return this.loadPromise;
+
+    logger.info('Fetching stash tabs for StashTabStore');
+    this.isLoading = true;
+    this.loadPromise = (async () => {
+      try {
+        const response = await electronService.getStashTabs();
+        this.createStashTabs(response.stashTabs ?? []);
+        this.itemStore.createItems(response.data?.items ?? []);
+        this.value = response.data?.value ?? 0;
+        this.hasLoaded = true;
+      } catch (error) {
+        logger.error('Failed to fetch stash tabs for StashTabStore', error);
+        throw error;
+      } finally {
+        this.isLoading = false;
+        this.loadPromise = null;
+      }
+    })();
+    return this.loadPromise;
+  }
+
+  async ensureLoaded() {
+    if (this.hasLoaded) return;
+    await this.fetchStashTabs();
   }
 
   @computed getStashTab(id: string) {

--- a/src/renderer/stores/stashTabStore.ts
+++ b/src/renderer/stores/stashTabStore.ts
@@ -32,10 +32,11 @@ export default class StashTabStore {
     this.loadPromise = (async () => {
       try {
         const response = await electronService.getStashTabs();
-        this.createStashTabs(response.stashTabs ?? []);
+        const stashTabs = response.stashTabs ?? [];
+        this.createStashTabs(stashTabs);
         this.itemStore.createItems(response.data?.items ?? []);
         this.value = response.data?.value ?? 0;
-        this.hasLoaded = true;
+        this.hasLoaded = stashTabs.length > 0;
       } catch (error) {
         logger.error('Failed to fetch stash tabs for StashTabStore', error);
         throw error;

--- a/src/renderer/stores/stashTabStore.ts
+++ b/src/renderer/stores/stashTabStore.ts
@@ -14,6 +14,7 @@ export default class StashTabStore {
   hasLoaded = false;
   private loadPromise: Promise<void> | null = null;
   private loadedProfileKey: string | null = null;
+  private loadingProfileKey: string | null = null;
 
   constructor() {
     makeAutoObservable(this);
@@ -26,15 +27,24 @@ export default class StashTabStore {
   }
 
   async fetchStashTabs() {
-    if (this.loadPromise) return this.loadPromise;
+    const settings = await electronService.getSettings();
+    const activeProfile = settings?.activeProfile;
+    const profileKey = `${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
+    if (this.loadPromise) {
+      if (this.loadingProfileKey === profileKey) return this.loadPromise;
+      try {
+        await this.loadPromise;
+      } catch {
+        // The newly selected profile still needs its own request.
+      }
+      return this.fetchStashTabs();
+    }
 
     logger.info('Fetching stash tabs for StashTabStore');
     this.isLoading = true;
+    this.loadingProfileKey = profileKey;
     this.loadPromise = (async () => {
       try {
-        const settings = await electronService.getSettings();
-        const activeProfile = settings?.activeProfile;
-        const profileKey = `${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
         if (this.loadedProfileKey !== null && this.loadedProfileKey !== profileKey) {
           runInAction(() => {
             this.stashTabs = [];
@@ -57,6 +67,7 @@ export default class StashTabStore {
       } finally {
         this.isLoading = false;
         this.loadPromise = null;
+        this.loadingProfileKey = null;
       }
     })();
     return this.loadPromise;

--- a/src/renderer/stores/stashTabStore.ts
+++ b/src/renderer/stores/stashTabStore.ts
@@ -29,7 +29,7 @@ export default class StashTabStore {
   async fetchStashTabs() {
     const settings = await electronService.getSettings();
     const activeProfile = settings?.activeProfile;
-    const profileKey = `${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
+    const profileKey = `${settings?.username ?? ''}:${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
     if (this.loadPromise) {
       if (this.loadingProfileKey === profileKey) return this.loadPromise;
       try {
@@ -76,7 +76,7 @@ export default class StashTabStore {
   async ensureLoaded() {
     const settings = await electronService.getSettings();
     const activeProfile = settings?.activeProfile;
-    const profileKey = `${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
+    const profileKey = `${settings?.username ?? ''}:${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
     if (this.hasLoaded && this.loadedProfileKey === profileKey) return;
     await this.fetchStashTabs();
   }

--- a/src/renderer/stores/stashTabStore.ts
+++ b/src/renderer/stores/stashTabStore.ts
@@ -15,6 +15,7 @@ export default class StashTabStore {
   private loadPromise: Promise<void> | null = null;
   private loadedProfileKey: string | null = null;
   private loadingProfileKey: string | null = null;
+  private desiredProfileKey: string | null = null;
 
   constructor() {
     makeAutoObservable(this);
@@ -30,8 +31,15 @@ export default class StashTabStore {
     const settings = await electronService.getSettings();
     const activeProfile = settings?.activeProfile;
     const profileKey = `${settings?.username ?? ''}:${activeProfile?.characterName ?? ''}:${activeProfile?.league ?? ''}`;
+    this.desiredProfileKey = profileKey;
     if (this.loadPromise) {
       if (this.loadingProfileKey === profileKey) return this.loadPromise;
+      runInAction(() => {
+        this.stashTabs = [];
+        this.itemStore.createItems([]);
+        this.value = 0;
+        this.hasLoaded = false;
+      });
       try {
         await this.loadPromise;
       } catch {
@@ -55,6 +63,7 @@ export default class StashTabStore {
         }
 
         const response = await electronService.getStashTabs();
+        if (this.desiredProfileKey !== profileKey) return;
         const stashTabs = response.stashTabs ?? [];
         this.createStashTabs(stashTabs);
         this.itemStore.createItems(response.data?.items ?? []);

--- a/test/main/GGGAPI.spec.ts
+++ b/test/main/GGGAPI.spec.ts
@@ -167,6 +167,42 @@ describe('GGGAPI auth gating', () => {
     expect(axiosRequest).toHaveBeenCalledTimes(1);
   });
 
+  it('bypasses the snapshot cache when fresh inventory is required', async () => {
+    axiosRequest.mockResolvedValue({
+      cached: false,
+      headers: {},
+      data: {
+        character: {
+          inventory: [],
+          equipment: [],
+          experience: 123,
+        },
+      },
+    });
+
+    const GGGAPI = (await import('../../src/main/GGGAPI')).default;
+    await expect(
+      GGGAPI.getDataForInventory({ fresh: true, throwOnError: true })
+    ).resolves.toMatchObject({ experience: 123 });
+
+    expect(axiosRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cache: { enabled: false },
+        url: '/character/AtlasRunner',
+      })
+    );
+  });
+
+  it('propagates a failed inventory request when a fresh snapshot is required', async () => {
+    axiosRequest.mockRejectedValue(new Error('snapshot failed'));
+
+    const GGGAPI = (await import('../../src/main/GGGAPI')).default;
+
+    await expect(
+      GGGAPI.getDataForInventory({ fresh: true, throwOnError: true })
+    ).rejects.toThrow('snapshot failed');
+  });
+
   it('waits only for account access when resolving the current character', async () => {
     axiosRequest.mockResolvedValue({
       cached: false,

--- a/test/main/GGGAPI.spec.ts
+++ b/test/main/GGGAPI.spec.ts
@@ -246,6 +246,14 @@ describe('GGGAPI auth gating', () => {
     expect(ensurePoeApiHostResolution).toHaveBeenCalledTimes(1);
   });
 
+  it('propagates stash request failures to callers that can offer a retry', async () => {
+    axiosRequest.mockRejectedValue(new Error('stash failed'));
+
+    const GGGAPI = (await import('../../src/main/GGGAPI')).default;
+
+    await expect(GGGAPI.getAllStashTabs()).rejects.toThrow('stash failed');
+  });
+
   it('surfaces a DNS resolution failure before making a doomed GGG request', async () => {
     ensurePoeApiHostResolution.mockRejectedValue(new Error('dns mismatch'));
 

--- a/test/main/GGGAPI.spec.ts
+++ b/test/main/GGGAPI.spec.ts
@@ -249,6 +249,12 @@ describe('GGGAPI auth gating', () => {
     expect(waitForProfileAccess).toHaveBeenCalledTimes(1);
     expect(waitForAccountAccess).not.toHaveBeenCalled();
     expect(ensurePoeApiHostResolution).toHaveBeenCalledTimes(1);
+    expect(axiosRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'getAllStashTabs-Mapper-Mirage',
+        url: '/stash/Mirage',
+      })
+    );
   });
 
   it('propagates stash request failures to callers that can offer a retry', async () => {

--- a/test/main/GGGAPI.spec.ts
+++ b/test/main/GGGAPI.spec.ts
@@ -1,4 +1,5 @@
 const axiosRequest = jest.fn();
+const removeCachedResponse = jest.fn(async () => undefined);
 const waitForAccountAccess = jest.fn(async () => undefined);
 const waitForProfileAccess = jest.fn(async () => undefined);
 const ensurePoeApiHostResolution = jest.fn(async () => undefined);
@@ -25,6 +26,7 @@ jest.mock('axios-cache-interceptor/dev', () => ({
   setupCache: () => axiosRequest,
   buildMemoryStorage: () => ({
     get: jest.fn(async () => null),
+    remove: (...args: unknown[]) => removeCachedResponse(...args),
   }),
 }));
 
@@ -190,6 +192,9 @@ describe('GGGAPI auth gating', () => {
         cache: { enabled: false },
         url: '/character/AtlasRunner',
       })
+    );
+    expect(removeCachedResponse).toHaveBeenCalledWith(
+      'getCharacter-Mapper-AtlasRunner'
     );
   });
 

--- a/test/main/db/index.spec.ts
+++ b/test/main/db/index.spec.ts
@@ -268,6 +268,14 @@ describe('db/index', () => {
       preparedSql.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS deferred_run'))
     ).toBe(true);
     expect(
+      preparedSql.some(
+        (sql: string) =>
+          sql.includes('CREATE TABLE IF NOT EXISTS deferred_run') &&
+          sql.includes('capture_required') &&
+          sql.includes('closing_event_id')
+      )
+    ).toBe(true);
+    expect(
       preparedSql.some((sql: string) =>
         sql.includes('ALTER TABLE deferred_run ADD COLUMN capture_required')
       )

--- a/test/main/db/index.spec.ts
+++ b/test/main/db/index.spec.ts
@@ -267,7 +267,12 @@ describe('db/index', () => {
     expect(
       preparedSql.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS deferred_run'))
     ).toBe(true);
-    expect(preparedSql.some((sql: string) => sql.includes('pragma user_version = 19'))).toBe(true);
+    expect(
+      preparedSql.some((sql: string) =>
+        sql.includes('ALTER TABLE deferred_run ADD COLUMN capture_required')
+      )
+    ).toBe(true);
+    expect(preparedSql.some((sql: string) => sql.includes('pragma user_version = 20'))).toBe(true);
     expect(preparedSql.some((sql: string) => sql.includes('delete from incubator'))).toBe(true);
     expect(manager.db.transaction).toHaveBeenCalled();
   });

--- a/test/main/db/index.spec.ts
+++ b/test/main/db/index.spec.ts
@@ -264,7 +264,10 @@ describe('db/index', () => {
         sql.includes('CREATE INDEX IF NOT EXISTS "graftblood_timestamp"')
       )
     ).toBe(true);
-    expect(preparedSql.some((sql: string) => sql.includes('pragma user_version = 18'))).toBe(true);
+    expect(
+      preparedSql.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS deferred_run'))
+    ).toBe(true);
+    expect(preparedSql.some((sql: string) => sql.includes('pragma user_version = 19'))).toBe(true);
     expect(preparedSql.some((sql: string) => sql.includes('delete from incubator'))).toBe(true);
     expect(manager.db.transaction).toHaveBeenCalled();
   });

--- a/test/main/db/items.spec.ts
+++ b/test/main/db/items.spec.ts
@@ -81,6 +81,51 @@ describe('Items', () => {
       );
     });
 
+    it('uses an exact event id when one is provided', async () => {
+      const mockItems = [
+        [
+          'item1',
+          '2023-01-01T12:00:00.000Z',
+          'icon1.png',
+          'Item Name',
+          'Rare',
+          'Currency',
+          1,
+          'Chaos Orb',
+          '',
+          1,
+          '{"raw":"data"}',
+          1,
+          1,
+          null,
+        ],
+      ];
+
+      await Items.insertItems(mockItems, 42);
+
+      expect(mockDB.transaction).toHaveBeenCalledWith(
+        expect.stringContaining('values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'),
+        [
+          [
+            'item1',
+            42,
+            'icon1.png',
+            'Item Name',
+            'Rare',
+            'Currency',
+            1,
+            'Chaos Orb',
+            '',
+            1,
+            '{"raw":"data"}',
+            1,
+            1,
+            null,
+          ],
+        ]
+      );
+    });
+
     it('should handle database transaction failure', async () => {
       const mockItems = [
         [

--- a/test/main/db/items.spec.ts
+++ b/test/main/db/items.spec.ts
@@ -229,12 +229,15 @@ describe('Items', () => {
         [item],
         42,
         '2023-01-01T12:02:00.000Z',
-        inventory
+        inventory,
+        [{ id: 'item1', status: true }]
       );
 
       expect(mockDB.transactionSteps).toHaveBeenCalledWith([
         {
-          query: expect.stringContaining('values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'),
+          query: expect.stringContaining(
+            'values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+          ),
           params: [
             'item1',
             42,
@@ -250,6 +253,7 @@ describe('Items', () => {
             1,
             1,
             null,
+            1,
           ],
         },
         {

--- a/test/main/db/items.spec.ts
+++ b/test/main/db/items.spec.ts
@@ -205,6 +205,61 @@ describe('Items', () => {
     });
   });
 
+  describe('insertItemsAndInventory', () => {
+    it('commits exact-event item rows and the inventory baseline in one transaction', async () => {
+      const item = [
+        'item1',
+        '2023-01-01T12:00:00.000Z',
+        'icon1.png',
+        'Item Name',
+        'Rare',
+        'Currency',
+        1,
+        'Chaos Orb',
+        '',
+        1,
+        '{"raw":"data"}',
+        1,
+        1,
+        null,
+      ];
+      const inventory = { item1: { id: 'item1' } };
+
+      await Items.insertItemsAndInventory(
+        [item],
+        42,
+        '2023-01-01T12:02:00.000Z',
+        inventory
+      );
+
+      expect(mockDB.transactionSteps).toHaveBeenCalledWith([
+        {
+          query: expect.stringContaining('values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'),
+          params: [
+            'item1',
+            42,
+            'icon1.png',
+            'Item Name',
+            'Rare',
+            'Currency',
+            1,
+            'Chaos Orb',
+            '',
+            1,
+            '{"raw":"data"}',
+            1,
+            1,
+            null,
+          ],
+        },
+        {
+          query: 'INSERT INTO last_inventory(timestamp, inventory) VALUES(?, ?)',
+          params: ['2023-01-01T12:02:00.000Z', JSON.stringify(inventory)],
+        },
+      ]);
+    });
+  });
+
   describe('getMatchingItemsCount', () => {
     it('should return count for matching items', async () => {
       const itemIds = ['item1', 'item2', 'item3'];

--- a/test/main/db/run.spec.ts
+++ b/test/main/db/run.spec.ts
@@ -624,6 +624,12 @@ describe('Runs', () => {
       mockDB.run.mockResolvedValue({ changes: 1, lastInsertRowid: 0 });
 
       await expect(Runs.updateCurrentRunFirstEvent()).resolves.toBe(true);
+
+      expect(mockDB.run).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'WHERE id = (SELECT MAX(id) FROM run WHERE completed = 0)'
+        )
+      );
     });
 
     it('returns false when no active run was updated', async () => {

--- a/test/main/db/run.spec.ts
+++ b/test/main/db/run.spec.ts
@@ -71,7 +71,7 @@ describe('Runs', () => {
         '{"test": "data"}', // run_info
         true, // completed
       ];
-      mockDB.run.mockResolvedValue(undefined);
+      mockDB.run.mockResolvedValue({ lastInsertRowid: 42 });
 
       const result = await Runs.insertMapRun(mapData);
 
@@ -366,7 +366,7 @@ describe('Runs', () => {
       jest
         .spyOn(Runs, 'getAreaInfo')
         .mockResolvedValue({ name: undefined, level: undefined, depth: undefined } as any);
-      mockDB.run.mockResolvedValue(undefined);
+      mockDB.run.mockResolvedValue({ lastInsertRowid: 42 });
 
       const result = await Runs.insertAreaInfo(areaData);
 
@@ -488,7 +488,7 @@ describe('Runs', () => {
   describe('deleteMapMods', () => {
     it('should delete map mods successfully', async () => {
       const mapId = 42;
-      mockDB.run.mockResolvedValue(undefined);
+      mockDB.run.mockResolvedValue({ lastInsertRowid: 42 });
 
       const result = await Runs.deleteMapMods(mapId);
 
@@ -563,7 +563,7 @@ describe('Runs', () => {
         timestamp: '2023-01-01T12:00:00.000Z',
         server: 'test-server',
       };
-      mockDB.run.mockResolvedValue(undefined);
+      mockDB.run.mockResolvedValue({ lastInsertRowid: 42 });
 
       const result = await Runs.insertEvent(event);
 
@@ -574,7 +574,7 @@ describe('Runs', () => {
     `,
         [event.event_type, event.event_text, event.timestamp, event.server]
       );
-      expect(result).toBe(true);
+      expect(result).toBe(42);
     });
 
     it('should handle insertion failure', async () => {
@@ -594,7 +594,7 @@ describe('Runs', () => {
         timestamp: '2023-01-01T12:00:00.000Z',
         server: 'test-server',
       };
-      mockDB.run.mockResolvedValue(undefined);
+      mockDB.run.mockResolvedValue({ lastInsertRowid: 42 });
 
       await Runs.insertEvent(event);
 

--- a/test/main/modules/InventoryGetter.spec.ts
+++ b/test/main/modules/InventoryGetter.spec.ts
@@ -1,0 +1,86 @@
+import { jest } from '@jest/globals';
+import InventoryGetter from '../../../src/main/modules/InventoryGetter';
+
+jest.mock('../../../src/main/modules/GearChecker', () => ({
+  check: jest.fn(),
+}));
+jest.mock('../../../src/main/modules/XPTracker', () => ({
+  __esModule: true,
+  default: {
+    logXP: jest.fn(),
+  },
+}));
+jest.mock('../../../src/main/modules/GraftbloodTracker', () => ({
+  __esModule: true,
+  default: {
+    logGraftblood: jest.fn(),
+  },
+}));
+jest.mock('../../../src/main/modules/KillTracker', () => ({
+  __esModule: true,
+  default: {
+    logKillCount: jest.fn(),
+  },
+}));
+jest.mock('../../../src/main/modules/settings', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(() => ({})),
+  },
+}));
+
+describe('InventoryGetter capture contract', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('updates the inventory baseline only after the diff persists', async () => {
+    const previousInventory = {
+      existing: { id: 'existing', name: 'Chaos Orb', typeLine: 'Chaos Orb', stackSize: 1 },
+    };
+    const currentInventory = {
+      existing: { id: 'existing', name: 'Chaos Orb', typeLine: 'Chaos Orb', stackSize: 2 },
+    };
+    jest.spyOn(InventoryGetter, 'getPreviousInventory').mockResolvedValue(previousInventory);
+    jest.spyOn(InventoryGetter, 'getCurrentInventory').mockResolvedValue(currentInventory);
+    const updateLastInventory = jest
+      .spyOn(InventoryGetter, 'updateLastInventory')
+      .mockResolvedValue(undefined);
+    const persistDiff = jest.fn().mockRejectedValue(new Error('item insert failed'));
+
+    await expect(
+      InventoryGetter.captureInventoryDiff('2026-07-22T10:00:00.000Z', persistDiff)
+    ).rejects.toThrow('item insert failed');
+
+    expect(persistDiff).toHaveBeenCalledWith({
+      existing: {
+        id: 'existing',
+        name: 'Chaos Orb',
+        typeLine: 'Chaos Orb',
+        stackSize: 1,
+      },
+    });
+    expect(updateLastInventory).not.toHaveBeenCalled();
+  });
+
+  it('commits the inventory baseline after the diff persists', async () => {
+    const currentInventory = {
+      item: { id: 'item', name: 'Divine Orb', typeLine: 'Divine Orb' },
+    };
+    jest.spyOn(InventoryGetter, 'getPreviousInventory').mockResolvedValue({});
+    jest.spyOn(InventoryGetter, 'getCurrentInventory').mockResolvedValue(currentInventory);
+    const updateLastInventory = jest
+      .spyOn(InventoryGetter, 'updateLastInventory')
+      .mockResolvedValue(undefined);
+    const persistDiff = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      InventoryGetter.captureInventoryDiff('2026-07-22T10:00:00.000Z', persistDiff)
+    ).resolves.toEqual(currentInventory);
+
+    expect(persistDiff.mock.invocationCallOrder[0]).toBeLessThan(
+      updateLastInventory.mock.invocationCallOrder[0]
+    );
+    expect(updateLastInventory).toHaveBeenCalledWith(currentInventory);
+  });
+});

--- a/test/main/modules/InventoryGetter.spec.ts
+++ b/test/main/modules/InventoryGetter.spec.ts
@@ -98,4 +98,31 @@ describe('InventoryGetter capture contract', () => {
 
     expect(updateLastInventory).not.toHaveBeenCalled();
   });
+
+  it('serializes capture persistence across callers', async () => {
+    let releaseFirst: (() => void) | undefined;
+    const getInventoryCapture = jest
+      .spyOn(InventoryGetter, 'getInventoryCapture')
+      .mockResolvedValue({ diff: {}, currentInventory: {} });
+    const firstPersist = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        })
+    );
+    const secondPersist = jest.fn().mockResolvedValue(undefined);
+
+    const first = InventoryGetter.captureAndPersistInventory('first', firstPersist);
+    const second = InventoryGetter.captureAndPersistInventory('second', secondPersist);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getInventoryCapture).toHaveBeenCalledTimes(1);
+    expect(secondPersist).not.toHaveBeenCalled();
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+
+    expect(getInventoryCapture).toHaveBeenCalledTimes(2);
+    expect(secondPersist).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/main/modules/InventoryGetter.spec.ts
+++ b/test/main/modules/InventoryGetter.spec.ts
@@ -83,4 +83,19 @@ describe('InventoryGetter capture contract', () => {
     );
     expect(updateLastInventory).toHaveBeenCalledWith(currentInventory);
   });
+
+  it('can return the diff and current inventory without advancing the baseline', async () => {
+    const currentInventory = {
+      item: { id: 'item', name: 'Divine Orb', typeLine: 'Divine Orb' },
+    };
+    jest.spyOn(InventoryGetter, 'getPreviousInventory').mockResolvedValue({});
+    jest.spyOn(InventoryGetter, 'getCurrentInventory').mockResolvedValue(currentInventory);
+    const updateLastInventory = jest.spyOn(InventoryGetter, 'updateLastInventory');
+
+    await expect(
+      InventoryGetter.getInventoryCapture('2026-07-22T10:00:00.000Z')
+    ).resolves.toEqual({ diff: currentInventory, currentInventory });
+
+    expect(updateLastInventory).not.toHaveBeenCalled();
+  });
 });

--- a/test/main/modules/ItemParserSource.spec.ts
+++ b/test/main/modules/ItemParserSource.spec.ts
@@ -8,7 +8,7 @@ describe('ItemParser persistence contract', () => {
       path.join(process.cwd(), 'src', 'main', 'modules', 'ItemParser.js'),
       'utf8'
     );
-    const insertIndex = source.indexOf('await DB.insertItems(itemsToInsert);');
+    const insertIndex = source.indexOf('await DB.insertItems(itemsToInsert, eventId);');
     const ignoreUpdateIndex = source.indexOf(
       'await DB.updateIgnoredItems(formattedItemsForIgnoreManager);'
     );

--- a/test/main/modules/ItemParserSource.spec.ts
+++ b/test/main/modules/ItemParserSource.spec.ts
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+
+describe('ItemParser persistence contract', () => {
+  it('awaits item insertion before the dependent ignore-state update', () => {
+    const fs = jest.requireActual<typeof import('node:fs')>('node:fs');
+    const path = jest.requireActual<typeof import('node:path')>('node:path');
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src', 'main', 'modules', 'ItemParser.js'),
+      'utf8'
+    );
+    const insertIndex = source.indexOf('await DB.insertItems(itemsToInsert);');
+    const ignoreUpdateIndex = source.indexOf(
+      'await DB.updateIgnoredItems(formattedItemsForIgnoreManager);'
+    );
+
+    expect(insertIndex).toBeGreaterThan(-1);
+    expect(ignoreUpdateIndex).toBeGreaterThan(insertIndex);
+  });
+});

--- a/test/main/modules/ItemParserSource.spec.ts
+++ b/test/main/modules/ItemParserSource.spec.ts
@@ -16,4 +16,15 @@ describe('ItemParser persistence contract', () => {
     expect(insertIndex).toBeGreaterThan(-1);
     expect(ignoreUpdateIndex).toBeGreaterThan(insertIndex);
   });
+
+  it('uses the atomic item and inventory-baseline repository operation', () => {
+    const fs = jest.requireActual<typeof import('node:fs')>('node:fs');
+    const path = jest.requireActual<typeof import('node:path')>('node:path');
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src', 'main', 'modules', 'ItemParser.js'),
+      'utf8'
+    );
+
+    expect(source).toContain('await DB.insertItemsAndInventory(');
+  });
 });

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -11,6 +11,8 @@ const mockHasOngoingMapRun = jest.fn();
 const mockCreateNewMapRun = jest.fn();
 const mockRetryDeferredRun = jest.fn();
 const mockIsFirstRun = jest.fn();
+const mockGetLatestUncompletedRun = jest.fn();
+const mockMarkRunDeferred = jest.fn();
 jest.mock('uuid', () => ({
   v4: jest.fn(() => `log-task-${++uuidCounter}`),
 }));
@@ -29,7 +31,12 @@ jest.mock('../../../src/main/modules/RunParser', () => ({
 }));
 jest.mock('../../../src/main/db/run', () => ({
   __esModule: true,
-  default: { insertEvent: mockInsertEvent, isFirstRun: mockIsFirstRun },
+  default: {
+    insertEvent: mockInsertEvent,
+    isFirstRun: mockIsFirstRun,
+    getLatestUncompletedRun: mockGetLatestUncompletedRun,
+    markRunDeferred: mockMarkRunDeferred,
+  },
 }));
 jest.mock('../../../src/main/SettingsManager', () => ({
   __esModule: true,
@@ -81,6 +88,8 @@ describe('LogProcessorScheduler', () => {
     mockCreateNewMapRun.mockReset().mockResolvedValue(99);
     mockRetryDeferredRun.mockReset().mockResolvedValue(true);
     mockIsFirstRun.mockReset().mockResolvedValue(false);
+    mockGetLatestUncompletedRun.mockReset().mockResolvedValue(null);
+    mockMarkRunDeferred.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(async () => {
@@ -210,6 +219,11 @@ describe('LogProcessorScheduler', () => {
     });
     mockRetryDeferredRun.mockRejectedValueOnce(new Error('deferred DB failure'));
     mockTryProcess.mockResolvedValue(true);
+    mockGetLatestUncompletedRun.mockResolvedValue({
+      id: 8,
+      first_event: '2026-07-23T10:00:00.000Z',
+      last_event: '2026-07-23T10:00:00.000Z',
+    });
     const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
 
     await expect(
@@ -220,6 +234,10 @@ describe('LogProcessorScheduler', () => {
     ).resolves.toBeUndefined();
 
     expect(mockTryProcess).not.toHaveBeenCalled();
+    expect(mockMarkRunDeferred).toHaveBeenCalledWith(
+      8,
+      '2026-07-23T11:04:10.000Z'
+    );
     expect(mockCreateNewMapRun).toHaveBeenCalledTimes(1);
   });
 

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -199,6 +199,29 @@ describe('LogProcessorScheduler', () => {
     );
   });
 
+  it('continues generation when a deferred retry throws', async () => {
+    mockGetAreaFromId.mockReturnValue({
+      name: 'Dunes Map',
+      baseLevel: 74,
+      isTown: false,
+      isHideout: false,
+      isLabyrinthAirlock: false,
+      isLabyrinthBossArea: false,
+    });
+    mockRetryDeferredRun.mockRejectedValueOnce(new Error('deferred DB failure'));
+    mockTryProcess.mockResolvedValue(true);
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+
+    await expect(
+      LogProcessor.processGeneration(
+        '2026-07-23T11:04:10.000Z',
+        'Generating level 83 area "MapWorldsDunes" with seed 123'
+      )
+    ).resolves.toBeUndefined();
+
+    expect(mockCreateNewMapRun).toHaveBeenCalledTimes(1);
+  });
+
   it('does not emit a map entry for a town', async () => {
     mockIsTown.mockReturnValue(true);
     const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -9,6 +9,7 @@ const mockIsTown = jest.fn();
 const mockGetAreaFromId = jest.fn();
 const mockHasOngoingMapRun = jest.fn();
 const mockCreateNewMapRun = jest.fn();
+const mockRetryDeferredRun = jest.fn();
 const mockIsFirstRun = jest.fn();
 jest.mock('uuid', () => ({
   v4: jest.fn(() => `log-task-${++uuidCounter}`),
@@ -23,6 +24,7 @@ jest.mock('../../../src/main/modules/RunParser', () => ({
     insertEvent: mockInsertEvent,
     hasOngoingMapRun: mockHasOngoingMapRun,
     createNewMapRun: mockCreateNewMapRun,
+    retryDeferredRun: mockRetryDeferredRun,
   },
 }));
 jest.mock('../../../src/main/db/run', () => ({
@@ -77,6 +79,7 @@ describe('LogProcessorScheduler', () => {
     mockGetAreaFromId.mockReset();
     mockHasOngoingMapRun.mockReset().mockResolvedValue(false);
     mockCreateNewMapRun.mockReset().mockResolvedValue(99);
+    mockRetryDeferredRun.mockReset().mockResolvedValue(true);
     mockIsFirstRun.mockReset().mockResolvedValue(false);
   });
 

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -2,21 +2,31 @@ let uuidCounter = 0;
 const mockTryProcess = jest.fn();
 const mockInsertEvent = jest.fn();
 const mockSaveNewTree = jest.fn();
-const mockGetInventoryCapture = jest.fn();
+const mockCaptureAndPersistInventory = jest.fn();
 const mockInsertItemsAndInventoryBaseline = jest.fn();
 const mockGetEventByQuote = jest.fn();
 const mockIsTown = jest.fn();
+const mockGetAreaFromId = jest.fn();
+const mockHasOngoingMapRun = jest.fn();
+const mockCreateNewMapRun = jest.fn();
+const mockIsFirstRun = jest.fn();
 jest.mock('uuid', () => ({
   v4: jest.fn(() => `log-task-${++uuidCounter}`),
 }));
 
 jest.mock('../../../src/main/modules/RunParser', () => ({
   __esModule: true,
-  default: { tryProcess: mockTryProcess },
+  default: {
+    tryProcess: mockTryProcess,
+    getAreaFromId: mockGetAreaFromId,
+    insertEvent: mockInsertEvent,
+    hasOngoingMapRun: mockHasOngoingMapRun,
+    createNewMapRun: mockCreateNewMapRun,
+  },
 }));
 jest.mock('../../../src/main/db/run', () => ({
   __esModule: true,
-  default: { insertEvent: mockInsertEvent },
+  default: { insertEvent: mockInsertEvent, isFirstRun: mockIsFirstRun },
 }));
 jest.mock('../../../src/main/SettingsManager', () => ({
   __esModule: true,
@@ -32,7 +42,7 @@ jest.mock('../../../src/main/modules/SkillTreeWatcher', () => ({
 }));
 jest.mock('../../../src/main/modules/InventoryGetter', () => ({
   __esModule: true,
-  default: { getInventoryCapture: mockGetInventoryCapture },
+  default: { captureAndPersistInventory: mockCaptureAndPersistInventory },
 }));
 jest.mock('../../../src/main/modules/ItemParser', () => ({
   __esModule: true,
@@ -53,13 +63,20 @@ describe('LogProcessorScheduler', () => {
     mockTryProcess.mockReset();
     mockInsertEvent.mockReset().mockResolvedValue(42);
     mockSaveNewTree.mockReset().mockResolvedValue(undefined);
-    mockGetInventoryCapture.mockReset().mockResolvedValue({
-      diff: {},
-      currentInventory: {},
-    });
+    mockCaptureAndPersistInventory.mockReset().mockImplementation(
+      async (_timestamp, persistCapture) => {
+        const capture = { diff: {}, currentInventory: {} };
+        await persistCapture(capture);
+        return capture.diff;
+      }
+    );
     mockInsertItemsAndInventoryBaseline.mockReset().mockResolvedValue(undefined);
     mockGetEventByQuote.mockReset().mockReturnValue(undefined);
     mockIsTown.mockReset();
+    mockGetAreaFromId.mockReset();
+    mockHasOngoingMapRun.mockReset().mockResolvedValue(false);
+    mockCreateNewMapRun.mockReset().mockResolvedValue(99);
+    mockIsFirstRun.mockReset().mockResolvedValue(false);
   });
 
   afterEach(async () => {
@@ -120,6 +137,33 @@ describe('LogProcessorScheduler', () => {
       reason: 'explicit-end',
       source: 'chat',
     });
+  });
+
+  it('retries automatic completion with the original generation boundary', async () => {
+    mockGetAreaFromId.mockReturnValue({
+      name: 'Dunes Map',
+      baseLevel: 74,
+      isTown: false,
+      isHideout: false,
+      isLabyrinthAirlock: false,
+      isLabyrinthBossArea: false,
+    });
+    mockTryProcess.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+
+    await LogProcessor.processGeneration(
+      '2026-07-23T11:04:10.000Z',
+      'Generating level 83 area "MapWorldsDunes" with seed 123'
+    );
+
+    expect(mockTryProcess).toHaveBeenCalledTimes(2);
+    expect(mockTryProcess).toHaveBeenNthCalledWith(1, {
+      event: { timestamp: '2026-07-23T11:04:10.000Z', server: '' },
+    });
+    expect(mockTryProcess).toHaveBeenNthCalledWith(2, {
+      event: { timestamp: '2026-07-23T11:04:10.000Z', server: '' },
+    });
+    expect(mockCreateNewMapRun).toHaveBeenCalledTimes(1);
   });
 
   it('does not emit a map entry for a town', async () => {

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -219,6 +219,7 @@ describe('LogProcessorScheduler', () => {
       )
     ).resolves.toBeUndefined();
 
+    expect(mockTryProcess).not.toHaveBeenCalled();
     expect(mockCreateNewMapRun).toHaveBeenCalledTimes(1);
   });
 

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -17,6 +17,7 @@ jest.mock('uuid', () => ({
 jest.mock('../../../src/main/modules/RunParser', () => ({
   __esModule: true,
   default: {
+    accountingDeferred: false,
     tryProcess: mockTryProcess,
     getAreaFromId: mockGetAreaFromId,
     insertEvent: mockInsertEvent,
@@ -164,6 +165,35 @@ describe('LogProcessorScheduler', () => {
       event: { timestamp: '2026-07-23T11:04:10.000Z', server: '' },
     });
     expect(mockCreateNewMapRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates the generated run after accounting retries are deferred', async () => {
+    mockGetAreaFromId.mockReturnValue({
+      name: 'Dunes Map',
+      baseLevel: 74,
+      isTown: false,
+      isHideout: false,
+      isLabyrinthAirlock: false,
+      isLabyrinthBossArea: false,
+    });
+    mockTryProcess.mockResolvedValue(false);
+    mockHasOngoingMapRun.mockResolvedValue(true);
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+    const { default: RunParser } = await import('../../../src/main/modules/RunParser');
+    RunParser.accountingDeferred = true;
+
+    await LogProcessor.processGeneration(
+      '2026-07-23T11:04:10.000Z',
+      'Generating level 83 area "MapWorldsDunes" with seed 123'
+    );
+
+    expect(mockTryProcess).toHaveBeenCalledTimes(3);
+    expect(mockCreateNewMapRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        areaId: 'MapWorldsDunes',
+        timestamp: '2026-07-23T11:04:10.000Z',
+      })
+    );
   });
 
   it('does not emit a map entry for a town', async () => {

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -2,8 +2,8 @@ let uuidCounter = 0;
 const mockTryProcess = jest.fn();
 const mockInsertEvent = jest.fn();
 const mockSaveNewTree = jest.fn();
-const mockGetInventoryDiffs = jest.fn();
-const mockInsertItems = jest.fn();
+const mockGetInventoryCapture = jest.fn();
+const mockInsertItemsAndInventoryBaseline = jest.fn();
 const mockGetEventByQuote = jest.fn();
 const mockIsTown = jest.fn();
 jest.mock('uuid', () => ({
@@ -32,11 +32,11 @@ jest.mock('../../../src/main/modules/SkillTreeWatcher', () => ({
 }));
 jest.mock('../../../src/main/modules/InventoryGetter', () => ({
   __esModule: true,
-  default: { getInventoryDiffs: mockGetInventoryDiffs },
+  default: { getInventoryCapture: mockGetInventoryCapture },
 }));
 jest.mock('../../../src/main/modules/ItemParser', () => ({
   __esModule: true,
-  default: { insertItems: mockInsertItems },
+  default: { insertItemsAndInventoryBaseline: mockInsertItemsAndInventoryBaseline },
 }));
 jest.mock('../../../src/main/modules/EventParser', () => ({
   __esModule: true,
@@ -51,10 +51,13 @@ describe('LogProcessorScheduler', () => {
   beforeEach(() => {
     uuidCounter = 0;
     mockTryProcess.mockReset();
-    mockInsertEvent.mockReset().mockResolvedValue(true);
+    mockInsertEvent.mockReset().mockResolvedValue(42);
     mockSaveNewTree.mockReset().mockResolvedValue(undefined);
-    mockGetInventoryDiffs.mockReset().mockResolvedValue(null);
-    mockInsertItems.mockReset().mockResolvedValue(undefined);
+    mockGetInventoryCapture.mockReset().mockResolvedValue({
+      diff: {},
+      currentInventory: {},
+    });
+    mockInsertItemsAndInventoryBaseline.mockReset().mockResolvedValue(undefined);
     mockGetEventByQuote.mockReset().mockReturnValue(undefined);
     mockIsTown.mockReset();
   });
@@ -148,5 +151,12 @@ describe('LogProcessorScheduler', () => {
       },
       mode: 'automatic',
     });
+    expect(mockInsertItemsAndInventoryBaseline).toHaveBeenCalledWith(
+      {},
+      '2026-07-23T11:04:10.000Z',
+      42,
+      expect.any(String),
+      {}
+    );
   });
 });

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -22,6 +22,8 @@ jest.mock('../../../src/main/db/run', () => ({
   default: {
     getLastMapGeneratedEvent: jest.fn(),
     updateLastEvent: jest.fn(),
+    insertEvent: jest.fn(),
+    getItemsBetweenEvents: jest.fn(),
   },
 }));
 jest.mock('../../../src/main/GGGAPI', () => ({
@@ -367,6 +369,45 @@ describe('RunParser', () => {
     });
   });
 
+  describe('generateItemStats', () => {
+    it('counts explicit-end items associated with a synthetic closing zone', async () => {
+      const firstZone = {
+        event_text: 'Dunes Map',
+        event_id: 1,
+        item_id: null,
+      };
+      const closingZoneItem = {
+        event_text: 'Dunes Map',
+        event_id: 2,
+        item_id: 42,
+      };
+      (RunsDB.getItemsBetweenEvents as jest.Mock).mockResolvedValue([
+        firstZone,
+        closingZoneItem,
+      ]);
+      (Utils.isTown as jest.Mock).mockReturnValue(false);
+      jest.spyOn(RunParser, 'parseItems').mockResolvedValue({
+        count: 1,
+        value: 5,
+        importantDrops: {},
+      });
+
+      await expect(
+        RunParser.generateItemStats(
+          '123',
+          '2026-07-22T09:00:00.000Z',
+          '2026-07-22T10:00:00.000Z'
+        )
+      ).resolves.toEqual({
+        count: 1,
+        value: 5,
+        importantDrops: {},
+      });
+
+      expect(RunParser.parseItems).toHaveBeenCalledWith([closingZoneItem]);
+    });
+  });
+
   describe('tryProcess completion', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
@@ -450,6 +491,12 @@ describe('RunParser', () => {
         null,
         true
       );
+      expect(RunsDB.insertEvent).toHaveBeenCalledWith({
+        event_type: 'entered',
+        event_text: 'Dunes Map',
+        timestamp: '2026-07-22T10:00:00.000Z',
+        server: '127.0.0.1:6112',
+      });
       expect(InventoryGetter.getInventoryDiffs).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z');
     });
 
@@ -470,7 +517,7 @@ describe('RunParser', () => {
 
       expect(ItemParser.insertItems).toHaveBeenCalledWith(
         inventoryDiff,
-        '2026-07-22T09:00:00.000Z'
+        '2026-07-22T10:00:00.000Z'
       );
       expect(ItemParser.insertItems.mock.invocationCallOrder[0]).toBeLessThan(
         (RunParser.processRun as jest.Mock).mock.invocationCallOrder[0]

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -81,6 +81,19 @@ jest.mock('electron-log', () => ({
 }));
 
 describe('RunParser', () => {
+  describe('getXPDiff', () => {
+    it('uses the run immediately preceding a deferred target', async () => {
+      (DB.get as jest.Mock).mockResolvedValueOnce({ xp: 100 });
+
+      await expect(RunParser.getXPDiff(145, 7)).resolves.toBe(45);
+
+      expect(DB.get).toHaveBeenCalledWith(
+        'SELECT xp FROM run WHERE id < ? ORDER BY id DESC LIMIT 1',
+        [7]
+      );
+    });
+  });
+
   describe('setLatestGeneratedArea', () => {
     afterEach(() => {
       RunParser.setLatestGeneratedArea({ run_id: 1, level: 80, depth: 0, name: '' });

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -311,7 +311,7 @@ describe('RunParser', () => {
       ]);
     });
 
-    it('propagates operational pricing failures so accounting can retry', async () => {
+    it('isolates a pricing failure to the affected item', async () => {
       (ItemPricer.price as jest.Mock).mockRejectedValueOnce(new Error('rate database unavailable'));
       const updateItemValues = jest.spyOn(RunParser, 'updateItemValues');
 
@@ -329,7 +329,7 @@ describe('RunParser', () => {
             event_id: 1,
           },
         ] as any)
-      ).rejects.toThrow('rate database unavailable');
+      ).resolves.toEqual({ count: 1, value: 0, importantDrops: {} });
 
       expect(updateItemValues).not.toHaveBeenCalled();
     });
@@ -740,6 +740,50 @@ describe('RunParser', () => {
 
       await expect(RunParser.retryDeferredRun()).resolves.toBe(true);
 
+      expect(RunParser.processRun).toHaveBeenCalledWith(
+        '2026-07-22T08:00:00.000Z',
+        5
+      );
+    });
+
+    it('retries a persisted explicit capture before processing the deferred run', async () => {
+      const inventoryDiff = { item: { id: 'item', typeLine: 'Chaos Orb' } };
+      (RunsDB.getDeferredRun as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        first_event: '2026-07-22T07:00:00.000Z',
+        last_event: '2026-07-22T08:00:00.000Z',
+        capture_required: 1,
+        closing_event_id: 42,
+      });
+      (InventoryGetter.captureAndPersistInventory as jest.Mock).mockImplementationOnce(
+        async (_timestamp, persistCapture) => {
+          await persistCapture({
+            diff: inventoryDiff,
+            currentInventory: inventoryDiff,
+          });
+          return inventoryDiff;
+        }
+      );
+      (RunParser.processRun as jest.Mock).mockResolvedValueOnce({
+        name: 'Mesa Map',
+        gained: 3,
+      });
+
+      await expect(RunParser.retryDeferredRun()).resolves.toBe(true);
+
+      expect(ItemParser.insertItemsAndInventoryBaseline).toHaveBeenCalledWith(
+        inventoryDiff,
+        '2026-07-22T08:00:00.000Z',
+        42,
+        expect.any(String),
+        inventoryDiff
+      );
+      expect(RunsDB.markRunDeferred).toHaveBeenCalledWith(
+        5,
+        '2026-07-22T08:00:00.000Z',
+        false,
+        42
+      );
       expect(RunParser.processRun).toHaveBeenCalledWith(
         '2026-07-22T08:00:00.000Z',
         5

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -371,6 +371,30 @@ describe('RunParser', () => {
       expect(ItemPricer.price).toHaveBeenCalledTimes(1);
       expect(RunParser.updateItemValues).toHaveBeenCalledWith([[3, null, 2, 1]]);
     });
+
+    it('counts items captured from the character rucksack', async () => {
+      (ItemPricer.price as jest.Mock).mockResolvedValueOnce({
+        isVendor: false,
+        value: 4,
+        explanation: null,
+      });
+
+      await expect(
+        RunParser.parseItems([
+          {
+            id: 4,
+            name: '',
+            typeline: 'Chaos Orb',
+            raw_data: JSON.stringify({
+              inventoryId: 'Rucksack',
+              baseType: 'Chaos Orb',
+            }),
+            category: 'Currency',
+            event_id: 2,
+          },
+        ] as any)
+      ).resolves.toEqual({ count: 1, value: 4, importantDrops: {} });
+    });
   });
 
   describe('getItemStats', () => {
@@ -690,6 +714,11 @@ describe('RunParser', () => {
 
       expect(RunParser.processRun).not.toHaveBeenCalled();
       expect(RunParser.resetRunData).not.toHaveBeenCalled();
+      expect(RunParser.accountingDeferred).toBe(true);
+      expect(RunParser.deferredRun).toEqual({
+        runId: 7,
+        lastEventTimestamp: '2026-07-22T10:00:00.000Z',
+      });
     });
 
     it('serializes repeated explicit completion requests', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -629,6 +629,20 @@ describe('RunParser', () => {
       ).toBeLessThan(
         (RunParser.processRun as jest.Mock).mock.invocationCallOrder[0]
       );
+      expect(RunsDB.markRunDeferred).toHaveBeenNthCalledWith(
+        1,
+        7,
+        '2026-07-22T10:00:00.000Z',
+        true,
+        42
+      );
+      expect(RunsDB.markRunDeferred).toHaveBeenNthCalledWith(
+        2,
+        7,
+        '2026-07-22T10:00:00.000Z',
+        false,
+        42
+      );
     });
 
     it('does not advance completion when final item persistence fails', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -28,6 +28,7 @@ jest.mock('../../../src/main/db/run', () => ({
     getDeferredRun: jest.fn(),
     markRunDeferred: jest.fn(),
     clearDeferredRun: jest.fn(),
+    completeDeferredCapture: jest.fn(),
   },
 }));
 jest.mock('../../../src/main/GGGAPI', () => ({
@@ -522,6 +523,7 @@ describe('RunParser', () => {
       (RunsDB.getDeferredRun as jest.Mock).mockResolvedValue(null);
       (RunsDB.markRunDeferred as jest.Mock).mockResolvedValue(undefined);
       (RunsDB.clearDeferredRun as jest.Mock).mockResolvedValue(undefined);
+      (RunsDB.completeDeferredCapture as jest.Mock).mockResolvedValue(undefined);
       (Utils.isTown as jest.Mock).mockReturnValue(false);
       (Utils.isLabArea as jest.Mock).mockReturnValue(false);
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
@@ -679,13 +681,7 @@ describe('RunParser', () => {
         true,
         42
       );
-      expect(RunsDB.markRunDeferred).toHaveBeenNthCalledWith(
-        2,
-        7,
-        '2026-07-22T10:00:00.000Z',
-        false,
-        42
-      );
+      expect(RunsDB.completeDeferredCapture).toHaveBeenCalledWith(7, 42);
     });
 
     it('does not advance completion when final item persistence fails', async () => {
@@ -715,10 +711,7 @@ describe('RunParser', () => {
       expect(RunParser.processRun).not.toHaveBeenCalled();
       expect(RunParser.resetRunData).not.toHaveBeenCalled();
       expect(RunParser.accountingDeferred).toBe(true);
-      expect(RunParser.deferredRun).toEqual({
-        runId: 7,
-        lastEventTimestamp: '2026-07-22T10:00:00.000Z',
-      });
+      expect(RunParser.deferredRun).toBeNull();
     });
 
     it('serializes repeated explicit completion requests', async () => {
@@ -840,12 +833,7 @@ describe('RunParser', () => {
         expect.any(String),
         inventoryDiff
       );
-      expect(RunsDB.markRunDeferred).toHaveBeenCalledWith(
-        5,
-        '2026-07-22T08:00:00.000Z',
-        false,
-        42
-      );
+      expect(RunsDB.completeDeferredCapture).toHaveBeenCalledWith(5, 42);
       expect(RunParser.processRun).toHaveBeenCalledWith(
         '2026-07-22T08:00:00.000Z',
         5

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -50,12 +50,14 @@ jest.mock('../../../src/main/modules/InventoryGetter', () => ({
   default: {
     getInventoryDiffs: jest.fn().mockResolvedValue({}),
     captureInventoryDiff: jest.fn().mockResolvedValue({}),
+    getInventoryCapture: jest.fn().mockResolvedValue({ diff: {}, currentInventory: {} }),
   },
 }));
 jest.mock('../../../src/main/modules/ItemParser', () => ({
   __esModule: true,
   default: {
     insertItems: jest.fn().mockResolvedValue(undefined),
+    insertItemsAndInventoryBaseline: jest.fn().mockResolvedValue(undefined),
   },
 }));
 jest.mock('../../../src/main/modules/LogProcessor', () => ({
@@ -206,6 +208,7 @@ describe('RunParser', () => {
   describe('parseItems', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
+      jest.clearAllMocks();
       (ItemPricer.price as jest.Mock)
         .mockReset()
         .mockResolvedValue({ isVendor: false, value: 0, explanation: null });
@@ -475,6 +478,7 @@ describe('RunParser', () => {
   describe('tryProcess completion', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
+      jest.clearAllMocks();
       (RunsDB.getLastMapGeneratedEvent as jest.Mock).mockResolvedValue({
         event_text: JSON.stringify({ areaName: 'Dunes Map' }),
       });
@@ -485,13 +489,11 @@ describe('RunParser', () => {
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
       (Utils.isLabTrial as jest.Mock).mockReturnValue(false);
       (InventoryGetter.getInventoryDiffs as jest.Mock).mockResolvedValue({});
-      (InventoryGetter.captureInventoryDiff as jest.Mock).mockImplementation(
-        async (_timestamp, persistDiff) => {
-          const diff = {};
-          await persistDiff(diff);
-          return diff;
-        }
-      );
+      (InventoryGetter.getInventoryCapture as jest.Mock).mockResolvedValue({
+        diff: {},
+        currentInventory: {},
+      });
+      (ItemParser.insertItemsAndInventoryBaseline as jest.Mock).mockResolvedValue(undefined);
       jest.spyOn(RunParser, 'getLatestUnusedMapEnteredEvents').mockResolvedValue([
         {
           timestamp: '2026-07-22T09:00:00.000Z',
@@ -569,20 +571,18 @@ describe('RunParser', () => {
         timestamp: '2026-07-22T10:00:00.000Z',
         server: '127.0.0.1:6112',
       });
-      expect(InventoryGetter.captureInventoryDiff).toHaveBeenCalledWith(
-        '2026-07-22T10:00:00.000Z',
-        expect.any(Function)
+      expect(InventoryGetter.getInventoryCapture).toHaveBeenCalledWith(
+        '2026-07-22T10:00:00.000Z'
       );
     });
 
     it('persists the final inventory diff before explicit completion', async () => {
       const inventoryDiff = { 'item-1': { id: 'item-1', typeLine: 'Chaos Orb' } };
-      (InventoryGetter.captureInventoryDiff as jest.Mock).mockImplementationOnce(
-        async (_timestamp, persistDiff) => {
-          await persistDiff(inventoryDiff);
-          return inventoryDiff;
-        }
-      );
+      const currentInventory = { 'item-1': inventoryDiff['item-1'] };
+      (InventoryGetter.getInventoryCapture as jest.Mock).mockResolvedValueOnce({
+        diff: inventoryDiff,
+        currentInventory,
+      });
 
       await expect(
         RunParser.tryProcess({
@@ -595,25 +595,29 @@ describe('RunParser', () => {
         })
       ).resolves.toBe(true);
 
-      expect(ItemParser.insertItems).toHaveBeenCalledWith(
+      expect(ItemParser.insertItemsAndInventoryBaseline).toHaveBeenCalledWith(
         inventoryDiff,
         '2026-07-22T10:00:00.000Z',
-        42
+        42,
+        expect.any(String),
+        currentInventory
       );
-      expect(ItemParser.insertItems.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(
+        ItemParser.insertItemsAndInventoryBaseline.mock.invocationCallOrder[0]
+      ).toBeLessThan(
         (RunParser.processRun as jest.Mock).mock.invocationCallOrder[0]
       );
     });
 
     it('does not advance completion when final item persistence fails', async () => {
       const inventoryDiff = { 'item-1': { id: 'item-1', typeLine: 'Chaos Orb' } };
-      (InventoryGetter.captureInventoryDiff as jest.Mock).mockImplementationOnce(
-        async (_timestamp, persistDiff) => {
-          await persistDiff(inventoryDiff);
-          return inventoryDiff;
-        }
+      (InventoryGetter.getInventoryCapture as jest.Mock).mockResolvedValueOnce({
+        diff: inventoryDiff,
+        currentInventory: inventoryDiff,
+      });
+      (ItemParser.insertItemsAndInventoryBaseline as jest.Mock).mockRejectedValueOnce(
+        new Error('item insert failed')
       );
-      (ItemParser.insertItems as jest.Mock).mockRejectedValueOnce(new Error('item insert failed'));
 
       await expect(
         RunParser.tryProcess({
@@ -628,6 +632,45 @@ describe('RunParser', () => {
 
       expect(RunParser.processRun).not.toHaveBeenCalled();
       expect(RunParser.resetRunData).not.toHaveBeenCalled();
+    });
+
+    it('serializes repeated explicit completion requests', async () => {
+      let releaseCapture: (() => void) | undefined;
+      (InventoryGetter.getInventoryCapture as jest.Mock).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseCapture = () => resolve({ diff: {}, currentInventory: {} });
+          })
+      );
+      (RunParser.getLatestUnusedMapEnteredEvents as jest.Mock)
+        .mockResolvedValueOnce([
+          {
+            timestamp: '2026-07-22T09:00:00.000Z',
+            area: 'Dunes Map',
+            server: '127.0.0.1:6112',
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      const request = {
+        event: {
+          timestamp: '2026-07-22T10:00:00.000Z',
+          server: '127.0.0.1:6112',
+        },
+        reason: 'explicit-end' as const,
+        source: 'shortcut' as const,
+      };
+
+      const first = RunParser.tryProcess(request);
+      const second = RunParser.tryProcess(request);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(RunsDB.insertEvent).toHaveBeenCalledTimes(1);
+      releaseCapture?.();
+
+      await expect(Promise.all([first, second])).resolves.toEqual([true, false]);
+      expect(RunsDB.insertEvent).toHaveBeenCalledTimes(1);
+      expect(ItemParser.insertItemsAndInventoryBaseline).toHaveBeenCalledTimes(1);
+      expect(RunParser.processRun).toHaveBeenCalledTimes(1);
     });
 
     it('leaves the run open when item accounting is not ready', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -24,6 +24,7 @@ jest.mock('../../../src/main/db/run', () => ({
     updateLastEvent: jest.fn(),
     insertEvent: jest.fn(),
     getItemsBetweenEvents: jest.fn(),
+    getLatestUncompletedRun: jest.fn(),
   },
 }));
 jest.mock('../../../src/main/GGGAPI', () => ({
@@ -210,6 +211,7 @@ describe('RunParser', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
       jest.clearAllMocks();
+      RunParser.deferredRun = null;
       (ItemPricer.price as jest.Mock)
         .mockReset()
         .mockResolvedValue({ isVendor: false, value: 0, explanation: null });
@@ -485,6 +487,11 @@ describe('RunParser', () => {
       });
       (RunsDB.updateLastEvent as jest.Mock).mockResolvedValue(undefined);
       (RunsDB.insertEvent as jest.Mock).mockResolvedValue(42);
+      (RunsDB.getLatestUncompletedRun as jest.Mock).mockResolvedValue({
+        id: 7,
+        first_event: '2026-07-22T09:00:00.000Z',
+        last_event: '2026-07-22T10:00:00.000Z',
+      });
       (Utils.isTown as jest.Mock).mockReturnValue(false);
       (Utils.isLabArea as jest.Mock).mockReturnValue(false);
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
@@ -547,7 +554,7 @@ describe('RunParser', () => {
       expect(ItemParser.insertItems).not.toHaveBeenCalled();
       expect(RunParser.processRun).toHaveBeenCalledWith(
         '2026-07-22T10:00:00.000Z',
-        null,
+        7,
         false
       );
     });
@@ -566,7 +573,7 @@ describe('RunParser', () => {
 
       expect(RunParser.processRun).toHaveBeenCalledWith(
         '2026-07-22T10:00:00.000Z',
-        null,
+        7,
         true
       );
       expect(RunsDB.insertEvent).toHaveBeenCalledWith({
@@ -686,6 +693,32 @@ describe('RunParser', () => {
       expect(RunsDB.insertEvent).toHaveBeenCalledTimes(1);
       expect(ItemParser.insertItemsAndInventoryBaseline).toHaveBeenCalledTimes(1);
       expect(RunParser.processRun).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries the exact deferred run without targeting the newer open run', async () => {
+      RunParser.deferredRun = {
+        runId: 7,
+        lastEventTimestamp: '2026-07-22T10:00:00.000Z',
+      };
+      const processedRun = {
+        name: 'Dunes Map',
+        gained: 5,
+        xp: 0,
+        kills: 0,
+        firstEvent: '2026-07-22T09:00:00.000Z',
+        lastEvent: '2026-07-22T10:00:00.000Z',
+      };
+      (RunParser.processRun as jest.Mock).mockResolvedValueOnce(processedRun);
+      const emit = jest.spyOn(RunParser.emitter, 'emit');
+
+      await expect(RunParser.retryDeferredRun()).resolves.toBe(true);
+
+      expect(RunParser.processRun).toHaveBeenCalledWith(
+        '2026-07-22T10:00:00.000Z',
+        7
+      );
+      expect(RunParser.deferredRun).toBeNull();
+      expect(emit).toHaveBeenCalledWith('run-parser:run-processed', processedRun);
     });
 
     it('leaves the run open when item accounting is not ready', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -49,6 +49,7 @@ jest.mock('../../../src/main/modules/InventoryGetter', () => ({
   __esModule: true,
   default: {
     getInventoryDiffs: jest.fn().mockResolvedValue({}),
+    captureInventoryDiff: jest.fn().mockResolvedValue({}),
   },
 }));
 jest.mock('../../../src/main/modules/ItemParser', () => ({
@@ -204,6 +205,10 @@ describe('RunParser', () => {
 
   describe('parseItems', () => {
     beforeEach(() => {
+      jest.restoreAllMocks();
+      (ItemPricer.price as jest.Mock)
+        .mockReset()
+        .mockResolvedValue({ isVendor: false, value: 0, explanation: null });
       jest.spyOn(RunParser, 'updateItemValues').mockResolvedValue();
     });
 
@@ -236,14 +241,12 @@ describe('RunParser', () => {
       expect(parsedItems).toEqual(expectedItems);
     });
 
-    it('hydrates raw item fields and keeps pricing other drops when one item fails', async () => {
+    it('hydrates raw item fields before pricing drops', async () => {
       const price = ItemPricer.price as jest.Mock;
       price
         .mockReset()
         .mockResolvedValueOnce({ isVendor: false, value: 12.5, explanation: null })
-        .mockRejectedValueOnce(
-          new TypeError("Cannot read properties of undefined (reading 'includes')")
-        )
+        .mockResolvedValueOnce({ isVendor: false, value: 0, explanation: null })
         .mockResolvedValueOnce({ isVendor: false, value: 3, explanation: null });
       const items = [
         {
@@ -297,6 +300,67 @@ describe('RunParser', () => {
         [0, null, 2, 1],
         [3, null, 3, 1],
       ]);
+    });
+
+    it('propagates operational pricing failures so accounting can retry', async () => {
+      (ItemPricer.price as jest.Mock).mockRejectedValueOnce(new Error('rate database unavailable'));
+      const updateItemValues = jest.spyOn(RunParser, 'updateItemValues');
+
+      await expect(
+        RunParser.parseItems([
+          {
+            id: 1,
+            name: '',
+            typeline: 'Chaos Orb',
+            raw_data: JSON.stringify({
+              inventoryId: 'MainInventory',
+              baseType: 'Chaos Orb',
+            }),
+            category: 'Currency',
+            event_id: 1,
+          },
+        ] as any)
+      ).rejects.toThrow('rate database unavailable');
+
+      expect(updateItemValues).not.toHaveBeenCalled();
+    });
+
+    it('skips irrecoverably malformed item rows without blocking the run', async () => {
+      (ItemPricer.price as jest.Mock).mockResolvedValueOnce({
+        isVendor: false,
+        value: 3,
+        explanation: null,
+      });
+
+      await expect(
+        RunParser.parseItems([
+          {
+            id: 1,
+            typeline: 'Broken Item',
+            raw_data: '{not-json',
+            category: null,
+            event_id: 1,
+          },
+          {
+            id: 2,
+            name: '',
+            typeline: 'Chaos Orb',
+            raw_data: JSON.stringify({
+              inventoryId: 'MainInventory',
+              baseType: 'Chaos Orb',
+            }),
+            category: 'Currency',
+            event_id: 1,
+          },
+        ] as any)
+      ).resolves.toEqual({
+        count: 1,
+        value: 3,
+        importantDrops: {},
+      });
+
+      expect(ItemPricer.price).toHaveBeenCalledTimes(1);
+      expect(RunParser.updateItemValues).toHaveBeenCalledWith([[3, null, 2, 1]]);
     });
   });
 
@@ -420,6 +484,13 @@ describe('RunParser', () => {
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
       (Utils.isLabTrial as jest.Mock).mockReturnValue(false);
       (InventoryGetter.getInventoryDiffs as jest.Mock).mockResolvedValue({});
+      (InventoryGetter.captureInventoryDiff as jest.Mock).mockImplementation(
+        async (_timestamp, persistDiff) => {
+          const diff = {};
+          await persistDiff(diff);
+          return diff;
+        }
+      );
       jest.spyOn(RunParser, 'getLatestUnusedMapEnteredEvents').mockResolvedValue([
         {
           timestamp: '2026-07-22T09:00:00.000Z',
@@ -497,12 +568,20 @@ describe('RunParser', () => {
         timestamp: '2026-07-22T10:00:00.000Z',
         server: '127.0.0.1:6112',
       });
-      expect(InventoryGetter.getInventoryDiffs).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z');
+      expect(InventoryGetter.captureInventoryDiff).toHaveBeenCalledWith(
+        '2026-07-22T10:00:00.000Z',
+        expect.any(Function)
+      );
     });
 
     it('persists the final inventory diff before explicit completion', async () => {
       const inventoryDiff = { 'item-1': { id: 'item-1', typeLine: 'Chaos Orb' } };
-      (InventoryGetter.getInventoryDiffs as jest.Mock).mockResolvedValue(inventoryDiff);
+      (InventoryGetter.captureInventoryDiff as jest.Mock).mockImplementationOnce(
+        async (_timestamp, persistDiff) => {
+          await persistDiff(inventoryDiff);
+          return inventoryDiff;
+        }
+      );
 
       await expect(
         RunParser.tryProcess({
@@ -522,6 +601,31 @@ describe('RunParser', () => {
       expect(ItemParser.insertItems.mock.invocationCallOrder[0]).toBeLessThan(
         (RunParser.processRun as jest.Mock).mock.invocationCallOrder[0]
       );
+    });
+
+    it('does not advance completion when final item persistence fails', async () => {
+      const inventoryDiff = { 'item-1': { id: 'item-1', typeLine: 'Chaos Orb' } };
+      (InventoryGetter.captureInventoryDiff as jest.Mock).mockImplementationOnce(
+        async (_timestamp, persistDiff) => {
+          await persistDiff(inventoryDiff);
+          return inventoryDiff;
+        }
+      );
+      (ItemParser.insertItems as jest.Mock).mockRejectedValueOnce(new Error('item insert failed'));
+
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6112',
+          },
+          reason: 'explicit-end',
+          source: 'shortcut',
+        })
+      ).resolves.toBe(false);
+
+      expect(RunParser.processRun).not.toHaveBeenCalled();
+      expect(RunParser.resetRunData).not.toHaveBeenCalled();
     });
 
     it('leaves the run open when item accounting is not ready', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -25,6 +25,7 @@ jest.mock('../../../src/main/db/run', () => ({
     insertEvent: jest.fn(),
     getItemsBetweenEvents: jest.fn(),
     getLatestUncompletedRun: jest.fn(),
+    getOldestDeferredRun: jest.fn(),
   },
 }));
 jest.mock('../../../src/main/GGGAPI', () => ({
@@ -492,6 +493,7 @@ describe('RunParser', () => {
         first_event: '2026-07-22T09:00:00.000Z',
         last_event: '2026-07-22T10:00:00.000Z',
       });
+      (RunsDB.getOldestDeferredRun as jest.Mock).mockResolvedValue(null);
       (Utils.isTown as jest.Mock).mockReturnValue(false);
       (Utils.isLabArea as jest.Mock).mockReturnValue(false);
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
@@ -719,6 +721,25 @@ describe('RunParser', () => {
       );
       expect(RunParser.deferredRun).toBeNull();
       expect(emit).toHaveBeenCalledWith('run-parser:run-processed', processedRun);
+    });
+
+    it('recovers a deferred retry target from persisted uncompleted runs', async () => {
+      (RunsDB.getOldestDeferredRun as jest.Mock).mockResolvedValueOnce({
+        id: 5,
+        first_event: '2026-07-22T07:00:00.000Z',
+        last_event: '2026-07-22T08:00:00.000Z',
+      });
+      (RunParser.processRun as jest.Mock).mockResolvedValueOnce({
+        name: 'Mesa Map',
+        gained: 3,
+      });
+
+      await expect(RunParser.retryDeferredRun()).resolves.toBe(true);
+
+      expect(RunParser.processRun).toHaveBeenCalledWith(
+        '2026-07-22T08:00:00.000Z',
+        5
+      );
     });
 
     it('leaves the run open when item accounting is not ready', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -51,6 +51,7 @@ jest.mock('../../../src/main/modules/InventoryGetter', () => ({
     getInventoryDiffs: jest.fn().mockResolvedValue({}),
     captureInventoryDiff: jest.fn().mockResolvedValue({}),
     getInventoryCapture: jest.fn().mockResolvedValue({ diff: {}, currentInventory: {} }),
+    captureAndPersistInventory: jest.fn().mockResolvedValue({}),
   },
 }));
 jest.mock('../../../src/main/modules/ItemParser', () => ({
@@ -489,10 +490,13 @@ describe('RunParser', () => {
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
       (Utils.isLabTrial as jest.Mock).mockReturnValue(false);
       (InventoryGetter.getInventoryDiffs as jest.Mock).mockResolvedValue({});
-      (InventoryGetter.getInventoryCapture as jest.Mock).mockResolvedValue({
-        diff: {},
-        currentInventory: {},
-      });
+      (InventoryGetter.captureAndPersistInventory as jest.Mock).mockImplementation(
+        async (_timestamp, persistCapture) => {
+          const capture = { diff: {}, currentInventory: {} };
+          await persistCapture(capture);
+          return capture.diff;
+        }
+      );
       (ItemParser.insertItemsAndInventoryBaseline as jest.Mock).mockResolvedValue(undefined);
       jest.spyOn(RunParser, 'getLatestUnusedMapEnteredEvents').mockResolvedValue([
         {
@@ -571,18 +575,23 @@ describe('RunParser', () => {
         timestamp: '2026-07-22T10:00:00.000Z',
         server: '127.0.0.1:6112',
       });
-      expect(InventoryGetter.getInventoryCapture).toHaveBeenCalledWith(
-        '2026-07-22T10:00:00.000Z'
+      expect(InventoryGetter.captureAndPersistInventory).toHaveBeenCalledWith(
+        '2026-07-22T10:00:00.000Z',
+        expect.any(Function),
+        true
       );
     });
 
     it('persists the final inventory diff before explicit completion', async () => {
       const inventoryDiff = { 'item-1': { id: 'item-1', typeLine: 'Chaos Orb' } };
       const currentInventory = { 'item-1': inventoryDiff['item-1'] };
-      (InventoryGetter.getInventoryCapture as jest.Mock).mockResolvedValueOnce({
-        diff: inventoryDiff,
-        currentInventory,
-      });
+      (InventoryGetter.captureAndPersistInventory as jest.Mock).mockImplementationOnce(
+        async (_timestamp, persistCapture) => {
+          const capture = { diff: inventoryDiff, currentInventory };
+          await persistCapture(capture);
+          return inventoryDiff;
+        }
+      );
 
       await expect(
         RunParser.tryProcess({
@@ -611,10 +620,13 @@ describe('RunParser', () => {
 
     it('does not advance completion when final item persistence fails', async () => {
       const inventoryDiff = { 'item-1': { id: 'item-1', typeLine: 'Chaos Orb' } };
-      (InventoryGetter.getInventoryCapture as jest.Mock).mockResolvedValueOnce({
-        diff: inventoryDiff,
-        currentInventory: inventoryDiff,
-      });
+      (InventoryGetter.captureAndPersistInventory as jest.Mock).mockImplementationOnce(
+        async (_timestamp, persistCapture) => {
+          const capture = { diff: inventoryDiff, currentInventory: inventoryDiff };
+          await persistCapture(capture);
+          return inventoryDiff;
+        }
+      );
       (ItemParser.insertItemsAndInventoryBaseline as jest.Mock).mockRejectedValueOnce(
         new Error('item insert failed')
       );
@@ -636,10 +648,13 @@ describe('RunParser', () => {
 
     it('serializes repeated explicit completion requests', async () => {
       let releaseCapture: (() => void) | undefined;
-      (InventoryGetter.getInventoryCapture as jest.Mock).mockImplementationOnce(
-        () =>
+      (InventoryGetter.captureAndPersistInventory as jest.Mock).mockImplementationOnce(
+        (_timestamp, persistCapture) =>
           new Promise((resolve) => {
-            releaseCapture = () => resolve({ diff: {}, currentInventory: {} });
+            releaseCapture = async () => {
+              await persistCapture({ diff: {}, currentInventory: {} });
+              resolve({});
+            };
           })
       );
       (RunParser.getLatestUnusedMapEnteredEvents as jest.Mock)

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -705,6 +705,7 @@ describe('RunParser', () => {
 
       expect(emit).not.toHaveBeenCalledWith('run-parser:run-processed', expect.anything());
       expect(RunParser.resetRunData).not.toHaveBeenCalled();
+      expect(RunParser.accountingDeferred).toBe(true);
     });
 
     it('retains special-zone safeguards for explicit completion', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -479,6 +479,7 @@ describe('RunParser', () => {
         event_text: JSON.stringify({ areaName: 'Dunes Map' }),
       });
       (RunsDB.updateLastEvent as jest.Mock).mockResolvedValue(undefined);
+      (RunsDB.insertEvent as jest.Mock).mockResolvedValue(42);
       (Utils.isTown as jest.Mock).mockReturnValue(false);
       (Utils.isLabArea as jest.Mock).mockReturnValue(false);
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
@@ -596,7 +597,8 @@ describe('RunParser', () => {
 
       expect(ItemParser.insertItems).toHaveBeenCalledWith(
         inventoryDiff,
-        '2026-07-22T10:00:00.000Z'
+        '2026-07-22T10:00:00.000Z',
+        42
       );
       expect(ItemParser.insertItems.mock.invocationCallOrder[0]).toBeLessThan(
         (RunParser.processRun as jest.Mock).mock.invocationCallOrder[0]

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -7,6 +7,9 @@ import Utils from '../../../src/main/modules/Utils';
 import { get } from '../../../src/main/db/settings';
 import logger from 'electron-log';
 import RunsDB from '../../../src/main/db/run';
+import ItemPricer from '../../../src/main/modules/ItemPricer';
+import InventoryGetter from '../../../src/main/modules/InventoryGetter';
+import ItemParser from '../../../src/main/modules/ItemParser';
 
 jest.mock('../../../src/main/db', () => ({
   get: jest.fn(),
@@ -34,10 +37,23 @@ jest.mock('../../../src/main/modules/Utils', () => ({
     isLabArea: jest.fn(),
     isVaalArea: jest.fn(),
     isLabTrial: jest.fn(),
+    sleep: jest.fn().mockResolvedValue(undefined),
   },
 }));
 jest.mock('../../../src/main/modules/ItemPricer', () => ({
   price: jest.fn().mockReturnValue(Promise.resolve({ value: 0, count: 0, importantDrops: {} })),
+}));
+jest.mock('../../../src/main/modules/InventoryGetter', () => ({
+  __esModule: true,
+  default: {
+    getInventoryDiffs: jest.fn().mockResolvedValue({}),
+  },
+}));
+jest.mock('../../../src/main/modules/ItemParser', () => ({
+  __esModule: true,
+  default: {
+    insertItems: jest.fn().mockResolvedValue(undefined),
+  },
 }));
 jest.mock('../../../src/main/modules/LogProcessor', () => ({
   __esModule: true,
@@ -50,6 +66,7 @@ jest.mock('electron-log', () => ({
   scope: jest.fn(),
   debug: jest.fn(),
   error: jest.fn(),
+  warn: jest.fn(),
 }));
 
 describe('RunParser', () => {
@@ -216,9 +233,77 @@ describe('RunParser', () => {
       const parsedItems = await RunParser.parseItems(items);
       expect(parsedItems).toEqual(expectedItems);
     });
+
+    it('hydrates raw item fields and keeps pricing other drops when one item fails', async () => {
+      const price = ItemPricer.price as jest.Mock;
+      price
+        .mockReset()
+        .mockResolvedValueOnce({ isVendor: false, value: 12.5, explanation: null })
+        .mockRejectedValueOnce(
+          new TypeError("Cannot read properties of undefined (reading 'includes')")
+        )
+        .mockResolvedValueOnce({ isVendor: false, value: 3, explanation: null });
+      const items = [
+        {
+          id: 1,
+          name: '',
+          typeline: 'Agate Amulet',
+          raw_data: JSON.stringify({
+            inventoryId: 'MainInventory',
+            baseType: 'Agate Amulet',
+          }),
+          category: 'Amulets',
+          event_id: 1,
+        },
+        {
+          id: 2,
+          name: '',
+          typeline: 'Unknown Item',
+          raw_data: JSON.stringify({ inventoryId: 'MainInventory' }),
+          category: null,
+          event_id: 1,
+        },
+        {
+          id: 3,
+          name: '',
+          typeline: 'Chaos Orb',
+          raw_data: JSON.stringify({
+            inventoryId: 'MainInventory',
+            baseType: 'Chaos Orb',
+            stackSize: 3,
+          }),
+          category: 'Currency',
+          event_id: 1,
+        },
+      ];
+
+      await expect(RunParser.parseItems(items as any)).resolves.toEqual({
+        count: 3,
+        value: 15.5,
+        importantDrops: {},
+      });
+      expect(price).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ baseType: 'Agate Amulet', typeline: 'Agate Amulet' })
+      );
+      expect(price).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ baseType: 'Chaos Orb', stack_size: 3 })
+      );
+      expect(RunParser.updateItemValues).toHaveBeenCalledWith([
+        [12.5, null, 1, 1],
+        [0, null, 2, 1],
+        [3, null, 3, 1],
+      ]);
+    });
   });
 
   describe('getItemStats', () => {
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      (Utils.sleep as jest.Mock).mockClear();
+    });
+
     it('compares inventory timestamps without relying on main process dayjs setup', async () => {
       const itemStats = { count: 2, value: 12.5, importantDrops: {} };
       jest
@@ -240,6 +325,44 @@ describe('RunParser', () => {
         '2026-07-22T09:59:55.000Z'
       );
     });
+
+    it('waits for a fresh inventory snapshot before calculating profit', async () => {
+      const itemStats = { count: 2, value: 12.5, importantDrops: {} };
+      jest
+        .spyOn(RunParser, 'getLastInventoryTimestamp')
+        .mockResolvedValueOnce('2026-07-22T09:58:00.000Z')
+        .mockResolvedValueOnce('2026-07-22T10:00:00.000Z');
+      jest.spyOn(RunParser, 'generateItemStats').mockResolvedValue(itemStats);
+
+      await expect(
+        RunParser.getItemStats(
+          { run_id: 123, name: 'Dunes Map' },
+          '2026-07-22T09:00:00.000Z',
+          '2026-07-22T10:00:00.000Z'
+        )
+      ).resolves.toEqual(itemStats);
+
+      expect(Utils.sleep).toHaveBeenCalledWith(3000);
+      expect(RunParser.generateItemStats).toHaveBeenCalledTimes(1);
+    });
+
+    it('defers item accounting when the inventory stays stale', async () => {
+      jest
+        .spyOn(RunParser, 'getLastInventoryTimestamp')
+        .mockResolvedValue('2026-07-22T09:58:00.000Z');
+      const generateItemStats = jest.spyOn(RunParser, 'generateItemStats');
+
+      await expect(
+        RunParser.getItemStats(
+          { run_id: 123, name: 'Dunes Map' },
+          '2026-07-22T09:00:00.000Z',
+          '2026-07-22T10:00:00.000Z'
+        )
+      ).resolves.toBe(false);
+
+      expect(Utils.sleep).toHaveBeenCalledTimes(2);
+      expect(generateItemStats).not.toHaveBeenCalled();
+    });
   });
 
   describe('tryProcess explicit completion', () => {
@@ -253,6 +376,7 @@ describe('RunParser', () => {
       (Utils.isLabArea as jest.Mock).mockReturnValue(false);
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
       (Utils.isLabTrial as jest.Mock).mockReturnValue(false);
+      (InventoryGetter.getInventoryDiffs as jest.Mock).mockResolvedValue({});
       jest.spyOn(RunParser, 'getLatestUnusedMapEnteredEvents').mockResolvedValue([
         {
           timestamp: '2026-07-22T09:00:00.000Z',
@@ -297,6 +421,50 @@ describe('RunParser', () => {
       ).resolves.toBe(true);
 
       expect(RunParser.processRun).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z');
+      expect(InventoryGetter.getInventoryDiffs).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z');
+    });
+
+    it('persists the final inventory diff before explicit completion', async () => {
+      const inventoryDiff = { 'item-1': { id: 'item-1', typeLine: 'Chaos Orb' } };
+      (InventoryGetter.getInventoryDiffs as jest.Mock).mockResolvedValue(inventoryDiff);
+
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6112',
+          },
+          reason: 'explicit-end',
+          source: 'shortcut',
+        })
+      ).resolves.toBe(true);
+
+      expect(ItemParser.insertItems).toHaveBeenCalledWith(
+        inventoryDiff,
+        '2026-07-22T09:00:00.000Z'
+      );
+      expect(ItemParser.insertItems.mock.invocationCallOrder[0]).toBeLessThan(
+        (RunParser.processRun as jest.Mock).mock.invocationCallOrder[0]
+      );
+    });
+
+    it('leaves the run open when item accounting is not ready', async () => {
+      jest.spyOn(RunParser, 'processRun').mockResolvedValue(false);
+      const emit = jest.spyOn(RunParser.emitter, 'emit');
+
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6112',
+          },
+          reason: 'explicit-end',
+          source: 'shortcut',
+        })
+      ).resolves.toBe(false);
+
+      expect(emit).not.toHaveBeenCalledWith('run-parser:run-processed', expect.anything());
+      expect(RunParser.resetRunData).not.toHaveBeenCalled();
     });
 
     it('retains special-zone safeguards for explicit completion', async () => {

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -25,7 +25,9 @@ jest.mock('../../../src/main/db/run', () => ({
     insertEvent: jest.fn(),
     getItemsBetweenEvents: jest.fn(),
     getLatestUncompletedRun: jest.fn(),
-    getOldestDeferredRun: jest.fn(),
+    getDeferredRun: jest.fn(),
+    markRunDeferred: jest.fn(),
+    clearDeferredRun: jest.fn(),
   },
 }));
 jest.mock('../../../src/main/GGGAPI', () => ({
@@ -493,7 +495,9 @@ describe('RunParser', () => {
         first_event: '2026-07-22T09:00:00.000Z',
         last_event: '2026-07-22T10:00:00.000Z',
       });
-      (RunsDB.getOldestDeferredRun as jest.Mock).mockResolvedValue(null);
+      (RunsDB.getDeferredRun as jest.Mock).mockResolvedValue(null);
+      (RunsDB.markRunDeferred as jest.Mock).mockResolvedValue(undefined);
+      (RunsDB.clearDeferredRun as jest.Mock).mockResolvedValue(undefined);
       (Utils.isTown as jest.Mock).mockReturnValue(false);
       (Utils.isLabArea as jest.Mock).mockReturnValue(false);
       (Utils.isVaalArea as jest.Mock).mockReturnValue(false);
@@ -724,7 +728,7 @@ describe('RunParser', () => {
     });
 
     it('recovers a deferred retry target from persisted uncompleted runs', async () => {
-      (RunsDB.getOldestDeferredRun as jest.Mock).mockResolvedValueOnce({
+      (RunsDB.getDeferredRun as jest.Mock).mockResolvedValueOnce({
         id: 5,
         first_event: '2026-07-22T07:00:00.000Z',
         last_event: '2026-07-22T08:00:00.000Z',

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -304,11 +304,9 @@ describe('RunParser', () => {
       (Utils.sleep as jest.Mock).mockClear();
     });
 
-    it('compares inventory timestamps without relying on main process dayjs setup', async () => {
+    it('calculates automatic item stats without waiting for a future inventory snapshot', async () => {
       const itemStats = { count: 2, value: 12.5, importantDrops: {} };
-      jest
-        .spyOn(RunParser, 'getLastInventoryTimestamp')
-        .mockResolvedValue('2026-07-22T10:00:00.000Z');
+      const getLastInventoryTimestamp = jest.spyOn(RunParser, 'getLastInventoryTimestamp');
       jest.spyOn(RunParser, 'generateItemStats').mockResolvedValue(itemStats);
 
       await expect(
@@ -324,6 +322,8 @@ describe('RunParser', () => {
         '2026-07-22T09:00:00.000Z',
         '2026-07-22T09:59:55.000Z'
       );
+      expect(getLastInventoryTimestamp).not.toHaveBeenCalled();
+      expect(Utils.sleep).not.toHaveBeenCalled();
     });
 
     it('waits for a fresh inventory snapshot before calculating profit', async () => {
@@ -338,7 +338,8 @@ describe('RunParser', () => {
         RunParser.getItemStats(
           { run_id: 123, name: 'Dunes Map' },
           '2026-07-22T09:00:00.000Z',
-          '2026-07-22T10:00:00.000Z'
+          '2026-07-22T10:00:00.000Z',
+          true
         )
       ).resolves.toEqual(itemStats);
 
@@ -356,7 +357,8 @@ describe('RunParser', () => {
         RunParser.getItemStats(
           { run_id: 123, name: 'Dunes Map' },
           '2026-07-22T09:00:00.000Z',
-          '2026-07-22T10:00:00.000Z'
+          '2026-07-22T10:00:00.000Z',
+          true
         )
       ).resolves.toBe(false);
 
@@ -365,7 +367,7 @@ describe('RunParser', () => {
     });
   });
 
-  describe('tryProcess explicit completion', () => {
+  describe('tryProcess completion', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
       (RunsDB.getLastMapGeneratedEvent as jest.Mock).mockResolvedValue({
@@ -408,6 +410,29 @@ describe('RunParser', () => {
       expect(RunParser.processRun).not.toHaveBeenCalled();
     });
 
+    it('does not wait for or associate a future inventory snapshot during automatic completion', async () => {
+      (RunsDB.getLastMapGeneratedEvent as jest.Mock).mockResolvedValue({
+        event_text: JSON.stringify({ areaName: 'Strand Map' }),
+      });
+
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6222',
+          },
+        })
+      ).resolves.toBe(true);
+
+      expect(InventoryGetter.getInventoryDiffs).not.toHaveBeenCalled();
+      expect(ItemParser.insertItems).not.toHaveBeenCalled();
+      expect(RunParser.processRun).toHaveBeenCalledWith(
+        '2026-07-22T10:00:00.000Z',
+        null,
+        false
+      );
+    });
+
     it('completes the current run when explicitly requested in the same instance', async () => {
       await expect(
         RunParser.tryProcess({
@@ -420,7 +445,11 @@ describe('RunParser', () => {
         })
       ).resolves.toBe(true);
 
-      expect(RunParser.processRun).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z');
+      expect(RunParser.processRun).toHaveBeenCalledWith(
+        '2026-07-22T10:00:00.000Z',
+        null,
+        true
+      );
       expect(InventoryGetter.getInventoryDiffs).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z');
     });
 

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -488,7 +488,7 @@ describe('RunParser', () => {
       (RunsDB.getLastMapGeneratedEvent as jest.Mock).mockResolvedValue({
         event_text: JSON.stringify({ areaName: 'Dunes Map' }),
       });
-      (RunsDB.updateLastEvent as jest.Mock).mockResolvedValue(undefined);
+      (RunsDB.updateLastEvent as jest.Mock).mockResolvedValue(true);
       (RunsDB.insertEvent as jest.Mock).mockResolvedValue(42);
       (RunsDB.getLatestUncompletedRun as jest.Mock).mockResolvedValue({
         id: 7,
@@ -540,6 +540,25 @@ describe('RunParser', () => {
       ).resolves.toBe(false);
 
       expect(RunParser.processRun).not.toHaveBeenCalled();
+    });
+
+    it('does not process a run when its requested boundary cannot be persisted', async () => {
+      (RunsDB.updateLastEvent as jest.Mock).mockResolvedValueOnce(false);
+      (RunsDB.getLastMapGeneratedEvent as jest.Mock).mockResolvedValue({
+        event_text: JSON.stringify({ areaName: 'Strand Map' }),
+      });
+
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6222',
+          },
+        })
+      ).resolves.toBe(false);
+
+      expect(RunParser.processRun).not.toHaveBeenCalled();
+      expect(RunsDB.markRunDeferred).not.toHaveBeenCalled();
     });
 
     it('does not wait for or associate a future inventory snapshot during automatic completion', async () => {

--- a/test/renderer/AppShell.spec.tsx
+++ b/test/renderer/AppShell.spec.tsx
@@ -139,6 +139,16 @@ describe('renderer app shell smoke tests', () => {
     expect(mockElectronService.getOAuthInfo).toHaveBeenCalledTimes(1);
   });
 
+  it('does not start stash loading before redirecting an unauthenticated stash route', async () => {
+    mockElectronService.isAuthenticated.mockResolvedValue(false);
+    const stashTabStore = createStashTabStore();
+
+    renderApp('/stash', stashTabStore);
+
+    expect(await screen.findByRole('button', { name: /login with poe/i })).toBeInTheDocument();
+    expect(stashTabStore.ensureLoaded).not.toHaveBeenCalled();
+  });
+
   it('renders the main shell for authenticated launches', async () => {
     renderApp('/');
 
@@ -180,5 +190,23 @@ describe('renderer app shell smoke tests', () => {
     fireEvent.click(await screen.findByRole('tab', { name: 'Stashes' }));
 
     await waitFor(() => expect(stashTabStore.ensureLoaded).toHaveBeenCalledTimes(1));
+  });
+
+  it('offers a retry when stash loading fails from settings', async () => {
+    const stashTabStore = createStashTabStore();
+    stashTabStore.ensureLoaded
+      .mockRejectedValueOnce(new Error('stash request failed'))
+      .mockResolvedValueOnce(undefined);
+
+    renderApp('/settings', stashTabStore);
+    fireEvent.click(await screen.findByRole('tab', { name: 'Stashes' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load stash tabs.');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(stashTabStore.ensureLoaded).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.queryByText('Unable to load stash tabs.')).not.toBeInTheDocument()
+    );
   });
 });

--- a/test/renderer/AppShell.spec.tsx
+++ b/test/renderer/AppShell.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { vi } from 'vitest';
@@ -64,12 +64,23 @@ const createRunStore = () =>
     getSortedRuns: () => [],
   } as any);
 
-const renderApp = (initialEntry: string) => {
+const createStashTabStore = () =>
+  ({
+    ensureLoaded: vi.fn().mockResolvedValue(undefined),
+    flattenedStashTabs: [],
+    itemStore: {
+      getItemsForLootTable: () => [],
+    },
+    stashTabs: [],
+    trackedStashTabs: [],
+  } as any);
+
+const renderApp = (initialEntry: string, stashTabStore = createStashTabStore()) => {
   const router = createMemoryRouter(
     createAppRoutes({
       runStore: createRunStore(),
-      characterStore: {} as any,
-      stashTabStore: {} as any,
+      characterStore: { characters: [], fetchCharacters: vi.fn() } as any,
+      stashTabStore,
     }),
     {
       future: {
@@ -85,7 +96,7 @@ const renderApp = (initialEntry: string) => {
     </ThemeProvider>
   );
 
-  return router;
+  return { router, stashTabStore };
 };
 
 beforeEach(() => {
@@ -136,5 +147,23 @@ describe('renderer app shell smoke tests', () => {
     expect(screen.getByText(/Exile Diary/i)).toBeInTheDocument();
     expect(mockElectronService.refreshProfitPerHour).toHaveBeenCalledTimes(1);
     expect(mockElectronService.requestNetWorthRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads stash tabs on demand for the stash route', async () => {
+    const stashTabStore = createStashTabStore();
+
+    renderApp('/stash', stashTabStore);
+
+    await waitFor(() => expect(stashTabStore.ensureLoaded).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Stash Tabs')).toBeInTheDocument();
+  });
+
+  it('loads stash tabs when the stash settings tab is selected', async () => {
+    const stashTabStore = createStashTabStore();
+
+    renderApp('/settings', stashTabStore);
+    fireEvent.click(await screen.findByRole('tab', { name: 'Stashes' }));
+
+    await waitFor(() => expect(stashTabStore.ensureLoaded).toHaveBeenCalledTimes(1));
   });
 });

--- a/test/renderer/AppShell.spec.tsx
+++ b/test/renderer/AppShell.spec.tsx
@@ -158,6 +158,21 @@ describe('renderer app shell smoke tests', () => {
     expect(await screen.findByText('Stash Tabs')).toBeInTheDocument();
   });
 
+  it('offers an in-route retry when stash loading fails', async () => {
+    const stashTabStore = createStashTabStore();
+    stashTabStore.ensureLoaded
+      .mockRejectedValueOnce(new Error('stash request failed'))
+      .mockResolvedValueOnce(undefined);
+
+    renderApp('/stash', stashTabStore);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load stash tabs.');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(stashTabStore.ensureLoaded).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Stash Tabs')).toBeInTheDocument();
+  });
+
   it('loads stash tabs when the stash settings tab is selected', async () => {
     const stashTabStore = createStashTabStore();
 

--- a/test/renderer/RunEvent.spec.tsx
+++ b/test/renderer/RunEvent.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import RunEvent from '../../src/renderer/components/RunEvent/RunEvent';
+
+vi.mock('../../src/renderer/electron.service', () => ({
+  electronService: {
+    logger: {
+      scope: () => ({
+        info: vi.fn(),
+      }),
+    },
+  },
+}));
+
+const enteredEvent = {
+  event_type: 'entered',
+  event_text: 'Dunes',
+  timestamp: '2026-07-28T12:00:00.000Z',
+};
+
+describe('RunEvent', () => {
+  it('hides duplicate entered events without labeling them unknown', () => {
+    const { container } = render(
+      <RunEvent event={enteredEvent} runInfo={{}} previousEvent={{ ...enteredEvent }} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Unknown event type: entered')).not.toBeInTheDocument();
+  });
+
+  it('labels event types without a formatter as unknown', () => {
+    render(
+      <RunEvent
+        event={{ ...enteredEvent, event_type: 'new-event-type' }}
+        runInfo={{}}
+        previousEvent={null}
+      />
+    );
+
+    expect(screen.getByText('Unknown event type: new-event-type')).toBeInTheDocument();
+  });
+});

--- a/test/renderer/stashTabStore.spec.tsx
+++ b/test/renderer/stashTabStore.spec.tsx
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getStashTabs, logger, on } = vi.hoisted(() => {
+  const logger = {
+    error: vi.fn(),
+    info: vi.fn(),
+    scope: vi.fn(),
+  };
+  logger.scope.mockReturnValue(logger);
+  return {
+    getStashTabs: vi.fn(),
+    logger,
+    on: vi.fn(),
+  };
+});
+
+vi.mock('../../src/renderer/electron.service', () => ({
+  electronService: {
+    getStashTabs,
+    logger,
+    on,
+    saveStashTabs: vi.fn(),
+  },
+}));
+
+const { default: StashTabStore } = await import('../../src/renderer/stores/stashTabStore');
+
+describe('StashTabStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    on.mockReturnValue(vi.fn());
+  });
+
+  it('coalesces lazy loads and can retry after a failed request', async () => {
+    let rejectFirstRequest;
+    getStashTabs.mockImplementationOnce(
+      () =>
+        new Promise((resolve, reject) => {
+          rejectFirstRequest = reject;
+        })
+    );
+    const store = new StashTabStore();
+
+    const first = store.ensureLoaded();
+    const duplicate = store.ensureLoaded();
+    rejectFirstRequest(new Error('temporary API failure'));
+
+    await expect(first).rejects.toThrow('temporary API failure');
+    await expect(duplicate).rejects.toThrow('temporary API failure');
+    expect(getStashTabs).toHaveBeenCalledTimes(1);
+    expect(store.isLoading).toBe(false);
+    expect(store.hasLoaded).toBe(false);
+
+    getStashTabs.mockResolvedValueOnce({
+      stashTabs: [{ id: 'currency', name: 'Currency', tracked: true }],
+      data: { items: [], value: 42 },
+    });
+
+    await store.ensureLoaded();
+
+    expect(getStashTabs).toHaveBeenCalledTimes(2);
+    expect(store.hasLoaded).toBe(true);
+    expect(store.stashTabs).toHaveLength(1);
+    expect(store.value).toBe(42);
+  });
+});

--- a/test/renderer/stashTabStore.spec.tsx
+++ b/test/renderer/stashTabStore.spec.tsx
@@ -138,6 +138,7 @@ describe('StashTabStore', () => {
       activeProfile: { characterName: 'OtherMapper', league: 'Standard' },
     });
     const second = store.ensureLoaded();
+    await vi.waitFor(() => expect(store.stashTabs).toHaveLength(0));
     resolveFirstRequest({
       stashTabs: [{ id: 'currency', name: 'Currency', tracked: true }],
       data: { items: [], value: 42 },

--- a/test/renderer/stashTabStore.spec.tsx
+++ b/test/renderer/stashTabStore.spec.tsx
@@ -63,4 +63,28 @@ describe('StashTabStore', () => {
     expect(store.stashTabs).toHaveLength(1);
     expect(store.value).toBe(42);
   });
+
+  it('retries when the backend returns no stash tabs', async () => {
+    getStashTabs
+      .mockResolvedValueOnce({
+        stashTabs: [],
+        data: {},
+      })
+      .mockResolvedValueOnce({
+        stashTabs: [{ id: 'currency', name: 'Currency', tracked: true }],
+        data: { items: [], value: 42 },
+      });
+    const store = new StashTabStore();
+
+    await store.ensureLoaded();
+
+    expect(store.hasLoaded).toBe(false);
+    expect(getStashTabs).toHaveBeenCalledTimes(1);
+
+    await store.ensureLoaded();
+
+    expect(getStashTabs).toHaveBeenCalledTimes(2);
+    expect(store.hasLoaded).toBe(true);
+    expect(store.stashTabs).toHaveLength(1);
+  });
 });

--- a/test/renderer/stashTabStore.spec.tsx
+++ b/test/renderer/stashTabStore.spec.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getStashTabs, logger, on } = vi.hoisted(() => {
+const { getSettings, getStashTabs, logger, on } = vi.hoisted(() => {
   const logger = {
     error: vi.fn(),
     info: vi.fn(),
@@ -9,6 +9,7 @@ const { getStashTabs, logger, on } = vi.hoisted(() => {
   logger.scope.mockReturnValue(logger);
   return {
     getStashTabs: vi.fn(),
+    getSettings: vi.fn(),
     logger,
     on: vi.fn(),
   };
@@ -17,6 +18,7 @@ const { getStashTabs, logger, on } = vi.hoisted(() => {
 vi.mock('../../src/renderer/electron.service', () => ({
   electronService: {
     getStashTabs,
+    getSettings,
     logger,
     on,
     saveStashTabs: vi.fn(),
@@ -29,6 +31,9 @@ describe('StashTabStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     on.mockReturnValue(vi.fn());
+    getSettings.mockResolvedValue({
+      activeProfile: { characterName: 'Mapper', league: 'Mirage' },
+    });
   });
 
   it('coalesces lazy loads and can retry after a failed request', async () => {
@@ -43,6 +48,7 @@ describe('StashTabStore', () => {
 
     const first = store.ensureLoaded();
     const duplicate = store.ensureLoaded();
+    await vi.waitFor(() => expect(getStashTabs).toHaveBeenCalledTimes(1));
     rejectFirstRequest(new Error('temporary API failure'));
 
     await expect(first).rejects.toThrow('temporary API failure');
@@ -86,5 +92,28 @@ describe('StashTabStore', () => {
     expect(getStashTabs).toHaveBeenCalledTimes(2);
     expect(store.hasLoaded).toBe(true);
     expect(store.stashTabs).toHaveLength(1);
+  });
+
+  it('reloads and clears stale tabs when the active profile changes', async () => {
+    getStashTabs
+      .mockResolvedValueOnce({
+        stashTabs: [{ id: 'currency', name: 'Currency', tracked: true }],
+        data: { items: [], value: 42 },
+      })
+      .mockResolvedValueOnce({
+        stashTabs: [{ id: 'maps', name: 'Maps', tracked: true }],
+        data: { items: [], value: 12 },
+      });
+    const store = new StashTabStore();
+    await store.ensureLoaded();
+
+    getSettings.mockResolvedValue({
+      activeProfile: { characterName: 'OtherMapper', league: 'Standard' },
+    });
+    await store.ensureLoaded();
+
+    expect(getStashTabs).toHaveBeenCalledTimes(2);
+    expect(store.stashTabs.map((tab) => tab.id)).toEqual(['maps']);
+    expect(store.value).toBe(12);
   });
 });

--- a/test/renderer/stashTabStore.spec.tsx
+++ b/test/renderer/stashTabStore.spec.tsx
@@ -116,4 +116,37 @@ describe('StashTabStore', () => {
     expect(store.stashTabs.map((tab) => tab.id)).toEqual(['maps']);
     expect(store.value).toBe(12);
   });
+
+  it('queues a follow-up load when the profile changes during a request', async () => {
+    let resolveFirstRequest;
+    getStashTabs
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRequest = resolve;
+          })
+      )
+      .mockResolvedValueOnce({
+        stashTabs: [{ id: 'maps', name: 'Maps', tracked: true }],
+        data: { items: [], value: 12 },
+      });
+    const store = new StashTabStore();
+    const first = store.ensureLoaded();
+    await vi.waitFor(() => expect(getStashTabs).toHaveBeenCalledTimes(1));
+
+    getSettings.mockResolvedValue({
+      activeProfile: { characterName: 'OtherMapper', league: 'Standard' },
+    });
+    const second = store.ensureLoaded();
+    resolveFirstRequest({
+      stashTabs: [{ id: 'currency', name: 'Currency', tracked: true }],
+      data: { items: [], value: 42 },
+    });
+
+    await Promise.all([first, second]);
+
+    expect(getStashTabs).toHaveBeenCalledTimes(2);
+    expect(store.stashTabs.map((tab) => tab.id)).toEqual(['maps']);
+    expect(store.value).toBe(12);
+  });
 });


### PR DESCRIPTION
## What changed

- wait for a fresh inventory snapshot before completing map accounting
- persist the final explicit-end inventory diff before calculating and displaying run profit
- associate those items with the latest persisted map event, preventing null `item.event_id` inserts
- await item persistence so database errors remain in the map-completion flow
- isolate item-pricing failures so one malformed item does not zero the whole run
- load stash tabs after authentication and when the stash settings tab is opened, with deduplicated in-flight requests

## Root cause

Map completion could calculate profit before the final inventory snapshot was available. The explicit-end path also used the shortcut timestamp for inserted items, but that timestamp did not necessarily correspond to an `event` row, causing `NOT NULL constraint failed: item.event_id`. Separately, stash-tab loading was tied to startup timing and could be skipped before authentication was ready.

## Impact

Completed-map overlays should show the actual currency collected during the run, explicit completion should no longer trigger the item event constraint failure, and stash tabs should load reliably without redundant requests.

## Validation

- `npm run test:main -- --runInBand test/main/modules/RunParser.spec.ts test/main/modules/ItemParserSource.spec.ts` (22 tests)
- `npm run test:renderer -- test/renderer/AppShell.spec.tsx test/renderer/stashTabStore.spec.tsx` (5 tests)
- `npm run typecheck:main`
- `npm run typecheck:renderer`