### PR TITLE
Fix packaged renderer asset loading

### DIFF
--- a/src/renderer/components/Item/ItemTooltip.tsx
+++ b/src/renderer/components/Item/ItemTooltip.tsx
@@ -4,6 +4,16 @@ import Constants from '../../../helpers/constants';
 import classNames from 'classnames';
 import { getItemMods, getLegacyFrameType } from '../../../helpers/poeItemApi';
 
+const itemBackgroundUrls = import.meta.glob('../../../assets/img/itemicons/*Background*.png', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+const getItemBackgroundUrl = (influence: 'Shaper' | 'Elder', width: number, height: number) =>
+  itemBackgroundUrls[
+    `../../../assets/img/itemicons/${influence}Background${width}x${height}.png`
+  ];
+
 const hasStructuredMods = (mods: unknown): boolean =>
   Array.isArray(mods) && mods.some((mod) => mod && typeof mod === 'object');
 
@@ -586,9 +596,11 @@ const getIcon = (item) => {
   const { w: width, h: height } = rawData;
   let backgroundImage: any = null;
   if (rawData.shaper) {
-    backgroundImage = require(`../../assets/img/itemicons/ShaperBackground${width}x${height}.png`);
+    const backgroundUrl = getItemBackgroundUrl('Shaper', width, height);
+    backgroundImage = backgroundUrl ? `url("${backgroundUrl}")` : null;
   } else if (rawData.elder) {
-    backgroundImage = require(`../../assets/img/itemicons/ElderBackground${width}x${height}.png`);
+    const backgroundUrl = getItemBackgroundUrl('Elder', width, height);
+    backgroundImage = backgroundUrl ? `url("${backgroundUrl}")` : null;
   }
 
   return (

--- a/src/renderer/components/RunEvent/RunEventIcons.tsx
+++ b/src/renderer/components/RunEvent/RunEventIcons.tsx
@@ -36,6 +36,24 @@ import dayjs from 'dayjs';
 // 'Veritania, the Redeemer'
 // 'Drox, the Warlord'
 
+const shrineIconUrls = import.meta.glob('../../assets/img/shrineicons/*.png', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+const metamorphIconUrls = import.meta.glob('../../assets/img/metamorphicons/*.png', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+const getShrineIconUrl = (shrine: string) =>
+  shrineIconUrls[`../../assets/img/shrineicons/${shrine.replace(' Shrine', '')}.png`];
+
+const getMetamorphIconUrl = (organ: string) =>
+  metamorphIconUrls[
+    `../../assets/img/metamorphicons/${organ.replace(/\s+/g, '').toLowerCase()}.png`
+  ];
+
 const ConquerorsMap = {
   'Baran, the Crusader': BaranIcon,
   'Al-Hezmin, the Hunter': AlHezminIcon,
@@ -302,10 +320,11 @@ const iconMap = {
       alt: 'Contained a Metamorph Encounter',
       additionalIcons: info.metamorph
         ? Object.keys(info?.metamorph).map((organ) => {
-            const Icon = require(`../../assets/img/metamorphicons/${organ}.png`);
+            const iconUrl = getMetamorphIconUrl(organ);
+            if (!iconUrl) return null;
             return (
               <Tooltip title={`${organ} x ${info.metamorph[organ]}`}>
-                <img className="Run-Event__Mini-Icon" src={Icon} alt={organ} />
+                <img className="Run-Event__Mini-Icon" src={iconUrl} alt={organ} />
               </Tooltip>
             );
           })
@@ -326,10 +345,11 @@ const iconMap = {
       alt: `Contained ${info?.shrines?.length} Shrine${info?.shrines?.length > 1 ? 's' : ''}`,
       additionalIcons: info?.shrines?.map((shrine) => {
         if (shrine) {
-          const Icon = require(`../../assets/img/shrineicons/${shrine.replace(' Shrine', '')}.png`);
+          const iconUrl = getShrineIconUrl(shrine);
+          if (!iconUrl) return null;
           return (
             <Tooltip title={shrine}>
-              <img className="Run-Event__Mini-Icon" src={Icon} alt={shrine} />
+              <img className="Run-Event__Mini-Icon" src={iconUrl} alt={shrine} />
             </Tooltip>
           );
         } else {

--- a/test/renderer/RendererAssetSource.spec.tsx
+++ b/test/renderer/RendererAssetSource.spec.tsx
@@ -1,0 +1,21 @@
+import path from 'path';
+import { readFileSync } from 'node:fs';
+
+describe('renderer asset loading contracts', () => {
+  const readSource = (...parts: string[]) => readFileSync(path.join(process.cwd(), ...parts), 'utf8');
+
+  it('does not use CommonJS require for run event icons', () => {
+    const source = readSource('src', 'renderer', 'components', 'RunEvent', 'RunEventIcons.tsx');
+
+    expect(source).not.toContain('require(');
+    expect(source).toContain("import.meta.glob('../../assets/img/shrineicons/*.png'");
+    expect(source).toContain("import.meta.glob('../../assets/img/metamorphicons/*.png'");
+  });
+
+  it('does not use CommonJS require for item influence backgrounds', () => {
+    const source = readSource('src', 'renderer', 'components', 'Item', 'ItemTooltip.tsx');
+
+    expect(source).not.toContain('require(');
+    expect(source).toContain("import.meta.glob('../../../assets/img/itemicons/*Background*.png'");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #489 and related packaged renderer crashes caused by dynamic CommonJS asset loading.

## Changes

- Replace shrine and metamorph icon `require()` calls with Vite-native `import.meta.glob` asset maps.
- Replace Shaper/Elder tooltip background `require()` calls with Vite-native asset lookups.
- Gracefully skip missing detail assets instead of crashing the run page.
- Add renderer source contracts preventing these CommonJS lookups from returning.

## Root cause

The Electron-Vite renderer bundle does not provide a global `require`. Runs containing shrine data therefore failed during `RunEventIcons` rendering with `ReferenceError: require is not defined`.

## Validation

- Main tests: 524 passed
- Renderer tests: 36 passed
- Renderer typecheck passed
- `npm run build:app` passed