### PR TITLE
ci: modernize GitHub Actions and Node runtime

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -10,13 +10,16 @@ on:
 jobs:
   linux-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v${{ inputs.version }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install linux dependencies
         run: |
@@ -30,15 +33,16 @@ jobs:
       - name: Build app
         run: npm run package:linux
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app
+          if-no-files-found: error
           path: |
             dist/latest-linux.yml
             dist/exile-diary-reborn_v*_amd64.flatpak
             dist/exile-diary-reborn_v*_amd64.AppImage
       - name: Update release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: v${{ inputs.version }}
           files: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,10 +14,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: v${{ inputs.version }}
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
             dist/exile-diary-reborn_v*_amd64.flatpak
             dist/exile-diary-reborn_v*_amd64.AppImage
       - name: Update release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
           tag_name: v${{ inputs.version }}
           files: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,10 +14,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: v${{ inputs.version }}
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
             dist/exile-diary-reborn-portable-v${{ inputs.version }}.zip
             dist/latest.yml
       - name: Update release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
           tag_name: v${{ inputs.version }}
           draft: false

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -10,13 +10,16 @@ on:
 jobs:
   win-build:
     runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v${{ inputs.version }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -29,16 +32,17 @@ jobs:
       - name: Smoke packaged renderer
         run: npm run test:packaged-renderer
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app
+          if-no-files-found: error
           path: |
             dist/exile-diary-reborn-setup-v${{ inputs.version }}.exe
             dist/exile-diary-reborn-setup-v${{ inputs.version }}.exe.blockmap
             dist/exile-diary-reborn-portable-v${{ inputs.version }}.zip
             dist/latest.yml
       - name: Update release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: v${{ inputs.version }}
           draft: false

--- a/.github/workflows/deploy-cloudflare-auth.yml
+++ b/.github/workflows/deploy-cloudflare-auth.yml
@@ -22,9 +22,9 @@ jobs:
       group: cloudflare-auth-production
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/deploy-cloudflare-auth.yml
+++ b/.github/workflows/deploy-cloudflare-auth.yml
@@ -16,16 +16,17 @@ jobs:
   deploy:
     name: Deploy auth worker
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: ${{ inputs.environment }}
     concurrency:
       group: cloudflare-auth-production
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/publish-poe-pricing.yml
+++ b/.github/workflows/publish-poe-pricing.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Check out the default branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Test and publish the exact workflow revision that was triggered.
           # This matters for manual runs from a non-default branch (for example,
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/publish-poe-pricing.yml
+++ b/.github/workflows/publish-poe-pricing.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Check out the default branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Test and publish the exact workflow revision that was triggered.
           # This matters for manual runs from a non-default branch (for example,
@@ -62,9 +62,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,12 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
     steps:
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           draft: true
@@ -21,13 +24,16 @@ jobs:
   build-windows:
     needs: create-release
     runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref_name }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -41,17 +47,18 @@ jobs:
       - name: Smoke packaged renderer
         run: npm run test:packaged-renderer
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-app
           overwrite: true
+          if-no-files-found: error
           path: |
             dist/exile-diary-reborn-setup-v*.exe
             dist/exile-diary-reborn-setup-v*.exe.blockmap
             dist/exile-diary-reborn-portable-v*.zip
             dist/latest.yml
       - name: Update release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           files: |
@@ -64,13 +71,16 @@ jobs:
   build-linux:
     needs: create-release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref_name }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - name: Install linux dependencies
         run: |
@@ -84,16 +94,17 @@ jobs:
       - name: Build app
         run: npm run package:linux
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-app
           overwrite: true
+          if-no-files-found: error
           path: |
             dist/latest-linux.yml
             dist/exile-diary-reborn_v*_amd64.flatpak
             dist/exile-diary-reborn_v*_amd64.AppImage
       - name: Update release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           files: |
@@ -105,9 +116,12 @@ jobs:
   publish-release:
     needs: [build-windows, build-linux]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
     steps:
       - name: Publish release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           draft: true
@@ -28,10 +28,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref_name }}
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -58,7 +58,7 @@ jobs:
             dist/exile-diary-reborn-portable-v*.zip
             dist/latest.yml
       - name: Update release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           files: |
@@ -75,10 +75,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref_name }}
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -104,7 +104,7 @@ jobs:
             dist/exile-diary-reborn_v*_amd64.flatpak
             dist/exile-diary-reborn_v*_amd64.AppImage
       - name: Update release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           files: |
@@ -121,7 +121,7 @@ jobs:
       contents: write
     steps:
       - name: Publish release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           draft: false

--- a/.github/workflows/update-poe-data.yml
+++ b/.github/workflows/update-poe-data.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Create data updater token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.POE_DATA_APP_ID }}
           private-key: ${{ secrets.POE_DATA_APP_PRIVATE_KEY }}
@@ -44,16 +44,16 @@ jobs:
           permission-pull-requests: write
 
       - name: Check out the default branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
           cache-dependency-path: tools/poe-data-extractor/package-lock.json
 

--- a/.github/workflows/update-poe-data.yml
+++ b/.github/workflows/update-poe-data.yml
@@ -44,14 +44,14 @@ jobs:
           permission-pull-requests: write
 
       - name: Check out the default branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,8 +102,8 @@
         "wrangler": "^4.115.0"
       },
       "engines": {
-        "node": "22.x",
-        "npm": ">=9 <11"
+        "node": "24.x",
+        "npm": ">=11 <12"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "exile-diary",
   "version": "1.11.13",
   "private": true,
-  "packageManager": "npm@9.6.5",
+  "packageManager": "npm@11.16.0",
   "engines": {
-    "node": "22.x",
-    "npm": ">=9 <11"
+    "node": "24.x",
+    "npm": ">=11 <12"
   },
   "main": "./out/electron/main/index.js",
   "build": {


### PR DESCRIPTION
## Summary

- move the project and CI workflows from Node.js 22/npm 9 to Node.js 24/npm 11
- pin third-party GitHub Actions to exact, current commit SHAs
- add explicit job timeouts and least-required release permissions
- fail artifact uploads when expected package outputs are missing

## Why

The workflows mixed mutable major-version references with older runtime metadata and did not consistently bound execution or verify artifact presence. This update makes release and maintenance automation more reproducible, easier to diagnose, and aligned with the repository's declared runtime.

## Impact

Developer installs and CI now expect Node.js 24.x and npm 11.x. Build, release, Cloudflare auth, pricing, and data-update workflows otherwise retain their existing triggers and behavior.

## Validation

- All six modified workflow files parse successfully as YAML.
- Renderer suite: 16 files / 38 tests passed.
- Main suite: 72 files and 526 tests passed; 3 existing `stats.spec.ts` assertions fail because they expect `>` while `origin/main` already implements `>=`. Neither the source nor those tests are changed by this PR.
- `git diff --check origin/main...HEAD` passed.

The local machine is still on Node.js 22/npm 9, so the PR's GitHub checks provide the Node.js 24/npm 11 environment validation.