### PR TITLE
Update screenshot handling in DataSearchResults

### DIFF
--- a/src/main/db/repositories/stats.ts
+++ b/src/main/db/repositories/stats.ts
@@ -89,7 +89,7 @@ const stats = {
     const query = `
       SELECT run.id, area_info.name AS area, item.*
       FROM item, run, area_info, event
-      WHERE item.value > ?
+      WHERE item.value >= ?
       AND item.event_id = event.id
       AND item.ignored = 0
       AND DATETIME(event.timestamp) BETWEEN DATETIME(run.first_event) AND DATETIME(run.last_event)
@@ -184,9 +184,9 @@ const stats = {
           : ''
       }
       ${deaths ? `AND deaths BETWEEN ${deaths.min} AND ${deaths.max} ` : ''}
-      AND itemcount.items > 0
+      ${neededItemName ? 'AND itemcount.items > 0' : ''}
       AND json_extract(run_info, '$.ignored') IS NULL
-      AND gained > ?
+      AND gained >= ?
       AND DATETIME(run.first_event) BETWEEN DATETIME(?) AND DATETIME(?)
       ORDER BY run.id desc
     `;
@@ -224,7 +224,7 @@ const stats = {
     const query = `
       SELECT run.id AS map_id, area_info.name AS area, item.*
       FROM item, run, area_info, event
-      WHERE item.value > ?
+      WHERE item.value >= ?
       AND item.event_id = event.id
       AND item.ignored = 0
       AND DATETIME(event.timestamp) BETWEEN DATETIME(run.first_event) AND DATETIME(run.last_event)

--- a/src/renderer/components/DataSearchForm/DataSearchForm.tsx
+++ b/src/renderer/components/DataSearchForm/DataSearchForm.tsx
@@ -333,7 +333,7 @@ const DataSearchForm = ({
                 type="number"
                 size="small"
                 onChange={(e) => {
-                  if (parseInt(e.target.value) > 0) setMinLootValue(parseInt(e.target.value));
+                  if (parseInt(e.target.value) >= 0) setMinLootValue(parseInt(e.target.value));
                 }}
               />
             </FormControl>
@@ -346,7 +346,7 @@ const DataSearchForm = ({
                 size="small"
                 type="number"
                 onChange={(e) => {
-                  if (parseInt(e.target.value) > 0) setMinMapValue(parseInt(e.target.value));
+                  if (parseInt(e.target.value) >= 0) setMinMapValue(parseInt(e.target.value));
                 }}
               />
             </FormControl>

--- a/src/renderer/components/DataSearchResults/DataSearchResults.tsx
+++ b/src/renderer/components/DataSearchResults/DataSearchResults.tsx
@@ -127,7 +127,11 @@ const DataSearchResults = ({
   useEffect(() => {
     if (isTakingScreenshot) {
       fallbackExpanded.current = [...expanded];
+      expandedPanels.current = [...expanded]; // panels already open count as "done" now
       setExpanded(Panels);
+      if (expanded.length === Panels.length) {
+        runScreenshotCommand();
+      }
     } else {
       setExpanded(fallbackExpanded.current);
       fallbackExpanded.current = ['panel 1'];

--- a/src/renderer/components/DataSearchResults/DataSearchResults.tsx
+++ b/src/renderer/components/DataSearchResults/DataSearchResults.tsx
@@ -158,7 +158,8 @@ const DataSearchResults = ({
           <CircularProgress color="secondary" />
         </Stack>
       </Backdrop>
-      <Accordion expanded={expanded.includes('panel 1')} onChange={handleTabChange('panel 1')}>
+      <Accordion expanded={expanded.includes('panel 1')} onChange={handleTabChange('panel 1')}
+        slotProps={{ transition: { onEntered: handleOpenTabEnd('panel 1') } }}>
         <AccordionSummary>
           <Typography variant="button">Stats</Typography>
         </AccordionSummary>


### PR DESCRIPTION
EDR hangs when capturing stats while Loot and/or Runs panels were expanded manually.