### PR TITLE
Fix stash tab items not appearing on initial load

### DIFF
--- a/src/main/StashTabsManager.ts
+++ b/src/main/StashTabsManager.ts
@@ -12,7 +12,7 @@ class StashTabsManager {
     return maps >= limit;
   }
 
-  async getStashData(date: string = dayjs().toISOString()): Promise<any> {
+  async getStashData(date: string = dayjs().format('YYYYMMDDHHmmss')): Promise<any> {
     const league = SettingsManager.get('activeProfile').league;
     const data = await DB.getStashData(date, league);
     const items =

--- a/src/main/runtime-core/use-cases/createRendererStashUseCases.ts
+++ b/src/main/runtime-core/use-cases/createRendererStashUseCases.ts
@@ -29,6 +29,9 @@ export function createRendererStashUseCases(deps: RendererStashUseCaseDependenci
       const trackedTabIds = trackedStashTabs?.[activeProfile.league] ?? [];
       const stashTabs = markTrackedTabs(await deps.gggApi.getAllStashTabs(), trackedTabIds);
       const stashData = await deps.stashTabsManager.getStashData();
+      logger.info(
+        `Loaded stash snapshot for the renderer: ${stashData?.items?.length ?? 0} items`
+      );
       return { stashTabs, data: stashData };
     },
 

--- a/src/renderer/routes/StashTabs.tsx
+++ b/src/renderer/routes/StashTabs.tsx
@@ -26,6 +26,31 @@ const StashTabs = ({ store }) => {
   const [order, setOrder] = React.useState<Order>('desc');
   const [selectedStashTabs, setSelectedStashTabs] =
     React.useState<string[]>(allTrackedStashTabsIds);
+  const previousTrackedStashTabsIds = React.useRef(allTrackedStashTabsIds);
+
+  React.useEffect(() => {
+    const previousIds = previousTrackedStashTabsIds.current;
+    previousTrackedStashTabsIds.current = allTrackedStashTabsIds;
+
+    setSelectedStashTabs((selectedIds) => {
+      const selectedIdsStillExist = selectedIds.filter((id) =>
+        allTrackedStashTabsIds.includes(id)
+      );
+      const tabsLoadedAfterInitialRender =
+        previousIds.length === 0 && allTrackedStashTabsIds.length > 0 && selectedIds.length === 0;
+      const tabSetChanged =
+        previousIds.length > 0 &&
+        allTrackedStashTabsIds.length > 0 &&
+        previousIds.every((id) => !allTrackedStashTabsIds.includes(id));
+
+      if (tabsLoadedAfterInitialRender || tabSetChanged) {
+        return allTrackedStashTabsIds;
+      }
+
+      return selectedIdsStillExist;
+    });
+  }, [allTrackedStashTabsIds.join('\u0000')]);
+
   const sortCallback = (column: StashTabsColumn, order: Order) => () => {
     const realOrder = order === 'desc' && orderBy === column ? 'asc' : 'desc';
     setOrder(realOrder);
@@ -43,7 +68,7 @@ const StashTabs = ({ store }) => {
 
   const [searchString, setSearchString] = React.useState<string>('');
   const sortedItems = store.itemStore
-    .getItemsForLootTable(orderBy, order)
+    .getItemsForLootTable(orderBy, order, true)
     .filter((item) => selectedStashTabs.includes(item.stashTabId))
     .filter((item) => item.name.toLowerCase().includes(searchString));
 

--- a/src/renderer/routes/StashTabs.tsx
+++ b/src/renderer/routes/StashTabs.tsx
@@ -70,7 +70,7 @@ const StashTabs = ({ store }) => {
   const sortedItems = store.itemStore
     .getItemsForLootTable(orderBy, order, true)
     .filter((item) => selectedStashTabs.includes(item.stashTabId))
-    .filter((item) => item.name.toLowerCase().includes(searchString));
+.filter((item) => item.name.toLowerCase().includes(searchString.toLowerCase()));
 
   const changeSelectedTabs = (event: SelectChangeEvent<typeof selectedStashTabs>) => {
     const {

--- a/src/renderer/stores/itemStore.ts
+++ b/src/renderer/stores/itemStore.ts
@@ -59,8 +59,8 @@ export default class ItemStore {
     });
   }
 
-  groupItemsPerType(ignoredItems: boolean = false) {
-    const items = ignoredItems ? this.ignoredItems : this.acceptedItems;
+  groupItemsPerType(ignoredItems: boolean = false, includeIgnored: boolean = false) {
+    const items = includeIgnored ? this.items : ignoredItems ? this.ignoredItems : this.acceptedItems;
     const grouped: any[] = [];
     items
       .map((item) => item.toLootTable())
@@ -103,8 +103,8 @@ export default class ItemStore {
     return grouped;
   }
 
-  @computed getItemsForLootTable(key: string, order: Order) {
-    return this.groupItemsPerType().sort((a, b) => {
+  @computed getItemsForLootTable(key: string, order: Order, includeIgnored: boolean = false) {
+    return this.groupItemsPerType(false, includeIgnored).sort((a, b) => {
       let first = a;
       let second = b;
       if (order === 'asc') {

--- a/test/main/StashTabsManager.spec.ts
+++ b/test/main/StashTabsManager.spec.ts
@@ -1,0 +1,47 @@
+const getStashData = jest.fn();
+
+jest.mock('../../src/main/db/repositories/stashtabs', () => ({
+  __esModule: true,
+  default: { getStashData: (...args: unknown[]) => getStashData(...args) },
+}));
+
+jest.mock('../../src/main/SettingsManager', () => ({
+  __esModule: true,
+  default: { get: jest.fn(() => ({ league: 'Settlers' })) },
+}));
+
+jest.mock('../../src/main/modules/StashGetter', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+jest.mock('../../src/main/RendererLogger', () => ({
+  __esModule: true,
+  default: { log: jest.fn() },
+}));
+
+jest.mock('electron-log', () => ({
+  error: jest.fn(),
+}));
+
+import StashTabsManager from '../../src/main/StashTabsManager';
+
+describe('StashTabsManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getStashData.mockResolvedValue({ value: 123, items: JSON.stringify([{ id: 'item-1' }]) });
+  });
+
+  it('uses the persisted compact timestamp format for the default snapshot cutoff', async () => {
+    const result = await StashTabsManager.getStashData();
+
+    expect(getStashData).toHaveBeenCalledWith(expect.stringMatching(/^\d{14}$/), 'Settlers');
+    expect(result).toEqual({ value: 123, items: [{ id: 'item-1' }] });
+  });
+
+  it('preserves an explicitly supplied historical cutoff', async () => {
+    await StashTabsManager.getStashData('20240102030405');
+
+    expect(getStashData).toHaveBeenCalledWith('20240102030405', 'Settlers');
+  });
+});

--- a/test/renderer/StashTabs.spec.tsx
+++ b/test/renderer/StashTabs.spec.tsx
@@ -1,0 +1,67 @@
+import React, { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import { computed, observable, runInAction } from 'mobx';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/renderer/components/Item/Item', () => ({
+  default: ({ item }: { item: { name: string } }) => <span>{item.name}</span>,
+}));
+
+vi.mock('../../src/renderer/components/Pricing/ChaosIcon', () => ({
+  default: () => <span aria-hidden="true" />,
+}));
+
+const { default: StashTabs } = await import('../../src/renderer/routes/StashTabs');
+
+const createStore = () => {
+  const trackedStashTabs = observable.array<any>([]);
+  const items = observable.array<any>([]);
+  const itemsForLootTable = computed(() => items.slice());
+  const getItemsForLootTable = vi.fn(() => itemsForLootTable.get());
+
+  return {
+    trackedStashTabs,
+    itemStore: {
+      items,
+      getItemsForLootTable,
+    },
+    getStashTab(id: string) {
+      return trackedStashTabs.find((stashTab) => stashTab.id === id) ?? null;
+    },
+  };
+};
+
+describe('StashTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows items when tracked tabs populate after the initial render', async () => {
+    const store = createStore();
+
+    store.itemStore.items.push({
+      id: 'item-1',
+      name: 'Ancient Orb',
+      stashTabId: 'currency',
+      quantity: 1,
+      value: 10,
+      totalValue: 10,
+      item: { name: 'Ancient Orb' },
+    });
+
+    render(<StashTabs store={store} />);
+
+    act(() => {
+      runInAction(() => {
+        store.trackedStashTabs.push({
+          id: 'currency',
+          name: 'Currency',
+          metadata: {},
+        });
+      });
+    });
+
+    expect(await screen.findByText('Ancient Orb')).toBeInTheDocument();
+    expect(store.itemStore.getItemsForLootTable).toHaveBeenCalledWith('name', 'desc', true);
+  });
+});

--- a/test/renderer/itemStore.spec.tsx
+++ b/test/renderer/itemStore.spec.tsx
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/renderer/electron.service', () => ({
+  electronService: {
+    logger: {
+      scope: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+      }),
+    },
+    on: vi.fn(),
+  },
+}));
+
+const { default: ItemStore } = await import('../../src/renderer/stores/itemStore');
+
+describe('ItemStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('can include ignored items when building a stash table', () => {
+    const store = new ItemStore([]);
+    store.items = [
+      {
+        isIgnored: true,
+        toLootTable: () => ({
+          id: 'item-1',
+          name: 'Ancient Orb',
+          value: 10,
+          originalValue: 10,
+          totalValue: 10,
+          quantity: 1,
+          stackSize: 0,
+          items: [],
+        }),
+      },
+    ] as any;
+
+    expect(store.getItemsForLootTable('name', 'desc')).toHaveLength(0);
+    expect(store.getItemsForLootTable('name', 'desc', true)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What changed
- Use the persisted `YYYYMMDDHHmmss` timestamp format when loading the latest stash snapshot.
- Log the number of snapshot items returned to the renderer.
- Keep asynchronously loaded tracked tabs selected and include stash items in the Stash Tabs table, with regression coverage.

## Root cause
The stash database stores compact text timestamps such as `20260802233349`, but the renderer lookup used an ISO cutoff such as `2026-08-03T17:58:40.603Z`. SQLite’s lexicographic comparison returned no snapshot, so 22 tabs were loaded while the item list was empty.

## Validation
- `npm test`
- 73 suites passed, 529 tests passed.
- Focused main and renderer stash tests passed.

This is a draft PR for review.