### PR TITLE
Use package version in Poe Ninja User-Agent

### DIFF
--- a/src/main/pricing/poe-ninja/PoeNinjaClient.ts
+++ b/src/main/pricing/poe-ninja/PoeNinjaClient.ts
@@ -2,6 +2,7 @@ import Axios from 'axios';
 import { buildMemoryStorage, setupCache } from 'axios-cache-interceptor/dev';
 import Bottleneck from 'bottleneck';
 import Logger from 'electron-log';
+import packageJson from '../../../../package.json';
 import { buildPoeNinjaPath, type PoeNinjaCategory } from './categoryCatalog';
 
 const logger = Logger.scope('pricing/poe-ninja');
@@ -12,7 +13,7 @@ const axios = setupCache(
   Axios.create({
     baseURL: 'https://poe.ninja',
     headers: {
-      'User-Agent': 'Exile-Diary-Reborn/1.11.8 (poe.ninja pricing; +https://github.com/qt-dev/exile-diary)',
+      'User-Agent': `Exile-Diary-Reborn/${packageJson.version} (poe.ninja pricing; +https://github.com/qt-dev/exile-diary)`,
     },
   }),
   {


### PR DESCRIPTION
## What changed

- Replace the hard-coded `1.11.8` Poe Ninja User-Agent version with `packageJson.version` from the root `package.json`.

## Why

The package version is `1.11.10`, so the stale User-Agent caused `PoeNinjaClient.spec.ts` to fail and would drift after future releases.

## Validation

- Focused PoeNinjaClient test: passed.
- `npm run typecheck:main`: passed.
- `npm run test:main`: passed — 72 suites, 525 tests.
- `git diff --check`: passed.