### PR TITLE
Construct R2 SDK commands correctly

### DIFF
--- a/test/tools/poe-ninja-publisher/storage.spec.ts
+++ b/test/tools/poe-ninja-publisher/storage.spec.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from '@jest/globals';
-import { resolveR2Endpoint } from '../../../tools/poe-ninja-publisher/storage';
+import { R2StorageTarget, resolveR2Endpoint } from '../../../tools/poe-ninja-publisher/storage';
+
+class GetObjectCommand {
+  constructor(readonly input: Record<string, unknown>) {}
+}
+
+class PutObjectCommand {
+  constructor(readonly input: Record<string, unknown>) {}
+}
 
 describe('publisher R2 storage', () => {
   it('honors a configured endpoint', () => {
@@ -12,5 +20,38 @@ describe('publisher R2 storage', () => {
     expect(resolveR2Endpoint('account-id', '')).toBe(
       'https://account-id.r2.cloudflarestorage.com'
     );
+  });
+
+  it('constructs AWS SDK commands before sending them', async () => {
+    const send = jest.fn(async (command: unknown) => {
+      if (command instanceof GetObjectCommand) {
+        return {
+          Body: { transformToByteArray: async () => new Uint8Array([1, 2, 3]) },
+          ContentType: 'application/json',
+        };
+      }
+      return {};
+    });
+    const storage = new R2StorageTarget({
+      client: { send },
+      bucket: 'pricing',
+      commandFactory: { GetObjectCommand, PutObjectCommand },
+    });
+
+    await expect(storage.get('/v1/current.json')).resolves.toMatchObject({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: 'application/json',
+    });
+    await storage.put('/v1/current.json', {
+      bytes: new Uint8Array([4, 5, 6]),
+      contentType: 'application/json',
+    });
+
+    expect(send.mock.calls[0][0]).toBeInstanceOf(GetObjectCommand);
+    expect((send.mock.calls[0][0] as GetObjectCommand).input).toMatchObject({
+      Bucket: 'pricing',
+      Key: 'v1/current.json',
+    });
+    expect(send.mock.calls[1][0]).toBeInstanceOf(PutObjectCommand);
   });
 });

--- a/tools/poe-ninja-publisher/storage.ts
+++ b/tools/poe-ninja-publisher/storage.ts
@@ -38,8 +38,8 @@ export type R2StorageOptions = {
   client: S3LikeClient;
   bucket: string;
   commandFactory: {
-    GetObjectCommand(input: Record<string, unknown>): unknown;
-    PutObjectCommand(input: Record<string, unknown>): unknown;
+    GetObjectCommand: new (input: Record<string, unknown>) => unknown;
+    PutObjectCommand: new (input: Record<string, unknown>) => unknown;
   };
 };
 
@@ -48,14 +48,14 @@ export class R2StorageTarget implements PublisherStorage {
   constructor(private readonly options: R2StorageOptions) {}
   async get(key: string): Promise<StoredObject | undefined> {
     try {
-      const output: any = await this.options.client.send(this.options.commandFactory.GetObjectCommand({ Bucket: this.options.bucket, Key: normalizedKey(key) }));
+      const output: any = await this.options.client.send(new this.options.commandFactory.GetObjectCommand({ Bucket: this.options.bucket, Key: normalizedKey(key) }));
       if (!output?.Body) return undefined;
       const bytes = output.Body.transformToByteArray ? await output.Body.transformToByteArray() : new Uint8Array(await output.Body);
       return { bytes, contentType: output.ContentType, contentEncoding: output.ContentEncoding, cacheControl: output.CacheControl };
     } catch (error: any) { if (error?.name === 'NoSuchKey' || error?.$metadata?.httpStatusCode === 404) return undefined; throw error; }
   }
   async put(key: string, object: PutObject): Promise<void> {
-    await this.options.client.send(this.options.commandFactory.PutObjectCommand({ Bucket: this.options.bucket, Key: normalizedKey(key), Body: object.bytes, ContentType: object.contentType, ContentEncoding: object.contentEncoding, CacheControl: object.cacheControl, IfNoneMatch: object.ifNoneMatch }));
+    await this.options.client.send(new this.options.commandFactory.PutObjectCommand({ Bucket: this.options.bucket, Key: normalizedKey(key), Body: object.bytes, ContentType: object.contentType, ContentEncoding: object.contentEncoding, CacheControl: object.cacheControl, IfNoneMatch: object.ifNoneMatch }));
   }
 }
 


### PR DESCRIPTION
## What changed

- instantiate AWS SDK v3 `GetObjectCommand` and `PutObjectCommand` classes with `new`
- express the command factory as constructor types
- add a regression test covering R2 reads and writes

## Why

Live pricing run #3 reached R2 publication but failed because command classes were invoked as regular functions.

## Validation

- 5 publisher suites, 14 tests passed
- main TypeScript check passed
- `git diff --check` passed