### PR TITLE
Version external API User-Agents for 1.11.8

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -7,6 +7,7 @@ This folder holds the deeper guidance that should not live in `AGENTS.md`.
 - [playbook.md](./playbook.md): request templates, verification rules, milestone checklist
 
 ## Runbooks
+- [cloudflare-oauth-worker.md](./runbooks/cloudflare-oauth-worker.md)
 - [native-module-abi-mismatch.md](./runbooks/native-module-abi-mismatch.md)
 - [single-instance-user-data-conflicts.md](./runbooks/single-instance-user-data-conflicts.md)
 - [gpu-startup-issues.md](./runbooks/gpu-startup-issues.md)

--- a/docs/ai/runbooks/cloudflare-oauth-worker.md
+++ b/docs/ai/runbooks/cloudflare-oauth-worker.md
@@ -1,0 +1,13 @@
+# Cloudflare OAuth Worker maintenance
+
+Before changing or deploying `server/cloudflare`, read the root `package.json` and use its current `version` for the OAuth User-Agent in `server/cloudflare/src/index.ts`.
+
+The User-Agent must remain in this form:
+
+```text
+OAuth exile-diary-reborn/<package.json version> (contact: quentin@devauchelle.com)
+```
+
+This applies to human and AI-assisted changes. Do not deploy a stale version. Run the Worker test and typecheck before deployment; the test compares the outbound User-Agent with `package.json.version`.
+
+Never log or expose `GGG_CLIENT_SECRET`, authorization codes, PKCE verifiers, access tokens, or refresh tokens. After deployment, verify the Wrangler version ID and complete a fresh real OAuth login rather than reusing an authorization code.

--- a/server/cloudflare/README.md
+++ b/server/cloudflare/README.md
@@ -10,6 +10,10 @@ This Worker replaces the API Gateway routes and three AWS Lambda functions curre
 
 The Worker intentionally has no database, R2 binding, or CORS policy. The desktop main process calls `/auth/token`; browsers never need to call it cross-origin.
 
+### Maintenance rule
+
+Keep the OAuth User-Agent version in `src/index.ts` aligned with the root `package.json` version. This is required for every human or AI-assisted change before deploying the Worker. Run the Worker test and typecheck first; the test fails if the User-Agent version drifts.
+
 ## Local development
 
 1. Copy `.dev.vars.example` to `.dev.vars` and fill in the real client secret.

--- a/server/cloudflare/src/index.ts
+++ b/server/cloudflare/src/index.ts
@@ -3,6 +3,8 @@ export interface Env {
 }
 
 const GGG_TOKEN_ENDPOINT = 'https://www.pathofexile.com/oauth/token';
+// Keep this version aligned with package.json. Any human or AI changing or deploying this Worker must update it to the latest desktop release.
+const GGG_OAUTH_USER_AGENT = 'OAuth exile-diary-reborn/1.11.8 (contact: quentin@devauchelle.com)';
 const PROJECT_URL = 'https://github.com/Qt-dev/exile-diary';
 const REDIRECT_URI = 'https://exilediary.com/auth/success';
 const OAUTH_SCOPE =
@@ -115,7 +117,11 @@ async function exchangeToken(request: Request, env: Env) {
 
   const upstream = await fetch(GGG_TOKEN_ENDPOINT, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': GGG_OAUTH_USER_AGENT,
+    },
     body: tokenRequest,
   });
 

--- a/server/cloudflare/test/auth-worker.test.ts
+++ b/server/cloudflare/test/auth-worker.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import worker, { type Env } from '../src/index';
 
 const env: Env = { GGG_CLIENT_SECRET: 'test-secret' };
