### PR TITLE
Build portable artifacts in GitHub Actions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build app
-        run: npm run package:win
+        run: |
+          npm run package:win
+          npm run package:portable
       - name: Smoke packaged sidecars
         run: npm run test:packaged-sidecars
       - name: Smoke packaged renderer
@@ -33,6 +35,7 @@ jobs:
           path: |
             dist/exile-diary-reborn-setup-v${{ inputs.version }}.exe
             dist/exile-diary-reborn-setup-v${{ inputs.version }}.exe.blockmap
+            dist/exile-diary-reborn-portable-v${{ inputs.version }}.zip
             dist/latest.yml
       - name: Update release
         uses: softprops/action-gh-release@v2
@@ -43,4 +46,5 @@ jobs:
           files: |
             dist/exile-diary-reborn-setup-v${{ inputs.version }}.exe
             dist/exile-diary-reborn-setup-v${{ inputs.version }}.exe.blockmap
+            dist/exile-diary-reborn-portable-v${{ inputs.version }}.zip
             dist/latest.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build app
-        run: npm run package:win
+        run: |
+          npm run package:win
+          npm run package:portable
       - name: Smoke packaged sidecars
         run: npm run test:packaged-sidecars
       - name: Smoke packaged renderer
@@ -45,6 +47,7 @@ jobs:
           path: |
             dist/exile-diary-reborn-setup-v*.exe
             dist/exile-diary-reborn-setup-v*.exe.blockmap
+            dist/exile-diary-reborn-portable-v*.zip
             dist/latest.yml
       - name: Update release
         uses: softprops/action-gh-release@v2
@@ -53,6 +56,7 @@ jobs:
           files: |
             dist/exile-diary-reborn-setup-v*.exe
             dist/exile-diary-reborn-setup-v*.exe.blockmap
+            dist/exile-diary-reborn-portable-v*.zip
             dist/latest.yml
 
   # Build Linux

--- a/test/main/runtime/ElectronViteBuildContract.spec.ts
+++ b/test/main/runtime/ElectronViteBuildContract.spec.ts
@@ -113,7 +113,12 @@ describe('electron-vite build contract', () => {
 
       expect(workflow).toContain('npm run test:packaged-sidecars');
       expect(workflow).toContain('npm run test:packaged-renderer');
+      expect(workflow).toContain('npm run package:portable');
+      expect(workflow).toContain('exile-diary-reborn-portable-v');
       expect(workflow.indexOf('npm run package:win')).toBeLessThan(
+        workflow.indexOf('npm run test:packaged-sidecars')
+      );
+      expect(workflow.indexOf('npm run package:portable')).toBeLessThan(
         workflow.indexOf('npm run test:packaged-sidecars')
       );
       expect(workflow.indexOf('npm run test:packaged-sidecars')).toBeLessThan(


### PR DESCRIPTION
## What changed

- Run the existing `npm run package:portable` command in both Windows GitHub Actions build jobs.
- Upload and attach the versioned portable ZIP alongside the installer artifacts.
- Extend the workflow contract test to require portable packaging before artifact publication.

## Why

Windows CI previously generated only the installer, even though the repository already defines a portable ZIP packaging script.

## Validation

- Focused workflow contract test: passed (7 tests).
- Workflow artifact/state audit: passed.
- `git diff --check`: passed.

The full test suite still has an unrelated pre-existing package-version mismatch in `PoeNinjaClient.spec.ts`.