### PR TITLE
Fix manual inventory diff detection

### DIFF
--- a/src/main/GGGAPI.ts
+++ b/src/main/GGGAPI.ts
@@ -172,6 +172,7 @@ const request = async ({
   cacheTime = CACHE_TIME_IN_SECONDS,
   limiterId = group,
   fresh = false,
+  freshToken = undefined as string | undefined,
 }) => {
   const requestKey = `${limiterId}:${group}:${params.url}:${fresh ? 'fresh' : 'cached'}`;
   const existingRequest = inFlightRequests.get(requestKey);
@@ -198,7 +199,7 @@ const request = async ({
     }
 
     return limiter.schedule({ id: scheduledId }, async () => {
-      logger.debug('Making request to GGG API', { url: params.url, group, params });
+      logger.debug('Making request to GGG API', { url: params.url, group, fresh });
       if (fresh) {
         params.cache = { enabled: false };
       } else if (!params.cache) {
@@ -207,7 +208,11 @@ const request = async ({
           ttl: 1000 * cacheTime,
         };
       }
-      const response: any = await axios({ ...params, id: group });
+      const response: any = await axios({
+        ...params,
+        ...(freshToken ? { params: { ...(params.params ?? {}), _ed_fresh: freshToken } } : {}),
+        id: group,
+      });
 
       updateLimiterFromHeaders(limiter, response.headers);
       if (fresh) {
@@ -239,6 +244,7 @@ const getCharacterSnapshot = async (
     group: `getCharacter-${username}-${characterName}`,
     cacheTime: CHARACTER_SNAPSHOT_CACHE_TIME_IN_SECONDS,
     fresh,
+    freshToken: fresh ? uuidv4() : undefined,
   });
   return response.data.character;
 };

--- a/src/main/SettingsManager.ts
+++ b/src/main/SettingsManager.ts
@@ -79,6 +79,7 @@ const DefaultSettings = {
   runParseScreenshotEnabled: true,
   runParseShortcut: 'CommandOrControl+F10',
   screenshotShortcut: 'CommandOrControl+F8',
+  inventoryCaptureShortcut: 'CommandOrControl+F11',
   overlayToggleShortcut: 'CommandOrControl+F7',
   overlayMovementShortcut: 'CommandOrControl+F9',
   autoScreenshotOnMapEntry: {

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -691,7 +691,7 @@ const Runs = {
         LEFT JOIN item
         ON item.event_id = event.id
       WHERE
-        event_type = 'entered'
+        event_type IN ('entered', 'inventoryCapture')
         AND
           (
             DATETIME(event.timestamp) BETWEEN DATETIME(?) AND DATETIME(?)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -295,6 +295,27 @@ class MainProcess {
         logger.info('Screenshot shortcut pressed');
         ScreenshotWatcher.emitter.emit('screenshot:capture');
       },
+      triggerInventoryCapture: () => {
+        logger.info('Manual inventory capture shortcut pressed');
+        void this.runtimeBridge.runTracking
+          .captureInventory()
+          .then(({ itemCount, eventCreated }) => {
+            const suffix = eventCreated
+              ? itemCount > 0
+                ? `${itemCount} newly captured item${itemCount === 1 ? '' : 's'}.`
+                : 'Fresh inventory received; no new items detected.'
+              : 'No active run or area; inventory baseline updated without creating loot.';
+            const message = `Manual inventory capture complete. ${suffix}`;
+            logger.info(message);
+            RendererLogger.log({ messages: [{ text: message }] });
+          })
+          .catch((error) => {
+            logger.error('Manual inventory capture failed', error);
+            RendererLogger.log({
+              messages: [{ text: 'Manual inventory capture failed. Check the logs for details.', type: 'error' }],
+            });
+          });
+      },
     });
   }
 

--- a/src/main/modules/InventoryGetter.ts
+++ b/src/main/modules/InventoryGetter.ts
@@ -38,7 +38,7 @@ class InventoryGetter extends EventEmitter {
   ) {
     return this.captureAndPersistInventory(timestamp, async ({ diff, currentInventory }) => {
       await persistDiff(diff);
-      await this.updateLastInventory(currentInventory);
+      await this.updateLastInventory(currentInventory, timestamp);
     });
   }
 
@@ -68,6 +68,9 @@ class InventoryGetter extends EventEmitter {
     const previousInventory = await this.getPreviousInventory();
     const currentInventory = await this.getCurrentInventory(timestamp, requireFresh);
     const diff = this.compareInventories(previousInventory, currentInventory);
+    logger.info(
+      `Inventory capture ${timestamp}: previous=${Object.keys(previousInventory).length}, current=${Object.keys(currentInventory).length}, diff=${Object.keys(diff).length}`
+    );
     return { diff, currentInventory };
   }
 
@@ -79,25 +82,42 @@ class InventoryGetter extends EventEmitter {
     const previousKeys = Object.keys(prev);
     const currentKeys = Object.keys(curr);
     const diff: Record<string, any> = {};
+    let changedCount = 0;
+    let addedCount = 0;
+
+    const missingIds = currentKeys.filter((key) => !key || !curr[key]?.id);
+    if (missingIds.length > 0) {
+      logger.warn(`Ignoring ${missingIds.length} inventory items without stable IDs`);
+    }
 
     currentKeys.forEach((key) => {
+      if (!key || !curr[key]?.id) return;
       if (!previousKeys.includes(key)) {
         diff[key] = curr[key];
+        addedCount += 1;
       } else {
         const element = this.compareElements(prev[key], curr[key]);
         if (element) {
           diff[key] = element;
+          changedCount += 1;
         }
       }
     });
+
+    const removedCount = previousKeys.filter((key) => !currentKeys.includes(key)).length;
+    logger.debug(
+      `Inventory diff details: added=${addedCount}, changed=${changedCount}, removed=${removedCount}, identical=${Object.keys(diff).length === 0 && removedCount === 0}`
+    );
 
     return diff;
   }
 
   compareElements(prev: any, curr: any) {
-    if (prev.stackSize && curr.stackSize && curr.stackSize > prev.stackSize) {
+    const previousQuantity = this.getItemQuantity(prev);
+    const currentQuantity = this.getItemQuantity(curr);
+    if (previousQuantity !== null && currentQuantity !== null && currentQuantity > previousQuantity) {
       const adjusted = { ...curr };
-      adjusted.stackSize -= prev.stackSize;
+      adjusted.stackSize = currentQuantity - previousQuantity;
       return adjusted;
     }
 
@@ -111,11 +131,14 @@ class InventoryGetter extends EventEmitter {
   async getPreviousInventory() {
     try {
       const rows = await DB.all(
-        'SELECT timestamp, inventory FROM last_inventory ORDER BY timestamp DESC'
+        'SELECT id, timestamp, inventory FROM last_inventory ORDER BY timestamp DESC, id DESC'
       );
       if (rows.length === 0) {
         return {};
       }
+      logger.debug(
+        `Loaded inventory baseline ${rows[0].id} from ${rows[0].timestamp} (${JSON.parse(rows[0].inventory)?.length ?? Object.keys(JSON.parse(rows[0].inventory)).length} items)`
+      );
       return JSON.parse(rows[0].inventory);
     } catch (err) {
       logger.info(`Failed to get previous inventory: ${err}`);
@@ -128,6 +151,9 @@ class InventoryGetter extends EventEmitter {
       requireFresh ? { fresh: true, throwOnError: true } : undefined
     );
     const inventory = this.getInventory(data.inventory);
+    logger.info(
+      `Received ${Object.keys(inventory.mainInventory).length} inventory items from ${requireFresh ? 'fresh' : 'cached'} API request`
+    );
     this.emit('xp', timestamp, data.experience);
     this.emit('equipment', timestamp, data.equipment);
     const graftblood = GraftbloodTracker.logGraftblood(timestamp, data.equipment);
@@ -135,10 +161,8 @@ class InventoryGetter extends EventEmitter {
     return inventory.mainInventory;
   }
 
-  async updateLastInventory(data: Record<string, any>) {
+  async updateLastInventory(data: Record<string, any>, timestamp = dayjs().toISOString()) {
     const dataString = JSON.stringify(data);
-    const timestamp = dayjs().toISOString();
-
     try {
       await DB.run('INSERT INTO last_inventory(timestamp, inventory) VALUES(?, ?)', [
         timestamp,
@@ -156,7 +180,12 @@ class InventoryGetter extends EventEmitter {
     logger.debug(`Parsing inventory for ${inventory?.length} items`);
     logger.silly(inventory);
 
-    inventory?.forEach((item) => {
+    inventory?.forEach((rawItem) => {
+      const item = this.normalizeItem(rawItem);
+      if (!item?.id) {
+        logger.warn('Ignoring inventory item without a stable ID');
+        return;
+      }
       if (item.inventoryId === 'MainInventory') {
         mainInventory[item.id] = item;
       } else {
@@ -164,7 +193,9 @@ class InventoryGetter extends EventEmitter {
         equippedItems[item.id] = item;
 
         if (item.socketedItems) {
-          for (const socketedItem of item.socketedItems) {
+          for (const rawSocketedItem of item.socketedItems) {
+            const socketedItem = this.normalizeItem(rawSocketedItem);
+            if (!socketedItem?.id) continue;
             mainInventory[socketedItem.id] = socketedItem;
             equippedItems[socketedItem.id] = socketedItem;
           }
@@ -176,6 +207,17 @@ class InventoryGetter extends EventEmitter {
       mainInventory,
       equippedItems,
     };
+  }
+
+  getItemQuantity(item: any): number | null {
+    const quantity = item?.stackSize ?? item?.stacksize ?? item?.pickupStackSize;
+    return typeof quantity === 'number' && Number.isFinite(quantity) ? quantity : null;
+  }
+
+  normalizeItem(item: any) {
+    if (!item || typeof item !== 'object' || !item.id) return null;
+    const quantity = this.getItemQuantity(item);
+    return quantity === null ? { ...item } : { ...item, stackSize: quantity };
   }
 }
 

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -1011,6 +1011,40 @@ const RunParser = {
     return attempt;
   },
 
+  captureInventory: async () => {
+    const timestamp = dayjs().toISOString();
+    const currentRun = await DB.getLatestUncompletedRun();
+    const currentArea = await DB.getCurrentAreaData();
+    let eventId: number | false = false;
+    let itemCount = 0;
+    await InventoryGetter.captureAndPersistInventory(
+      timestamp,
+      async ({ diff, currentInventory }) => {
+        itemCount = Object.keys(diff).length;
+        if (currentRun && currentArea?.name) {
+          eventId = await DB.insertEvent({
+            event_type: 'inventoryCapture',
+            event_text: currentArea.name,
+            timestamp,
+          });
+        }
+        if (eventId) {
+          await ItemParser.insertItemsAndInventoryBaseline(
+            diff,
+            timestamp,
+            eventId,
+            timestamp,
+            currentInventory
+          );
+        } else {
+          await InventoryGetter.updateLastInventory(currentInventory, timestamp);
+        }
+      },
+      true
+    );
+    return { itemCount, eventCreated: !!eventId };
+  },
+
   retryDeferredRun: async () => {
     const attempt = tryProcessQueue
       .catch(() => undefined)

--- a/src/main/runtime-core/services/createRunTrackingService.ts
+++ b/src/main/runtime-core/services/createRunTrackingService.ts
@@ -10,5 +10,7 @@ export function createRunTrackingService(runParser = RunParser) {
     setCurrentMapStats: runParser.setCurrentMapStats.bind(runParser),
     tryProcess: runParser.tryProcess.bind(runParser),
     tryUpdateCurrentArea: runParser.tryUpdateCurrentArea.bind(runParser),
+    captureInventory:
+      runParser.captureInventory?.bind(runParser) ?? (async () => ({ itemCount: 0, eventCreated: false })),
   };
 }

--- a/src/main/runtime/RuntimeSidecar.ts
+++ b/src/main/runtime/RuntimeSidecar.ts
@@ -141,6 +141,7 @@ const runtimeMethodHandlers: Record<RuntimeMethodKey, (...args: any[]) => Promis
   'runTracking.tryProcess': async (payload) => runtimeCore.runTracking.tryProcess(payload),
   'runTracking.tryUpdateCurrentArea': async () => runtimeCore.runTracking.tryUpdateCurrentArea(),
   'runTracking.getLatestGeneratedArea': async () => runtimeCore.runTracking.latestGeneratedArea,
+  'runTracking.captureInventory': async () => runtimeCore.runTracking.captureInventory(),
   'pricing.getCurrencyByName': async (...args) =>
     runtimeCore.pricing.getCurrencyByName(...(args as [string, string?, string?])),
   'pricing.updateRates': async () => runtimeCore.pricing.updateRates(),

--- a/src/main/runtime/createRuntimeSidecarBridge.ts
+++ b/src/main/runtime/createRuntimeSidecarBridge.ts
@@ -61,6 +61,10 @@ export function createRuntimeSidecarBridge() {
         RuntimeSidecarClient.callRuntimeMethod<boolean>('runTracking.tryProcess', [payload]),
       tryUpdateCurrentArea: () =>
         RuntimeSidecarClient.callRuntimeMethod<boolean>('runTracking.tryUpdateCurrentArea'),
+      captureInventory: () =>
+        RuntimeSidecarClient.callRuntimeMethod<{ itemCount: number; eventCreated: boolean }>(
+          'runTracking.captureInventory'
+        ),
     },
     stats: {
       registerProfitPerHourAnnouncer: (listener: (...args: any[]) => void) => {

--- a/src/main/runtime/registerRuntimeListeners.ts
+++ b/src/main/runtime/registerRuntimeListeners.ts
@@ -298,6 +298,7 @@ function registerShortcutSensitiveSettingListeners(
   runtime.settings.registerListener('screenshots', () => reregisterShortcuts());
   runtime.settings.registerListener('runParseShortcut', () => reregisterShortcuts());
   runtime.settings.registerListener('screenshotShortcut', () => reregisterShortcuts());
+  runtime.settings.registerListener('inventoryCaptureShortcut', () => reregisterShortcuts());
   runtime.settings.registerListener('overlayToggleShortcut', () => reregisterShortcuts());
   runtime.settings.registerListener('overlayMovementShortcut', () => reregisterShortcuts());
 }

--- a/src/main/runtime/trackedRuntimeSettingKeys.ts
+++ b/src/main/runtime/trackedRuntimeSettingKeys.ts
@@ -11,6 +11,7 @@ export const trackedRuntimeSettingKeys = [
   'screenshots',
   'runParseShortcut',
   'screenshotShortcut',
+  'inventoryCaptureShortcut',
   'overlayToggleShortcut',
   'overlayMovementShortcut',
   'overlayEnabled',

--- a/src/main/shortcuts/GlobalShortcutController.ts
+++ b/src/main/shortcuts/GlobalShortcutController.ts
@@ -16,6 +16,7 @@ export type GlobalShortcutControllerDependencies = {
   toggleOverlayMovement: () => boolean;
   triggerRunParse: () => void;
   triggerScreenshot: () => void;
+  triggerInventoryCapture?: () => void;
 };
 
 export class GlobalShortcutController {
@@ -41,6 +42,10 @@ export class GlobalShortcutController {
 
   private getShortcutDefinitions(): ShortcutDefinition[] {
     const shortcuts: ShortcutDefinition[] = [
+      {
+        accelerator: this.deps.getShortcut('inventoryCaptureShortcut') || 'CommandOrControl+F11',
+        callback: () => this.deps.triggerInventoryCapture?.(),
+      },
       {
         accelerator: this.deps.getShortcut('overlayToggleShortcut') || 'CommandOrControl+F7',
         callback: () => {

--- a/src/renderer/components/Settings/HotkeySettings/HotkeySettings.tsx
+++ b/src/renderer/components/Settings/HotkeySettings/HotkeySettings.tsx
@@ -17,6 +17,9 @@ const HotkeySettings = ({ settings, revalidate }) => {
   const [screenshotShortcut, setScreenshotShortcut] = React.useState(
     settings.screenshotShortcut || 'CommandOrControl+F8'
   );
+  const [inventoryCaptureShortcut, setInventoryCaptureShortcut] = React.useState(
+    settings.inventoryCaptureShortcut || 'CommandOrControl+F11'
+  );
   const [overlayToggleShortcut, setOverlayToggleShortcut] = React.useState(
     settings.overlayToggleShortcut || 'CommandOrControl+F7'
   );
@@ -36,12 +39,14 @@ const HotkeySettings = ({ settings, revalidate }) => {
     return (
       runParseShortcut !== (settings.runParseShortcut || 'CommandOrControl+F10') ||
       screenshotShortcut !== (settings.screenshotShortcut || 'CommandOrControl+F8') ||
+      inventoryCaptureShortcut !== (settings.inventoryCaptureShortcut || 'CommandOrControl+F11') ||
       overlayToggleShortcut !== (settings.overlayToggleShortcut || 'CommandOrControl+F7') ||
       overlayMovementShortcut !== (settings.overlayMovementShortcut || 'CommandOrControl+F9')
     );
   }, [
     runParseShortcut,
     screenshotShortcut,
+    inventoryCaptureShortcut,
     overlayToggleShortcut,
     overlayMovementShortcut,
     settings,
@@ -113,6 +118,9 @@ const HotkeySettings = ({ settings, revalidate }) => {
         case 'screenshot':
           setScreenshotShortcut(formatted);
           break;
+        case 'inventoryCapture':
+          setInventoryCaptureShortcut(formatted);
+          break;
         case 'overlayToggle':
           setOverlayToggleShortcut(formatted);
           break;
@@ -141,6 +149,8 @@ const HotkeySettings = ({ settings, revalidate }) => {
         return runParseShortcut;
       case 'screenshot':
         return screenshotShortcut;
+      case 'inventoryCapture':
+        return inventoryCaptureShortcut;
       case 'overlayToggle':
         return overlayToggleShortcut;
       case 'overlayMovement':
@@ -205,6 +215,7 @@ const HotkeySettings = ({ settings, revalidate }) => {
   const handleResetShortcuts = () => {
     setRunParseShortcut('CommandOrControl+F10');
     setScreenshotShortcut('CommandOrControl+F8');
+    setInventoryCaptureShortcut('CommandOrControl+F11');
     setOverlayToggleShortcut('CommandOrControl+F7');
     setOverlayMovementShortcut('CommandOrControl+F9');
   };
@@ -213,6 +224,7 @@ const HotkeySettings = ({ settings, revalidate }) => {
     // Reset all shortcuts to original settings values
     setRunParseShortcut(settings.runParseShortcut || 'CommandOrControl+F10');
     setScreenshotShortcut(settings.screenshotShortcut || 'CommandOrControl+F8');
+    setInventoryCaptureShortcut(settings.inventoryCaptureShortcut || 'CommandOrControl+F11');
     setOverlayToggleShortcut(settings.overlayToggleShortcut || 'CommandOrControl+F7');
     setOverlayMovementShortcut(settings.overlayMovementShortcut || 'CommandOrControl+F9');
   };
@@ -223,6 +235,7 @@ const HotkeySettings = ({ settings, revalidate }) => {
     const data = {
       runParseShortcut: runParseShortcut,
       screenshotShortcut: screenshotShortcut,
+      inventoryCaptureShortcut,
       overlayToggleShortcut: overlayToggleShortcut,
       overlayMovementShortcut: overlayMovementShortcut,
     };
@@ -281,6 +294,17 @@ const HotkeySettings = ({ settings, revalidate }) => {
         </Box>
 
         <Divider />
+
+        {/* Run Completion */}
+        <Divider />
+        <Box>
+          <h4 style={{ marginBottom: '10px' }}>Inventory Capture</h4>
+          <ShortcutTextField
+            fieldName="inventoryCapture"
+            label="Capture Inventory"
+            helperText="Fetch current inventory and record newly acquired items"
+          />
+        </Box>
 
         {/* Run Completion */}
         <Box>

--- a/src/shared/contracts/runtimeSidecar.ts
+++ b/src/shared/contracts/runtimeSidecar.ts
@@ -38,6 +38,7 @@ export const runtimeMethodKeys = [
   'runTracking.tryProcess',
   'runTracking.tryUpdateCurrentArea',
   'runTracking.getLatestGeneratedArea',
+  'runTracking.captureInventory',
   'pricing.getCurrencyByName',
   'pricing.updateRates',
   'stats.triggerProfitPerHourAnnouncer',

--- a/test/main/GGGAPI.spec.ts
+++ b/test/main/GGGAPI.spec.ts
@@ -191,6 +191,7 @@ describe('GGGAPI auth gating', () => {
       expect.objectContaining({
         cache: { enabled: false },
         url: '/character/AtlasRunner',
+        params: expect.objectContaining({ _ed_fresh: expect.any(String) }),
       })
     );
     expect(removeCachedResponse).toHaveBeenCalledWith(

--- a/test/main/modules/InventoryGetter.spec.ts
+++ b/test/main/modules/InventoryGetter.spec.ts
@@ -81,7 +81,7 @@ describe('InventoryGetter capture contract', () => {
     expect(persistDiff.mock.invocationCallOrder[0]).toBeLessThan(
       updateLastInventory.mock.invocationCallOrder[0]
     );
-    expect(updateLastInventory).toHaveBeenCalledWith(currentInventory);
+    expect(updateLastInventory).toHaveBeenCalledWith(currentInventory, '2026-07-22T10:00:00.000Z');
   });
 
   it('can return the diff and current inventory without advancing the baseline', async () => {
@@ -124,5 +124,36 @@ describe('InventoryGetter capture contract', () => {
 
     expect(getInventoryCapture).toHaveBeenCalledTimes(2);
     expect(secondPersist).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects new items and normalizes legacy stack quantities', () => {
+    const diff = InventoryGetter.compareInventories(
+      {
+        stack: { id: 'stack', name: '', typeLine: 'Orb', stacksize: 3 },
+      },
+      {
+        stack: { id: 'stack', name: '', typeLine: 'Orb', stackSize: 5 },
+        newItem: { id: 'newItem', name: '', typeLine: 'Divine Orb' },
+      }
+    );
+
+    expect(diff.stack.stackSize).toBe(2);
+    expect(diff.newItem).toMatchObject({ id: 'newItem' });
+  });
+
+  it('ignores unchanged items, quantity decreases, and items without IDs', () => {
+    const diff = InventoryGetter.compareInventories(
+      {
+        unchanged: { id: 'unchanged', name: '', typeLine: 'Orb', stackSize: 5 },
+        decreased: { id: 'decreased', name: '', typeLine: 'Orb', stackSize: 5 },
+      },
+      {
+        unchanged: { id: 'unchanged', name: '', typeLine: 'Orb', stackSize: 5 },
+        decreased: { id: 'decreased', name: '', typeLine: 'Orb', stackSize: 2 },
+        missing: { name: '', typeLine: 'Unknown' },
+      }
+    );
+
+    expect(diff).toEqual({});
   });
 });

--- a/test/main/shortcuts/GlobalShortcutController.spec.ts
+++ b/test/main/shortcuts/GlobalShortcutController.spec.ts
@@ -22,6 +22,7 @@ describe('GlobalShortcutController', () => {
     const toggleOverlayMovement = jest.fn(() => true);
     const triggerRunParse = jest.fn();
     const triggerScreenshot = jest.fn();
+    const triggerInventoryCapture = jest.fn();
 
     const controller = new GlobalShortcutController({
       getShortcut: (key) =>
@@ -37,38 +38,46 @@ describe('GlobalShortcutController', () => {
       toggleOverlayMovement,
       triggerRunParse,
       triggerScreenshot,
+      triggerInventoryCapture,
     });
 
     controller.registerAll();
 
-    expect(electron.globalShortcut.register).toHaveBeenCalledTimes(4);
+    expect(electron.globalShortcut.register).toHaveBeenCalledTimes(5);
     expect(electron.globalShortcut.register).toHaveBeenNthCalledWith(
       1,
-      'Ctrl+7',
+      'CommandOrControl+F11',
       expect.any(Function)
     );
     expect(electron.globalShortcut.register).toHaveBeenNthCalledWith(
       2,
-      'Ctrl+9',
+      'Ctrl+7',
       expect.any(Function)
     );
     expect(electron.globalShortcut.register).toHaveBeenNthCalledWith(
       3,
-      'Ctrl+10',
+      'Ctrl+9',
       expect.any(Function)
     );
     expect(electron.globalShortcut.register).toHaveBeenNthCalledWith(
       4,
+      'Ctrl+10',
+      expect.any(Function)
+    );
+    expect(electron.globalShortcut.register).toHaveBeenNthCalledWith(
+      5,
       'Ctrl+8',
       expect.any(Function)
     );
 
-    const overlayToggleCallback = (electron.globalShortcut.register as jest.Mock).mock.calls[0][1];
+    const inventoryCaptureCallback = (electron.globalShortcut.register as jest.Mock).mock.calls[0][1];
+    const overlayToggleCallback = (electron.globalShortcut.register as jest.Mock).mock.calls[1][1];
     const overlayMovementCallback = (electron.globalShortcut.register as jest.Mock).mock
-      .calls[1][1];
-    const runParseCallback = (electron.globalShortcut.register as jest.Mock).mock.calls[2][1];
-    const screenshotCallback = (electron.globalShortcut.register as jest.Mock).mock.calls[3][1];
+      .calls[2][1];
+    const runParseCallback = (electron.globalShortcut.register as jest.Mock).mock.calls[3][1];
+    const screenshotCallback = (electron.globalShortcut.register as jest.Mock).mock.calls[4][1];
 
+    inventoryCaptureCallback();
     overlayToggleCallback();
     overlayMovementCallback();
     runParseCallback();
@@ -78,6 +87,7 @@ describe('GlobalShortcutController', () => {
     expect(toggleOverlayMovement).toHaveBeenCalledTimes(1);
     expect(triggerRunParse).toHaveBeenCalledTimes(1);
     expect(triggerScreenshot).toHaveBeenCalledTimes(1);
+    expect(triggerInventoryCapture).toHaveBeenCalledTimes(1);
   });
 
   it('re-registers shortcuts by clearing the old registrations first', async () => {
@@ -99,7 +109,7 @@ describe('GlobalShortcutController', () => {
     controller.reregisterAll();
 
     expect(electron.globalShortcut.unregisterAll).toHaveBeenCalledTimes(1);
-    expect(electron.globalShortcut.register).toHaveBeenCalledTimes(2);
+    expect(electron.globalShortcut.register).toHaveBeenCalledTimes(3);
   });
 
   it('reports shortcut registration conflicts', async () => {


### PR DESCRIPTION
## Summary

Fix manual inventory captures so fresh API responses are observable and inventory differences are detected reliably.

## What changed

- Add a request-level freshness token while keeping Axios caching disabled for manual captures.
- Normalize stack quantities across `stackSize`, `stacksize`, and `pickupStackSize`.
- Detect new items and stack increases while ignoring unchanged/decreased items and missing IDs.
- Make inventory baseline selection deterministic and write baselines with the capture timestamp.
- Add diagnostics for snapshot sizes and diff composition.
- Improve zero-diff overlay messaging.
- Add focused API and inventory diff tests.

## Root cause

The capture path had limited visibility into whether the fresh snapshot changed, only handled one quantity field, and selected baselines by timestamp alone. These conditions could make valid inventory changes appear as empty diffs.

## Verification

- `npm run typecheck:main`
- `npm run typecheck:renderer`
- Focused main Jest suites: 4 suites, 19 tests passed
- `git diff --check`