### PR TITLE
Allow zero values in stats queries and inputs

### DIFF
--- a/src/main/db/repositories/stats.ts
+++ b/src/main/db/repositories/stats.ts
@@ -89,7 +89,7 @@ const stats = {
     const query = `
       SELECT run.id, area_info.name AS area, item.*
       FROM item, run, area_info, event
-      WHERE item.value > ?
+      WHERE item.value >= ?
       AND item.event_id = event.id
       AND item.ignored = 0
       AND DATETIME(event.timestamp) BETWEEN DATETIME(run.first_event) AND DATETIME(run.last_event)
@@ -184,9 +184,9 @@ const stats = {
           : ''
       }
       ${deaths ? `AND deaths BETWEEN ${deaths.min} AND ${deaths.max} ` : ''}
-      AND itemcount.items > 0
+      ${neededItemName ? 'AND itemcount.items > 0' : ''}
       AND json_extract(run_info, '$.ignored') IS NULL
-      AND gained > ?
+      AND gained >= ?
       AND DATETIME(run.first_event) BETWEEN DATETIME(?) AND DATETIME(?)
       ORDER BY run.id desc
     `;
@@ -224,7 +224,7 @@ const stats = {
     const query = `
       SELECT run.id AS map_id, area_info.name AS area, item.*
       FROM item, run, area_info, event
-      WHERE item.value > ?
+      WHERE item.value >= ?
       AND item.event_id = event.id
       AND item.ignored = 0
       AND DATETIME(event.timestamp) BETWEEN DATETIME(run.first_event) AND DATETIME(run.last_event)

--- a/src/renderer/components/DataSearchForm/DataSearchForm.tsx
+++ b/src/renderer/components/DataSearchForm/DataSearchForm.tsx
@@ -333,7 +333,7 @@ const DataSearchForm = ({
                 type="number"
                 size="small"
                 onChange={(e) => {
-                  if (parseInt(e.target.value) > 0) setMinLootValue(parseInt(e.target.value));
+                  if (parseInt(e.target.value) >= 0) setMinLootValue(parseInt(e.target.value));
                 }}
               />
             </FormControl>
@@ -346,7 +346,7 @@ const DataSearchForm = ({
                 size="small"
                 type="number"
                 onChange={(e) => {
-                  if (parseInt(e.target.value) > 0) setMinMapValue(parseInt(e.target.value));
+                  if (parseInt(e.target.value) >= 0) setMinMapValue(parseInt(e.target.value));
                 }}
               />
             </FormControl>


### PR DESCRIPTION
Change comparisons from > to >= for item.value and gained in stats queries so zero-valued loot/maps are included. Make the itemcount.items > 0 condition conditional (only applied when an item name is required) to avoid unintentionally filtering results. Update renderer numeric inputs to accept 0 as a valid minimum for loot and map value.