### PR TITLE
Skip Electron postinstall in pricing workflow

### DIFF
--- a/.github/workflows/publish-poe-pricing.yml
+++ b/.github/workflows/publish-poe-pricing.yml
@@ -65,7 +65,9 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        # This Node-only publisher does not need Electron native modules. Running the
+        # root postinstall on Linux attempts to compile electron-overlay-window.
+        run: npm ci --ignore-scripts
 
       - name: Validate pricing publisher contract
         run: npm run pricing:test


### PR DESCRIPTION
## What changed

- install publisher dependencies with `npm ci --ignore-scripts`
- document why Electron native postinstall is intentionally skipped

## Why

The live pricing publication failed before its tests because the repository postinstall tried to compile `electron-overlay-window` on Ubuntu without XCB headers. The pricing publisher is Node-only and does not use Electron native modules.

## Validation

- workflow diff is limited to the dependency installation step
- the production workflow will provide the clean Ubuntu verification immediately after merge