+const packageVersion = (JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8')) as { version: string }).version;
 
 test('redirects the legacy API root to the project repository', async () => {
   const response = await worker.fetch(
@@ -43,8 +45,10 @@ test('rejects malformed token requests before they reach GGG', async () => {
 test('exchanges a form-encoded OAuth code without exposing the client secret', async () => {
   const originalFetch = globalThis.fetch;
   let upstreamBody = '';
+  let upstreamHeaders: Headers | undefined;
   globalThis.fetch = async (_input, init) => {
     upstreamBody = String(init?.body);
+    upstreamHeaders = new Headers(init?.headers);
     return new Response(
       JSON.stringify({ access_token: 'token', expires_in: 3600, username: 'account' }),
       {
@@ -68,6 +72,8 @@ test('exchanges a form-encoded OAuth code without exposing the client secret', a
     assert.equal(response.headers.get('cache-control'), 'no-store, max-age=0');
     assert.match(upstreamBody, /client_secret=test-secret/);
     assert.match(upstreamBody, /code_verifier=verifier-value/);
+    assert.equal(upstreamHeaders?.get('user-agent'), `OAuth exile-diary-reborn/${packageVersion} (contact: quentin@devauchelle.com)`);
+    assert.equal(upstreamHeaders?.get('accept'), 'application/json');
     assert.deepEqual(await response.json(), {
       access_token: 'token',
       expires_in: 3600,

--- a/src/main/pricing/poe-ninja/PoeNinjaClient.ts
+++ b/src/main/pricing/poe-ninja/PoeNinjaClient.ts
@@ -11,7 +11,9 @@ const MAX_ATTEMPTS = 3;
 const axios = setupCache(
   Axios.create({
     baseURL: 'https://poe.ninja',
-    headers: { 'User-Agent': 'Exile-Diary-Reborn/desktop (poe.ninja pricing)' },
+    headers: {
+      'User-Agent': 'Exile-Diary-Reborn/1.11.8 (poe.ninja pricing; +https://github.com/qt-dev/exile-diary)',
+    },
   }),
   {
     enabled: true,

--- a/test/main/pricing/PoeNinjaClient.spec.ts
+++ b/test/main/pricing/PoeNinjaClient.spec.ts
@@ -1,0 +1,52 @@
+const axiosRequest = jest.fn();
+const axiosCreate = jest.fn(() => axiosRequest);
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { create: axiosCreate },
+}));
+
+jest.mock('axios-cache-interceptor/dev', () => ({
+  setupCache: (client: unknown) => client,
+  buildMemoryStorage: () => ({}),
+}));
+
+jest.mock('bottleneck', () => ({
+  __esModule: true,
+  default: class FakeBottleneck {
+    constructor(_options: unknown) {}
+
+    schedule(_options: unknown, operation: () => Promise<unknown>) {
+      return operation();
+    }
+  },
+}));
+
+jest.mock('electron-log', () => ({
+  __esModule: true,
+  default: { scope: () => ({ info: jest.fn() }) },
+}));
+
+describe('PoeNinjaClient User-Agent', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    axiosRequest.mockReset();
+    axiosCreate.mockClear();
+  });
+
+  it('includes the current package version and project contact URL', async () => {
+    const packageVersion = (require('../../../package.json') as { version: string }).version;
+    axiosRequest.mockResolvedValue({ data: { lines: [] } });
+    const client = require('../../../src/main/pricing/poe-ninja/PoeNinjaClient').default;
+
+    await client.getCategory('Currency', 'Allflame');
+
+    expect(axiosCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          'User-Agent': `Exile-Diary-Reborn/${packageVersion} (poe.ninja pricing; +https://github.com/qt-dev/exile-diary)`,
+        },
+      })
+    );
+  });
+});

--- a/test/tools/poe-ninja-publisher/requester.spec.ts
+++ b/test/tools/poe-ninja-publisher/requester.spec.ts
@@ -1,14 +1,40 @@
 import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
 import { PoeNinjaRequester } from '../../../tools/poe-ninja-publisher/requester';
+
+const packageVersion = (JSON.parse(readFileSync('package.json', 'utf8')) as { version: string }).version;
 
 describe('PoeNinjaRequester', () => {
   it('uses the economy league id rather than the display name', async () => {
-    const requester = new PoeNinjaRequester(async () => ({
-      status: 200,
-      headers: new Headers(),
-      json: async () => [{ id: 'Allflame', name: 'Curse of the Allflame' }],
-    }));
+    const requestUserAgents: string[] = [];
+    const requester = new PoeNinjaRequester(async (_input, init) => {
+      requestUserAgents.push(new Headers(init?.headers).get('user-agent') ?? '');
+      return {
+        status: 200,
+        headers: new Headers(),
+        json: async () => [{ id: 'Allflame', name: 'Curse of the Allflame' }],
+      };
+    });
 
     await expect(requester.getLeagues()).resolves.toEqual(['Allflame']);
+    await requester.getCategory('Currency', 'Allflame');
+    expect(requestUserAgents).toEqual([
+      `Exile-Diary-Reborn/${packageVersion} (pricing-publisher; +https://github.com/qt-dev/exile-diary)`,
+      `Exile-Diary-Reborn/${packageVersion} (pricing-publisher; +https://github.com/qt-dev/exile-diary)`,
+    ]);
+  });
+
+  it('preserves a custom User-Agent override', async () => {
+    let requestHeaders: Headers | undefined;
+    const requester = new PoeNinjaRequester(
+      async (_input, init) => {
+        requestHeaders = new Headers(init?.headers);
+        return { status: 200, headers: new Headers(), json: async () => [] };
+      },
+      { userAgent: 'custom-agent/1.0' }
+    );
+
+    await expect(requester.getLeagues()).resolves.toEqual([]);
+    expect(requestHeaders?.get('user-agent')).toBe('custom-agent/1.0');
   });
 });

--- a/tools/poe-ninja-publisher/requester.ts
+++ b/tools/poe-ninja-publisher/requester.ts
@@ -3,6 +3,7 @@ import { buildPoeNinjaPath, type PoeNinjaCategory } from '../../src/shared/prici
 export type PublisherRequest = { status: number; headers: Headers; json(): Promise<unknown> };
 export type PublisherFetch = (input: string, init?: RequestInit) => Promise<PublisherRequest>;
 export type CategoryFetchResult = { body?: unknown; etag?: string; unchanged: boolean };
+const DEFAULT_USER_AGENT = 'Exile-Diary-Reborn/1.11.8 (pricing-publisher; +https://github.com/qt-dev/exile-diary)';
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export class PoeNinjaRequester {
@@ -21,7 +22,7 @@ export class PoeNinjaRequester {
       let failure: unknown;
       for (let attempt = 0; attempt < (this.options.maxAttempts ?? 3); attempt += 1) {
         try {
-          const response = await this.fetcher(`${this.options.baseUrl ?? 'https://poe.ninja'}${buildPoeNinjaPath(category, league)}`, { headers: { 'User-Agent': this.options.userAgent ?? 'Exile-Diary-Reborn/pricing-publisher (+https://github.com/qt-dev/exile-diary)', Accept: 'application/json', ...(etag ? { 'If-None-Match': etag } : {}) } });
+          const response = await this.fetcher(`${this.options.baseUrl ?? 'https://poe.ninja'}${buildPoeNinjaPath(category, league)}`, { headers: { 'User-Agent': this.options.userAgent ?? DEFAULT_USER_AGENT, Accept: 'application/json', ...(etag ? { 'If-None-Match': etag } : {}) } });
           if (response.status === 304) return { unchanged: true, etag };
           if (response.status >= 200 && response.status < 300) return { unchanged: false, etag: response.headers.get('etag') ?? undefined, body: await response.json() };
           if (response.status < 500 && response.status !== 429) throw new Error(`poe.ninja returned HTTP ${response.status}`);
@@ -33,7 +34,7 @@ export class PoeNinjaRequester {
   }
   async getLeagues(): Promise<string[]> {
     const result = await this.scheduled(async () => {
-      const response = await this.fetcher(`${this.options.baseUrl ?? 'https://poe.ninja'}/poe1/api/economy/leagues`, { headers: { 'User-Agent': this.options.userAgent ?? 'Exile-Diary-Reborn/pricing-publisher (+https://github.com/qt-dev/exile-diary)', Accept: 'application/json' } });
+      const response = await this.fetcher(`${this.options.baseUrl ?? 'https://poe.ninja'}/poe1/api/economy/leagues`, { headers: { 'User-Agent': this.options.userAgent ?? DEFAULT_USER_AGENT, Accept: 'application/json' } });
       if (response.status < 200 || response.status >= 300) throw new Error(`poe.ninja league query returned HTTP ${response.status}`);
       return response.json();
     });


### PR DESCRIPTION
## Summary

- Update Cloudflare OAuth, desktop poe.ninja, and pricing publisher User-Agents for release 1.11.8.
- Add project contact information to poe.ninja identifiers.
- Add package-version drift tests and maintenance guidance for human and AI-assisted Worker changes.

## Why

The OAuth Worker User-Agent was stale at 1.11.7 after the application moved to 1.11.8. The other static poe.ninja identifiers did not include a release version, making upstream diagnostics and future maintenance less reliable.

## Validation

- `npm run cloudflare:auth:test`
- `npm run cloudflare:auth:typecheck`
- `npm run test:main -- --runTestsByPath test/main/pricing/PoeNinjaClient.spec.ts`
- `npm run pricing:test -- test/tools/poe-ninja-publisher/requester.spec.ts`
- `git diff --check`

The Cloudflare Worker was deployed and safe production GET checks passed. Existing unrelated working-tree changes were not included.