### PR TITLE
Fix Kingsmarch map tracking after restart

### DIFF
--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -237,7 +237,7 @@ const LogProcessor = {
 
     // Special case for the very first run in DB
     const isFirstRun = await DB.isFirstRun();
-    // Try to process the run if it's a town or a hideout
+    // A new map generation is an authoritative boundary for the previous run.
     let hasProcessed = false;
     if (!area.isTown && !area.isHideout && !deferredRetryFailed) {
       const completionRequest = {

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1121,7 +1121,16 @@ const RunParser = {
     const lastEventTimestamp = event.timestamp;
 
     // Get all the enter events from the beginning of the latest uncompleted run
-    const mapEvents = await RunParser.getLatestUnusedMapEnteredEvents();
+    let mapEvents = await RunParser.getLatestUnusedMapEnteredEvents();
+    if (isExplicitEnd && !mapEvents.some((event) => !Utils.isTown(event.area))) {
+      const previousMapEnterEvent = await RunParser.getLastMapEnterEvent();
+      if (previousMapEnterEvent && !Utils.isTown(previousMapEnterEvent.area)) {
+        logger.info(
+          `Using previous map entry ${previousMapEnterEvent.area} for explicit completion`
+        );
+        mapEvents = [previousMapEnterEvent];
+      }
+    }
     if (mapEvents.length < 1) {
       logger.debug('No map enter events found');
       return false;

--- a/src/main/modules/areaClassification.ts
+++ b/src/main/modules/areaClassification.ts
@@ -1,6 +1,10 @@
 import Constants from '../../helpers/constants';
 
 export function isTownArea(name: string): boolean {
+  if (name === 'Kingsmarch') {
+    return false;
+  }
+
   if (Constants.townstrings.includes(name)) {
     return true;
   }

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -13,21 +13,22 @@ const mockRetryDeferredRun = jest.fn();
 const mockIsFirstRun = jest.fn();
 const mockGetLatestUncompletedRun = jest.fn();
 const mockMarkRunDeferred = jest.fn();
+const mockRunParser = {
+  accountingDeferred: false,
+  tryProcess: mockTryProcess,
+  getAreaFromId: mockGetAreaFromId,
+  insertEvent: mockInsertEvent,
+  hasOngoingMapRun: mockHasOngoingMapRun,
+  createNewMapRun: mockCreateNewMapRun,
+  retryDeferredRun: mockRetryDeferredRun,
+};
 jest.mock('uuid', () => ({
   v4: jest.fn(() => `log-task-${++uuidCounter}`),
 }));
 
 jest.mock('../../../src/main/modules/RunParser', () => ({
   __esModule: true,
-  default: {
-    accountingDeferred: false,
-    tryProcess: mockTryProcess,
-    getAreaFromId: mockGetAreaFromId,
-    insertEvent: mockInsertEvent,
-    hasOngoingMapRun: mockHasOngoingMapRun,
-    createNewMapRun: mockCreateNewMapRun,
-    retryDeferredRun: mockRetryDeferredRun,
-  },
+  default: mockRunParser,
 }));
 jest.mock('../../../src/main/db/run', () => ({
   __esModule: true,
@@ -90,11 +91,13 @@ describe('LogProcessorScheduler', () => {
     mockIsFirstRun.mockReset().mockResolvedValue(false);
     mockGetLatestUncompletedRun.mockReset().mockResolvedValue(null);
     mockMarkRunDeferred.mockReset().mockResolvedValue(undefined);
+    mockRunParser.accountingDeferred = false;
   });
 
   afterEach(async () => {
     const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
     LogProcessor.emitter.removeAllListeners('client-logs:entered-map');
+    LogProcessor.emitter.removeAllListeners('client-logs:generated-run');
   });
 
   it('keeps asynchronous client-log work in submission order', async () => {
@@ -153,6 +156,7 @@ describe('LogProcessorScheduler', () => {
   });
 
   it('retries automatic completion with the original generation boundary', async () => {
+    mockIsTown.mockReturnValue(false);
     mockGetAreaFromId.mockReturnValue({
       name: 'Dunes Map',
       baseLevel: 74,
@@ -180,6 +184,7 @@ describe('LogProcessorScheduler', () => {
   });
 
   it('creates the generated run after accounting retries are deferred', async () => {
+    mockIsTown.mockReturnValue(false);
     mockGetAreaFromId.mockReturnValue({
       name: 'Dunes Map',
       baseLevel: 74,
@@ -205,6 +210,73 @@ describe('LogProcessorScheduler', () => {
         areaId: 'MapWorldsDunes',
         timestamp: '2026-07-23T11:04:10.000Z',
       })
+    );
+  });
+
+  it('keeps the old run as the explicit-end target when restart completion lacks events', async () => {
+    mockIsTown.mockReturnValue(false);
+    mockGetAreaFromId.mockReturnValue({
+      name: 'Strand Map',
+      baseLevel: 74,
+      isTown: false,
+      isHideout: false,
+      isLabyrinthAirlock: false,
+      isLabyrinthBossArea: false,
+    });
+    mockTryProcess.mockResolvedValue(false);
+    mockHasOngoingMapRun.mockResolvedValue(true);
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+    const generatedRun = jest.fn();
+    LogProcessor.emitter.on('client-logs:generated-run', generatedRun);
+
+    await LogProcessor.processGeneration(
+      '2026-07-24T11:04:10.000Z',
+      'Generating level 83 area "MapWorldsStrand" with seed 456'
+    );
+
+    expect(mockTryProcess).toHaveBeenCalledTimes(3);
+    const completionRequest = {
+      event: { timestamp: '2026-07-24T11:04:10.000Z', server: '' },
+    };
+    expect(mockTryProcess.mock.calls).toEqual([
+      [completionRequest],
+      [completionRequest],
+      [completionRequest],
+    ]);
+    expect(mockMarkRunDeferred).not.toHaveBeenCalled();
+    expect(mockCreateNewMapRun).not.toHaveBeenCalled();
+    expect(generatedRun).not.toHaveBeenCalled();
+  });
+
+  it('tracks Kingsmarch as a map-like run', async () => {
+    mockGetAreaFromId.mockReturnValue({
+      name: 'Kingsmarch',
+      baseLevel: 1,
+      isTown: false,
+      isMapArea: false,
+      isHideout: false,
+      isLabyrinthAirlock: false,
+      isLabyrinthBossArea: false,
+    });
+    const { default: LogProcessor } = await import('../../../src/main/modules/LogProcessor');
+    const generatedRun = jest.fn();
+    LogProcessor.emitter.on('client-logs:generated-run', generatedRun);
+
+    await LogProcessor.processGeneration(
+      '2026-07-24T10:00:00.000Z',
+      'Generating level 1 area "KalguuranSettlersLeague" with seed 123'
+    );
+
+    expect(mockTryProcess).toHaveBeenCalledTimes(3);
+    expect(mockCreateNewMapRun).toHaveBeenCalledWith({
+      areaId: 'KalguuranSettlersLeague',
+      areaName: 'Kingsmarch',
+      level: '1',
+      seed: '123',
+      timestamp: '2026-07-24T10:00:00.000Z',
+    });
+    expect(generatedRun).toHaveBeenCalledWith(
+      expect.objectContaining({ areaName: 'Kingsmarch', runId: 99 })
     );
   });
 

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -76,6 +76,7 @@ jest.mock('../../../src/main/modules/LogProcessor', () => ({
 jest.mock('electron-log', () => ({
   scope: jest.fn(),
   debug: jest.fn(),
+  info: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
 }));
@@ -649,6 +650,32 @@ describe('RunParser', () => {
       expect(InventoryGetter.captureAndPersistInventory).toHaveBeenCalledWith(
         '2026-07-22T10:00:00.000Z',
         expect.any(Function),
+        true
+      );
+    });
+
+    it('uses the previous run entry when restart leaves the latest event window empty', async () => {
+      jest.spyOn(RunParser, 'getLatestUnusedMapEnteredEvents').mockResolvedValueOnce([]);
+      jest.spyOn(RunParser, 'getLastMapEnterEvent').mockResolvedValueOnce({
+        timestamp: '2026-07-22T09:00:00.000Z',
+        area: 'Kingsmarch',
+        server: '127.0.0.1:6112',
+      });
+
+      await expect(
+        RunParser.tryProcess({
+          event: {
+            timestamp: '2026-07-22T10:00:00.000Z',
+            server: '127.0.0.1:6222',
+          },
+          reason: 'explicit-end',
+          source: 'shortcut',
+        })
+      ).resolves.toBe(true);
+
+      expect(RunParser.processRun).toHaveBeenCalledWith(
+        '2026-07-22T10:00:00.000Z',
+        7,
         true
       );
     });

--- a/test/main/modules/UtilsAreaClassification.spec.ts
+++ b/test/main/modules/UtilsAreaClassification.spec.ts
@@ -1,12 +1,16 @@
 import { isTownArea } from '../../../src/main/modules/areaClassification';
 
 describe('Utils area classification', () => {
-  it.each(['Karui Shores', 'The Rogue Harbour', 'Kingsmarch'])(
+  it.each(['Karui Shores', 'The Rogue Harbour'])(
     'treats the non-map hub %s as a town',
     (area) => {
       expect(isTownArea(area)).toBe(true);
     }
   );
+
+  it('treats Kingsmarch as a map-tracked area', () => {
+    expect(isTownArea('Kingsmarch')).toBe(false);
+  });
 
   it('treats hideouts as towns for map tracking', () => {
     expect(isTownArea('Alpine Hideout')).toBe(true);


### PR DESCRIPTION
## What changed

- keep Kingsmarch classified as a map-tracked area
- preserve the existing open run when restart reconciliation has no usable current event boundary
- let explicit map-end completion fall back to the previous persisted map-enter event
- reset scheduler mock state and add regression coverage for restart recovery

## Why

After closing the app/game in Kingsmarch, restarting could leave map tracking attached to stale state. The latest run event window may be empty, causing explicit map-end to fail and subsequent map names to remain wrong until the user manually cycled areas.

The root cause was a combination of Kingsmarch being included in generic town classification and explicit completion only considering events from the latest open-run window.

## Impact

Users can send a map-end signal after restarting and close the intended open run, even when recovery must use the previous run's persisted entry. Kingsmarch continues to behave as a map.

## Validation

- `npx jest --config jest.config.js --selectProjects main --runInBand test/main/modules/LogProcessorScheduler.spec.ts test/main/modules/RunParser.spec.ts test/main/modules/UtilsAreaClassification.spec.ts` (50 tests passed)
- `npm run typecheck:main`
- `git diff --check`