### PR TITLE
Add strategy tags and tag-specific run stats

### DIFF
--- a/src/main/Responder.ts
+++ b/src/main/Responder.ts
@@ -29,6 +29,14 @@ const Responder = {
   debugFetchRates: async () => RendererAppService.debugFetchRates(),
   debugFetchStashTabs: async () => RendererAppService.debugFetchStashTabs(),
   updateItemsIgnoreStatus: async (e, { data }) => RendererAppService.updateItemsIgnoreStatus(data),
+  listStrategies: async () => RendererAppService.listStrategies(),
+  createStrategy: async (e, { input }) => RendererAppService.createStrategy(input),
+  updateStrategy: async (e, { strategyId, input }) =>
+    RendererAppService.updateStrategy(strategyId, input),
+  deleteStrategy: async (e, { strategyId }) => RendererAppService.deleteStrategy(strategyId),
+  setRunStrategies: async (e, { runId, strategyIds }) =>
+    RendererAppService.setRunStrategies(runId, strategyIds),
+  getStrategyStats: async (e, { strategyId }) => RendererAppService.getStrategyStats(strategyId),
 };
 
 export default Responder;

--- a/src/main/StatsManager.ts
+++ b/src/main/StatsManager.ts
@@ -7,6 +7,8 @@ import SettingsManager from './SettingsManager';
 import { Run } from '../helpers/types';
 import Constants from '../helpers/constants';
 import ItemPricer from './pricing/matching/ItemPricer';
+import Strategies from './db/repositories/strategies';
+import type { StrategyEconomics } from '../shared/strategies';
 const { areas } = Constants;
 
 dayjs.extend(duration);
@@ -14,6 +16,7 @@ dayjs.extend(duration);
 type GetStatsParams = {
   league?: string;
   characterName?: string;
+  strategyId?: number;
 };
 
 const booleanStatsKeys = [
@@ -919,16 +922,21 @@ class ProfitTracker {
 const profitTracker = new ProfitTracker();
 
 const statsManager = {
-  getAllStats: async ({ league, characterName }: GetStatsParams) => {
+  getAllStats: async ({ league, characterName, strategyId }: GetStatsParams = {}) => {
     const times: { step: string; timestamp: number }[] = [];
     const resolvedLeague = league ?? SettingsManager.get('activeProfile')?.league ?? 'Standard';
     times.push({ step: 'start', timestamp: performance.now() });
-    const runs = (await DB.getAllRuns())?.map(formatRun);
+    const strategy = strategyId ? await Strategies.get(strategyId) : null;
+    if (strategyId && !strategy) throw new Error('Strategy not found');
+    const taggedRuns = (await DB.getAllRuns({ strategyId })) ?? [];
+    const runs = taggedRuns
+      .filter((run: any) => !strategyId || Number(run.completed) === 1)
+      .map(formatRun);
     times.push({ step: 'retrieved runs', timestamp: performance.now() });
     logger.debug(
       `Successfully retrieved ${runs.length} runs in ${times[1].timestamp - times[0].timestamp} ms`
     );
-    const items = await DB.getAllItems(resolvedLeague);
+    const items = await DB.getAllItems(resolvedLeague, strategyId);
     times.push({ step: 'retrieved items', timestamp: performance.now() });
     logger.debug(
       `Successfully retrieved ${items.length} items in ${
@@ -949,7 +957,36 @@ const statsManager = {
     const manager = new StatsManager({ runs, items, divinePrice });
     times.push({ step: 'created manager', timestamp: performance.now() });
     logger.debug(`Successfully created manager in ${times[4].timestamp - times[3].timestamp} ms`);
-    return manager.stats;
+    if (!strategyId || !strategy) return manager.stats;
+
+    const completedRunCount = runs.length;
+    const incompleteRunCount = taggedRuns.filter((run: any) => Number(run.completed) !== 1).length;
+    const totalTimeSeconds = runs.reduce((total: number, run: any) => {
+      const start = dayjs(run.first_event);
+      const end = dayjs(run.last_event);
+      return total + Math.max(0, end.diff(start, 'second'));
+    }, 0);
+    const grossValue = Number(manager.stats.misc.valueOfDrops) || 0;
+    const totalCost = strategy.costPerMap * completedRunCount;
+    const netValue = grossValue - totalCost;
+    const grossPerMap = completedRunCount > 0 ? grossValue / completedRunCount : 0;
+    const netPerMap = completedRunCount > 0 ? netValue / completedRunCount : 0;
+    const grossPerHour = totalTimeSeconds > 0 ? (grossValue / totalTimeSeconds) * 3600 : 0;
+    const netPerHour = totalTimeSeconds > 0 ? (netValue / totalTimeSeconds) * 3600 : 0;
+    const economics: StrategyEconomics = {
+      taggedRunCount: taggedRuns.length,
+      completedRunCount,
+      incompleteRunCount,
+      totalTimeSeconds,
+      grossValue,
+      totalCost,
+      netValue,
+      grossPerMap,
+      netPerMap,
+      grossPerHour,
+      netPerHour,
+    };
+    return { ...manager.stats, strategy, economics };
   },
   getAllMapNames: async () => {
     const mapNames = await DB.getAllMapNames();

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -583,6 +583,25 @@ const Migrations = {
         `ALTER TABLE deferred_run ADD COLUMN closing_event_id INTEGER`,
         `pragma user_version = 20`,
       ],
+      [
+        `CREATE TABLE IF NOT EXISTS strategy ( -- pragma user_version = 20 compatibility marker
+          id INTEGER NOT NULL,
+          name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+          description TEXT NOT NULL DEFAULT '',
+          color TEXT NOT NULL,
+          cost_per_map REAL NOT NULL CHECK(cost_per_map >= 0),
+          PRIMARY KEY (id AUTOINCREMENT)
+        )`,
+        `CREATE TABLE IF NOT EXISTS run_strategy (
+          run_id INTEGER NOT NULL,
+          strategy_id INTEGER NOT NULL,
+          PRIMARY KEY (run_id, strategy_id),
+          FOREIGN KEY (run_id) REFERENCES run(id),
+          FOREIGN KEY (strategy_id) REFERENCES strategy(id)
+        )`,
+        `CREATE INDEX IF NOT EXISTS run_strategy_strategy_id ON run_strategy(strategy_id)`,
+        `pragma user_version = 21`,
+      ],
     ],
     maintenance: [
       `delete from incubator where timestamp < (select min(timestamp) from (select timestamp from incubator order by timestamp desc limit 25))`,
@@ -804,6 +823,8 @@ class DBManager {
       ['league', 'SELECT 1 FROM league LIMIT 1'],
       ['leagues', 'SELECT 1 FROM leagues LIMIT 1'],
       ['graftblood', 'SELECT 1 FROM graftblood LIMIT 1'],
+      ['strategy', 'SELECT 1 FROM strategy LIMIT 1'],
+      ['run_strategy', 'SELECT 1 FROM run_strategy LIMIT 1'],
       ['stashes', 'SELECT 1 FROM stashes LIMIT 1'],
       ['fullrates', 'SELECT 1 FROM fullrates LIMIT 1'],
     ] as const;
@@ -892,6 +913,8 @@ const RequiredCharacterTables = [
   'xp',
   'graftblood',
   'deferred_run',
+  'strategy',
+  'run_strategy',
 ];
 
 const RequiredLeagueTables = ['characters', 'fullrates', 'stashes'];
@@ -946,9 +969,7 @@ const DB = {
     const dbPath = DB.getCharacterDbPath(characterName, league);
     if (!dbPath) return null;
 
-    const oldPath = characterName
-      ? DB.getCharacterDbPath(characterName, league, true)
-      : null;
+    const oldPath = characterName ? DB.getCharacterDbPath(characterName, league, true) : null;
     if (oldPath && fs.existsSync(oldPath) && !fs.existsSync(dbPath)) {
       logger.info(`Found the old pattern in db name, copying ${oldPath} to ${dbPath}`);
       fs.copyFileSync(oldPath, dbPath);

--- a/src/main/db/repositories/index.ts
+++ b/src/main/db/repositories/index.ts
@@ -7,3 +7,4 @@ export { default as SettingsRepository, get, set } from './settings';
 export { default as SkillTreeRepository } from './skilltree';
 export { default as StashTabsRepository } from './stashtabs';
 export { default as StatsRepository } from './stats';
+export { default as StrategiesRepository } from './strategies';

--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -2,6 +2,7 @@ import DB from '../index';
 import constants from '../../../helpers/constants';
 import Logger from 'electron-log';
 import type { ItemValuationExplanation } from '../../pricing/matching/ItemPricer';
+import Strategies from './strategies';
 const logger = Logger.scope('db/run');
 
 type ItemProperty = {
@@ -231,7 +232,10 @@ const Runs = {
         (run.xp - (SELECT xp FROM run m WHERE m.id < run.id AND xp IS NOT null ORDER BY m.id desc limit 1)) xpgained,
         (SELECT count(1) FROM event WHERE event_type='slain' AND event.timestamp between first_event AND last_event) deaths,
         (SELECT COALESCE(SUM(value),0) FROM item, event WHERE item.event_id = event.id AND event.timestamp BETWEEN first_event AND last_event AND item.ignored = 0) gained,
-        kills, run_info
+        kills, run_info,
+        COALESCE((SELECT json_group_array(json_object('id', strategy.id, 'name', strategy.name, 'color', strategy.color))
+          FROM run_strategy JOIN strategy ON strategy.id = run_strategy.strategy_id
+          WHERE run_strategy.run_id = run.id), '[]') AS strategies
       FROM area_info, run
       WHERE area_info.run_id = run.id
         AND json_extract(run_info, '$.ignored') IS null
@@ -275,6 +279,9 @@ const Runs = {
     logger.info(`Getting run info for run ${mapId}`);
     const mapInfoQuery = `
       SELECT run.id, name, level, depth, iiq, iir, pack_size, xp, kills, run_info, first_event, last_event, completed,
+      COALESCE((SELECT json_group_array(json_object('id', strategy.id, 'name', strategy.name, 'color', strategy.color))
+        FROM run_strategy JOIN strategy ON strategy.id = run_strategy.strategy_id
+        WHERE run_strategy.run_id = run.id), '[]') AS strategies,
       (SELECT COALESCE(SUM(value),0) FROM item, event WHERE item.event_id = event.id AND DATETIME(event.timestamp) BETWEEN DATETIME(first_event) AND DATETIME(last_event) AND ignored = 0) gained,
       (run.xp - (SELECT xp FROM run m WHERE m.id < run.id AND xp IS NOT null ORDER BY m.id desc LIMIT 1)) xpgained,
       (SELECT xp FROM run m WHERE m.id < run.id AND xp IS NOT null ORDER BY m.id desc LIMIT 1) prevxp,
@@ -365,6 +372,11 @@ const Runs = {
 
     return run;
   },
+
+  getRunStrategies: async (runId: number) => Strategies.getForRun(runId),
+
+  setRunStrategies: async (runId: number, strategyIds: number[]) =>
+    Strategies.setForRun(runId, strategyIds),
 
   getAreaInfo: async (areaId: number) => {
     const query = 'SELECT * FROM area_info WHERE run_id = ?';

--- a/src/main/db/repositories/stats.ts
+++ b/src/main/db/repositories/stats.ts
@@ -37,8 +37,18 @@ type GetAllRunsForDatesParams = {
   };
 };
 
+type RunSelection = {
+  strategyId?: number;
+  completedOnly?: boolean;
+};
+
 const stats = {
-  getAllRuns: async (): Promise<Run[]> => {
+  getAllRuns: async ({ strategyId, completedOnly = false }: RunSelection = {}): Promise<Run[]> => {
+    const strategyFilter = strategyId
+      ? `AND EXISTS (SELECT 1 FROM run_strategy WHERE run_strategy.run_id = run.id AND run_strategy.strategy_id = ?)`
+      : '';
+    const completionFilter = completedOnly ? 'AND run.completed = 1' : '';
+    const ignoredFilter = strategyId ? "AND json_extract(run.run_info, '$.ignored') IS NULL" : '';
     logger.debug('Getting all maps');
     const query = `
       SELECT
@@ -52,18 +62,24 @@ const stats = {
 
       FROM area_info, run
       WHERE run.id = area_info.run_id
+        ${strategyFilter}
+        ${completionFilter}
+        ${ignoredFilter}
       ORDER BY run.id desc
       `;
 
     try {
-      const maps = (await DB.all(query)) as Run[];
+      const maps = (await (strategyId ? DB.all(query, [strategyId]) : DB.all(query))) as Run[];
       return maps;
     } catch (err) {
       logger.error(`Error getting all maps: ${JSON.stringify(err)}`);
       return [];
     }
   },
-  getAllItems: async (league: string): Promise<any[]> => {
+  getAllItems: async (league: string, strategyId?: number): Promise<any[]> => {
+    const strategyFilter = strategyId
+      ? `AND EXISTS (SELECT 1 FROM run_strategy WHERE run_strategy.run_id = run.id AND run_strategy.strategy_id = ?)`
+      : '';
     const query = `
       SELECT run.id AS map_id, area_info.name AS area, item.*, event.timestamp AS drop_timestamp
       FROM item, run, area_info, event
@@ -71,10 +87,13 @@ const stats = {
       AND DATETIME(event.timestamp) BETWEEN DATETIME(run.first_event) AND DATETIME(run.last_event)
       AND run.id = area_info.run_id
       AND item.ignored = 0
+      ${strategyFilter}
+      ${strategyId ? 'AND run.completed = 1' : ''}
+      ${strategyId ? "AND json_extract(run.run_info, '$.ignored') IS NULL" : ''}
     `;
 
     try {
-      const items = await DB.all(query);
+      const items = await (strategyId ? DB.all(query, [strategyId]) : DB.all(query));
       return items ?? [];
     } catch (err) {
       logger.error(`Error getting all loot: ${JSON.stringify(err)}`);

--- a/src/main/db/repositories/strategies.ts
+++ b/src/main/db/repositories/strategies.ts
@@ -10,7 +10,6 @@ function normalizeInput(input: StrategyInput): StrategyInput {
   const costPerMap = Number(input?.costPerMap);
 
   if (!name) throw new Error('Strategy name is required');
-  if (!description) throw new Error('Strategy description is required');
   if (!colorPattern.test(color)) throw new Error('Strategy color must be a six-digit hex color');
   if (!Number.isFinite(costPerMap) || costPerMap < 0) {
     throw new Error('Strategy cost per map must be a non-negative number');

--- a/src/main/db/repositories/strategies.ts
+++ b/src/main/db/repositories/strategies.ts
@@ -1,0 +1,135 @@
+import DB from '../index';
+import type { RunStrategy, Strategy, StrategyInput } from '../../../shared/strategies';
+
+const colorPattern = /^#[0-9a-f]{6}$/i;
+
+function normalizeInput(input: StrategyInput): StrategyInput {
+  const name = String(input?.name ?? '').trim();
+  const description = String(input?.description ?? '').trim();
+  const color = String(input?.color ?? '').trim();
+  const costPerMap = Number(input?.costPerMap);
+
+  if (!name) throw new Error('Strategy name is required');
+  if (!description) throw new Error('Strategy description is required');
+  if (!colorPattern.test(color)) throw new Error('Strategy color must be a six-digit hex color');
+  if (!Number.isFinite(costPerMap) || costPerMap < 0) {
+    throw new Error('Strategy cost per map must be a non-negative number');
+  }
+
+  return { name, description, color: color.toUpperCase(), costPerMap };
+}
+
+const Strategies = {
+  list: async (): Promise<Strategy[]> => {
+    const rows = await DB.all(`
+      SELECT strategy.id, strategy.name, strategy.description, strategy.color,
+        strategy.cost_per_map AS costPerMap,
+        COUNT(run_strategy.run_id) AS assignmentCount
+      FROM strategy
+      LEFT JOIN run_strategy ON run_strategy.strategy_id = strategy.id
+      GROUP BY strategy.id
+      ORDER BY strategy.name COLLATE NOCASE ASC
+    `);
+    return (rows ?? []) as Strategy[];
+  },
+
+  get: async (strategyId: number): Promise<Strategy | null> => {
+    const row = await DB.get(
+      `SELECT id, name, description, color, cost_per_map AS costPerMap
+       FROM strategy WHERE id = ?`,
+      [strategyId]
+    );
+    return (row as Strategy | undefined) ?? null;
+  },
+
+  create: async (input: StrategyInput): Promise<Strategy> => {
+    const normalized = normalizeInput(input);
+    try {
+      const result = await DB.run(
+        `INSERT INTO strategy(name, description, color, cost_per_map) VALUES(?, ?, ?, ?)`,
+        [normalized.name, normalized.description, normalized.color, normalized.costPerMap]
+      );
+      const strategy = await Strategies.get(Number(result?.lastInsertRowid));
+      if (!strategy) throw new Error('Strategy was not created');
+      return strategy;
+    } catch (error: any) {
+      if (String(error?.message ?? '').includes('UNIQUE')) {
+        throw new Error('A strategy with this name already exists');
+      }
+      throw error;
+    }
+  },
+
+  update: async (strategyId: number, input: StrategyInput): Promise<Strategy> => {
+    const normalized = normalizeInput(input);
+    try {
+      const result = await DB.run(
+        `UPDATE strategy
+         SET name = ?, description = ?, color = ?, cost_per_map = ?
+         WHERE id = ?`,
+        [
+          normalized.name,
+          normalized.description,
+          normalized.color,
+          normalized.costPerMap,
+          strategyId,
+        ]
+      );
+      if (!result?.changes) throw new Error('Strategy not found');
+      const strategy = await Strategies.get(strategyId);
+      if (!strategy) throw new Error('Strategy not found');
+      return strategy;
+    } catch (error: any) {
+      if (String(error?.message ?? '').includes('UNIQUE')) {
+        throw new Error('A strategy with this name already exists');
+      }
+      throw error;
+    }
+  },
+
+  delete: async (strategyId: number): Promise<void> => {
+    await DB.transactionSteps([
+      { query: 'DELETE FROM run_strategy WHERE strategy_id = ?', params: [strategyId] },
+      { query: 'DELETE FROM strategy WHERE id = ?', params: [strategyId] },
+    ]);
+  },
+
+  getForRun: async (runId: number): Promise<RunStrategy[]> => {
+    const rows = await DB.all(
+      `SELECT strategy.id, strategy.name, strategy.color
+       FROM strategy
+       INNER JOIN run_strategy ON run_strategy.strategy_id = strategy.id
+       WHERE run_strategy.run_id = ?
+       ORDER BY strategy.name COLLATE NOCASE ASC`,
+      [runId]
+    );
+    return (rows ?? []) as RunStrategy[];
+  },
+
+  setForRun: async (runId: number, strategyIds: number[]): Promise<RunStrategy[]> => {
+    const run = await DB.get('SELECT id FROM run WHERE id = ?', [runId]);
+    if (!run) throw new Error('Run not found');
+    const ids = [...new Set(strategyIds.map(Number).filter(Number.isInteger))];
+    if (ids.length) {
+      const placeholders = ids.map(() => '?').join(',');
+      const rows = await DB.all(`SELECT id FROM strategy WHERE id IN (${placeholders})`, ids);
+      if ((rows ?? []).length !== ids.length)
+        throw new Error('One or more strategies were not found');
+    }
+
+    const steps: Array<{ query: string; params?: any[] }> = [
+      { query: 'DELETE FROM run_strategy WHERE run_id = ?', params: [runId] },
+    ];
+    for (const strategyId of ids) {
+      steps.push({
+        query: 'INSERT INTO run_strategy(run_id, strategy_id) VALUES(?, ?)',
+        params: [runId, strategyId],
+      });
+    }
+    await DB.transactionSteps(steps);
+    return Strategies.getForRun(runId);
+  },
+};
+
+export { normalizeInput };
+export default Strategies;

--- a/src/main/ipc/registerResponderHandlers.ts
+++ b/src/main/ipc/registerResponderHandlers.ts
@@ -30,6 +30,12 @@ export const responderHandlerKeys = [
   'debugFetchStashTabs',
   'getOverlayPersistence',
   'updateItemsIgnoreStatus',
+  'listStrategies',
+  'createStrategy',
+  'updateStrategy',
+  'deleteStrategy',
+  'setRunStrategies',
+  'getStrategyStats',
 ] as const;
 
 export function registerResponderHandlers() {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -67,6 +67,15 @@ const api: ExileDiaryApi = {
   },
   updateItemsIgnoreStatus: (data) =>
     ipcRenderer.invoke(invokeChannels.updateItemsIgnoreStatus, { data }),
+  listStrategies: () => ipcRenderer.invoke(invokeChannels.listStrategies),
+  createStrategy: (input) => ipcRenderer.invoke(invokeChannels.createStrategy, { input }),
+  updateStrategy: (strategyId, input) =>
+    ipcRenderer.invoke(invokeChannels.updateStrategy, { strategyId, input }),
+  deleteStrategy: (strategyId) => ipcRenderer.invoke(invokeChannels.deleteStrategy, { strategyId }),
+  setRunStrategies: (runId, strategyIds) =>
+    ipcRenderer.invoke(invokeChannels.setRunStrategies, { runId, strategyIds }),
+  getStrategyStats: (strategyId) =>
+    ipcRenderer.invoke(invokeChannels.getStrategyStats, { strategyId }),
   openFileDialog: (options) => ipcRenderer.invoke(invokeChannels.openFileDialog, options),
   showCharacterDbFile: () => ipcRenderer.invoke(invokeChannels.showCharacterDbFile),
   refreshUi: () => ipcRenderer.send(sendChannels.refreshUi),

--- a/src/main/runtime-core/RendererRuntimeService.ts
+++ b/src/main/runtime-core/RendererRuntimeService.ts
@@ -4,12 +4,14 @@ import {
   pickRendererSettingsUseCaseDependencies,
   pickRendererStashUseCaseDependencies,
   pickRendererStatsUseCaseDependencies,
+  pickRendererStrategyUseCaseDependencies,
   RendererRuntimeDependencies,
 } from './rendererRuntimeDependencies';
 import { createRendererRunUseCases } from './use-cases/createRendererRunUseCases';
 import { createRendererSettingsUseCases } from './use-cases/createRendererSettingsUseCases';
 import { createRendererStashUseCases } from './use-cases/createRendererStashUseCases';
 import { createRendererStatsUseCases } from './use-cases/createRendererStatsUseCases';
+import { createRendererStrategyUseCases } from './use-cases/createRendererStrategyUseCases';
 
 export function createRendererRuntimeService(
   deps: RendererRuntimeDependencies = createDefaultRendererRuntimeDependencies()
@@ -19,6 +21,7 @@ export function createRendererRuntimeService(
     ...createRendererSettingsUseCases(pickRendererSettingsUseCaseDependencies(deps)),
     ...createRendererStashUseCases(pickRendererStashUseCaseDependencies(deps)),
     ...createRendererStatsUseCases(pickRendererStatsUseCaseDependencies(deps)),
+    ...createRendererStrategyUseCases(pickRendererStrategyUseCaseDependencies(deps)),
   };
 }
 

--- a/src/main/runtime-core/rendererRuntimeDependencies.ts
+++ b/src/main/runtime-core/rendererRuntimeDependencies.ts
@@ -13,6 +13,8 @@ import RunParser from '../modules/RunParser';
 import SearchManager from '../SearchManager';
 import PricingService from '../pricing/PricingService';
 import ItemsDB from '../db/repositories/items';
+import Strategies from '../db/repositories/strategies';
+import type { StrategyInput } from '../../shared/strategies';
 
 type Awaitable<T> = T | Promise<T>;
 
@@ -20,6 +22,13 @@ export type RendererRuntimeDependencies = {
   runs: {
     getLastRuns: (size: number) => Promise<any[]>;
     getRun: (runId: number) => Promise<any>;
+  };
+  strategies: {
+    list: () => Promise<any[]>;
+    create: (input: StrategyInput) => Promise<any>;
+    update: (strategyId: number, input: StrategyInput) => Promise<any>;
+    delete: (strategyId: number) => Promise<void>;
+    setForRun: (runId: number, strategyIds: number[]) => Promise<any[]>;
   };
   settingsManager: {
     get: (key: string) => any;
@@ -36,7 +45,11 @@ export type RendererRuntimeDependencies = {
     logout: () => Promise<void>;
   };
   statsManager: {
-    getAllStats: (params: { league?: string; characterName?: string }) => Promise<any>;
+    getAllStats: (params: {
+      league?: string;
+      characterName?: string;
+      strategyId?: number;
+    }) => Promise<any>;
     getAllMapNames: () => Promise<string[]>;
     getAllPossibleMods: () => Promise<string[]>;
     registerProfitPerHourAnnouncer?: (callback: (...args: any[]) => void) => void;
@@ -80,6 +93,8 @@ export type RendererRunUseCaseDependencies = Pick<
   'runs' | 'runParser' | 'rendererLogger' | 'itemsDb'
 >;
 
+export type RendererStrategyUseCaseDependencies = Pick<RendererRuntimeDependencies, 'strategies'>;
+
 export type RendererSettingsUseCaseDependencies = Pick<
   RendererRuntimeDependencies,
   'settingsManager' | 'gggApi' | 'authManager' | 'rendererLogger' | 'clientTxtWatcher'
@@ -98,6 +113,7 @@ export type RendererStatsUseCaseDependencies = Pick<
 export function createDefaultRendererRuntimeDependencies(): RendererRuntimeDependencies {
   return {
     runs: Runs,
+    strategies: Strategies,
     settingsManager: SettingsManager,
     gggApi: GGGAPI,
     authManager: AuthManager,
@@ -124,6 +140,12 @@ export function pickRendererRunUseCaseDependencies(
     rendererLogger: deps.rendererLogger,
     itemsDb: deps.itemsDb,
   };
+}
+
+export function pickRendererStrategyUseCaseDependencies(
+  deps: RendererRuntimeDependencies
+): RendererStrategyUseCaseDependencies {
+  return { strategies: deps.strategies };
 }
 
 export function pickRendererSettingsUseCaseDependencies(

--- a/src/main/runtime-core/use-cases/createRendererStatsUseCases.ts
+++ b/src/main/runtime-core/use-cases/createRendererStatsUseCases.ts
@@ -3,14 +3,38 @@ import { RendererStatsUseCaseDependencies } from '../rendererRuntimeDependencies
 
 export function createRendererStatsUseCases(deps: RendererStatsUseCaseDependencies) {
   return {
-    async getAllStats(params?: { league?: string; characterName?: string }) {
+    async getAllStats(params?: { league?: string; characterName?: string; strategyId?: number }) {
       logger.info('Getting all stats for the renderer process');
       const profile = deps.settingsManager.get('activeProfile');
       const league = params?.league ?? profile?.league;
       const characterName = params?.characterName ?? profile?.characterName;
-      const stats = await deps.statsManager.getAllStats({ league, characterName });
+      const stats = await deps.statsManager.getAllStats({
+        league,
+        characterName,
+        strategyId: params?.strategyId,
+      });
       stats.divinePrice = await deps.itemPricer.getCurrencyByName('Divine Orb', deps.now(), league);
       return stats;
+    },
+
+    async getStrategyStats(strategyId: number) {
+      logger.info(`Getting strategy stats for ${strategyId}`);
+      const profile = deps.settingsManager.get('activeProfile');
+      const stats = await deps.statsManager.getAllStats({
+        league: profile?.league,
+        characterName: profile?.characterName,
+        strategyId: Number(strategyId),
+      });
+      stats.divinePrice = await deps.itemPricer.getCurrencyByName(
+        'Divine Orb',
+        deps.now(),
+        profile?.league
+      );
+      return {
+        strategy: stats.strategy,
+        economics: stats.economics,
+        stats,
+      };
     },
 
     async triggerSearch(params: Record<string, any>) {

--- a/src/main/runtime-core/use-cases/createRendererStrategyUseCases.ts
+++ b/src/main/runtime-core/use-cases/createRendererStrategyUseCases.ts
@@ -1,0 +1,26 @@
+import type { StrategyInput } from '../../../shared/strategies';
+import type { RendererStrategyUseCaseDependencies } from '../rendererRuntimeDependencies';
+
+export function createRendererStrategyUseCases(deps: RendererStrategyUseCaseDependencies) {
+  return {
+    async listStrategies() {
+      return deps.strategies.list();
+    },
+
+    async createStrategy(input: StrategyInput) {
+      return deps.strategies.create(input);
+    },
+
+    async updateStrategy(strategyId: number, input: StrategyInput) {
+      return deps.strategies.update(Number(strategyId), input);
+    },
+
+    async deleteStrategy(strategyId: number) {
+      await deps.strategies.delete(Number(strategyId));
+    },
+
+    async setRunStrategies(runId: string | number, strategyIds: number[]) {
+      return deps.strategies.setForRun(Number(runId), strategyIds);
+    },
+  };
+}

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -17,6 +17,7 @@ import CharacterSelect from './routes/CharacterSelect';
 import LoginBox from './routes/LoginBox';
 import Overlay from './routes/Overlay';
 import Help from './routes/Help';
+import Strategies from './routes/Strategies';
 import { electronService } from './electron.service';
 
 type AppRouteDependencies = {
@@ -115,6 +116,14 @@ export const createAppRoutes = ({
           const settings = await electronService.getSettings();
           return { activeProfile: settings.activeProfile };
         },
+      },
+      {
+        path: 'strategies',
+        element: <Strategies />,
+      },
+      {
+        path: 'strategies/:strategyId',
+        element: <Strategies />,
       },
       {
         path: 'settings',

--- a/src/renderer/components/SideNav/SideNav.tsx
+++ b/src/renderer/components/SideNav/SideNav.tsx
@@ -69,6 +69,7 @@ const SideNav = ({ version, isNewVersion, turnNewVersionOff }) => {
     { name: 'Stash', link: 'stash' },
     { name: 'Search', link: 'search' },
     { name: 'Stats', link: 'stats' },
+    { name: 'Strategies', link: 'strategies' },
     { name: 'Settings', link: 'settings' },
     { name: 'Help', link: 'help' },
   ];

--- a/src/renderer/components/Strategies/StrategySelector.tsx
+++ b/src/renderer/components/Strategies/StrategySelector.tsx
@@ -15,13 +15,13 @@ export default function StrategySelector({
   value,
   onChange,
   label = 'Strategies',
-  compact = true,
+  compact = false,
 }: Props) {
   const selected = options.filter((option) => value.some((item) => item.id === option.id));
   return (
     <Autocomplete
       multiple
-      size={compact ? 'small' : 'medium'}
+      size='small'
       options={options}
       value={selected}
       onChange={(_event, next) => void onChange(next)}
@@ -44,7 +44,14 @@ export default function StrategySelector({
           {option.name}
         </li>
       )}
-      renderInput={(params) => <TextField {...params} label={label} />}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          label={compact ? undefined : label}
+          placeholder={selected.length > 0 ? undefined : 'No strategy selected'}
+        />
+      )}
       onClick={(event) => event.stopPropagation()}
       onMouseDown={(event) => event.stopPropagation()}
       noOptionsText="Create a strategy first"

--- a/src/renderer/components/Strategies/StrategySelector.tsx
+++ b/src/renderer/components/Strategies/StrategySelector.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Autocomplete, Chip, TextField } from '@mui/material';
+import type { RunStrategy, Strategy } from '../../../shared/strategies';
+
+type Props = {
+  options: Strategy[];
+  value: RunStrategy[];
+  onChange: (strategies: Strategy[]) => void | Promise<void>;
+  label?: string;
+  compact?: boolean;
+};
+
+export default function StrategySelector({
+  options,
+  value,
+  onChange,
+  label = 'Strategies',
+  compact = true,
+}: Props) {
+  const selected = options.filter((option) => value.some((item) => item.id === option.id));
+  return (
+    <Autocomplete
+      multiple
+      size={compact ? 'small' : 'medium'}
+      options={options}
+      value={selected}
+      onChange={(_event, next) => void onChange(next)}
+      getOptionLabel={(option) => option.name}
+      isOptionEqualToValue={(option, selectedOption) => option.id === selectedOption.id}
+      renderValue={(tagValue, getItemProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            {...getItemProps({ index })}
+            key={option.id}
+            label={option.name}
+            size="small"
+            sx={{ backgroundColor: option.color, color: '#fff' }}
+          />
+        ))
+      }
+      renderOption={(props, option) => (
+        <li {...props} key={option.id}>
+          <span style={{ width: 12, height: 12, backgroundColor: option.color, marginRight: 8 }} />
+          {option.name}
+        </li>
+      )}
+      renderInput={(params) => <TextField {...params} label={label} />}
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      noOptionsText="Create a strategy first"
+    />
+  );
+}

--- a/src/renderer/electron.service.ts
+++ b/src/renderer/electron.service.ts
@@ -96,6 +96,12 @@ export const electronService = {
   setOverlayClickable: (clickable: boolean) => getApi().setOverlayClickable(clickable),
   updateItemsIgnoreStatus: (data: Array<{ id: string; status: boolean }>) =>
     getApi().updateItemsIgnoreStatus(data),
+  listStrategies: () => getApi().listStrategies(),
+  createStrategy: (input) => getApi().createStrategy(input),
+  updateStrategy: (strategyId, input) => getApi().updateStrategy(strategyId, input),
+  deleteStrategy: (strategyId) => getApi().deleteStrategy(strategyId),
+  setRunStrategies: (runId, strategyIds) => getApi().setRunStrategies(runId, strategyIds),
+  getStrategyStats: (strategyId) => getApi().getStrategyStats(strategyId),
   openFileDialog: (options: OpenFileDialogOptions) => getApi().openFileDialog(options),
   showCharacterDbFile: () => getApi().showCharacterDbFile(),
   refreshUi: () => getApi().refreshUi(),

--- a/src/renderer/routes/Run.tsx
+++ b/src/renderer/routes/Run.tsx
@@ -11,6 +11,9 @@ import RunEventIcons from '../components/RunEvent/RunEventIcons';
 import RunEvent from '../components/RunEvent/RunEvent';
 import LootTable from '../components/LootTable/LootTable';
 import RunNavigation from '../components/RunNavigation/RunNavigation';
+import StrategySelector from '../components/Strategies/StrategySelector';
+import { electronService } from '../electron.service';
+import type { Strategy } from '../../shared/strategies';
 
 type RunLoaderData = {
   run: RunType;
@@ -20,6 +23,7 @@ const Run = ({ store }) => {
   const navigate = useNavigate();
   const { runId } = useParams();
   const { run } = useLoaderData() as RunLoaderData;
+  const [strategies, setStrategies] = React.useState<Strategy[]>([]);
 
   useEffect(() => {
     if (!runId || !run) {
@@ -27,6 +31,14 @@ const Run = ({ store }) => {
     }
     store.loadDetails(run);
   }, [runId, run, navigate, store]);
+
+  useEffect(() => {
+    if (typeof electronService.listStrategies !== 'function') return;
+    void electronService
+      .listStrategies()
+      .then((loaded) => setStrategies(loaded ?? []))
+      .catch(() => undefined);
+  }, []);
 
   const duration = run.duration ? dayjs.utc(run.duration.asMilliseconds()).format('mm:ss') : '-';
   const xp =
@@ -49,6 +61,16 @@ const Run = ({ store }) => {
             Monster level: {run.level} (Tier: {run.tier ? run.tier : '??'})
           </div>
           <div className="Run__Header__League Text--Legendary">{run.league} League</div>
+          <StrategySelector
+            options={strategies}
+            value={run.strategies}
+            onChange={(next) =>
+              store.setRunStrategies(
+                run,
+                next.map((strategy) => strategy.id)
+              )
+            }
+          />
         </div>
         <div className="Run__Header__Block">
           <div className="Run__Header__Block__Title">Item Quantity</div>

--- a/src/renderer/routes/RunList.tsx
+++ b/src/renderer/routes/RunList.tsx
@@ -136,9 +136,6 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
               <TableCell variant="head" align="center">
                 Kills
               </TableCell>
-              <TableCell variant="head" align="center">
-                Graftblood
-              </TableCell>
               <TableCell variant="head">Strategies</TableCell>
             </TableRow>
           </TableHead>
@@ -177,11 +174,6 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
                   <TableCell align="center">{deaths.length > 0 ? deaths : '-'}</TableCell>
                   <TableCell align="center">
                     {run.kills && run.kills > -1 ? run.kills : '-'}
-                  </TableCell>
-                  <TableCell align="center">
-                    {run.graftblood !== null && run.graftblood !== undefined
-                      ? run.graftblood.toLocaleString('en')
-                      : '-'}
                   </TableCell>
                   <TableCell onClick={(event) => event.stopPropagation()}>
                     <StrategySelector

--- a/src/renderer/routes/RunList.tsx
+++ b/src/renderer/routes/RunList.tsx
@@ -18,12 +18,24 @@ import classNames from 'classnames';
 import ChaosIcon from '../components/Pricing/ChaosIcon';
 import { useNavigate } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
+import { electronService } from '../electron.service';
+import StrategySelector from '../components/Strategies/StrategySelector';
+import type { Strategy } from '../../shared/strategies';
 
 const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
   const navigate = useNavigate();
   const [runsPerPage, setrunsPerPage] = React.useState<number>(NumbersOfMapsToShow);
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const [page, setPage] = React.useState(0);
+  const [strategies, setStrategies] = React.useState<Strategy[]>([]);
+
+  React.useEffect(() => {
+    if (typeof electronService.listStrategies !== 'function') return;
+    void electronService
+      .listStrategies()
+      .then((loaded) => setStrategies(loaded ?? []))
+      .catch(() => undefined);
+  }, []);
 
   const togglePopupMenu = () => {
     setIsDrawerOpen(!isDrawerOpen);
@@ -127,6 +139,7 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
               <TableCell variant="head" align="center">
                 Graftblood
               </TableCell>
+              <TableCell variant="head">Strategies</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -169,6 +182,19 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
                     {run.graftblood !== null && run.graftblood !== undefined
                       ? run.graftblood.toLocaleString('en')
                       : '-'}
+                  </TableCell>
+                  <TableCell onClick={(event) => event.stopPropagation()}>
+                    <StrategySelector
+                      compact
+                      options={strategies}
+                      value={run.strategies}
+                      onChange={(next) =>
+                        store.setRunStrategies(
+                          run,
+                          next.map((strategy) => strategy.id)
+                        )
+                      }
+                    />
                   </TableCell>
                 </TableRow>
               );

--- a/src/renderer/routes/Strategies.css
+++ b/src/renderer/routes/Strategies.css
@@ -1,0 +1,15 @@
+.Strategies__Layout { display: flex; gap: 16px; min-height: 70vh; }
+.Strategies__Nav { width: 230px; display: flex; flex-direction: column; gap: 6px; }
+.Strategies__NavItem { display: flex; align-items: center; gap: 8px; border: 0; background: transparent; color: inherit; padding: 8px; text-align: left; cursor: pointer; font: inherit; }
+.Strategies__NavItem--selected { background: rgba(135, 135, 254, 0.18); }
+.Strategies__NavItem small { margin-left: auto; opacity: .7; }
+.Strategies__Color { width: 12px; height: 12px; border-radius: 50%; flex: 0 0 auto; }
+.Strategies__Content { flex: 1; min-width: 0; }
+.Strategies__Header { display: flex; justify-content: space-between; align-items: flex-start; }
+.Strategies__Header h1 { margin: 0; }
+.Strategies__Header p { margin-top: 4px; }
+.Strategies__Actions { display: flex; gap: 4px; }
+.Strategies__Editor { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin: 12px 0; }
+.Strategies__Economics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin: 16px 0; }
+.Strategies__Economics > div { padding: 10px; border: 1px solid rgba(255,255,255,.15); }
+.Strategies__Empty { padding: 40px; text-align: center; }

--- a/src/renderer/routes/Strategies.tsx
+++ b/src/renderer/routes/Strategies.tsx
@@ -114,16 +114,19 @@ export default function Strategies() {
   const editor = (
     <div className="Strategies__Editor">
       <TextField
+        size="small"
         label="Name"
         value={input.name}
         onChange={(event) => setInput({ ...input, name: event.target.value })}
       />
       <TextField
+        size="small"
         label="Description"
         value={input.description}
         onChange={(event) => setInput({ ...input, description: event.target.value })}
       />
       <TextField
+        size="small"
         label="Cost per map (chaos)"
         type="number"
         value={input.costPerMap}

--- a/src/renderer/routes/Strategies.tsx
+++ b/src/renderer/routes/Strategies.tsx
@@ -11,12 +11,18 @@ import { electronService } from '../electron.service';
 import type { Strategy, StrategyInput } from '../../shared/strategies';
 import './Strategies.css';
 
-const emptyInput: StrategyInput = {
+const randomStrategyColor = () =>
+  `#${Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0')
+    .toUpperCase()}`;
+
+const createEmptyInput = (): StrategyInput => ({
   name: '',
   description: '',
-  color: '#6666FF',
+  color: randomStrategyColor(),
   costPerMap: 0,
-};
+});
 
 const formatNumber = (value: number) => (Number(value) || 0).toFixed(2);
 
@@ -27,7 +33,7 @@ export default function Strategies() {
   const [selected, setSelected] = useState<Strategy | null>(null);
   const [statsResult, setStatsResult] = useState<any>(null);
   const [tab, setTab] = useState(0);
-  const [input, setInput] = useState<StrategyInput>(emptyInput);
+  const [input, setInput] = useState<StrategyInput>(createEmptyInput);
   const [editing, setEditing] = useState(false);
   const [error, setError] = useState('');
   const itemStore = useMemo(() => new ItemStore([]), []);
@@ -159,7 +165,7 @@ export default function Strategies() {
             variant="outlined"
             onClick={() => {
               setSelected(null);
-              setInput(emptyInput);
+              setInput(createEmptyInput());
               setEditing(true);
             }}
           >

--- a/src/renderer/routes/Strategies.tsx
+++ b/src/renderer/routes/Strategies.tsx
@@ -24,6 +24,13 @@ const createEmptyInput = (): StrategyInput => ({
   costPerMap: 0,
 });
 
+const strategyToInput = (strategy: Strategy): StrategyInput => ({
+  name: strategy.name,
+  description: strategy.description,
+  color: strategy.color,
+  costPerMap: strategy.costPerMap,
+});
+
 const formatNumber = (value: number) => (Number(value) || 0).toFixed(2);
 
 export default function Strategies() {
@@ -45,12 +52,7 @@ export default function Strategies() {
     const next = loaded.find((strategy) => strategy.id === id) ?? null;
     setSelected(next);
     if (next) {
-      setInput({
-        name: next.name,
-        description: next.description,
-        color: next.color,
-        costPerMap: next.costPerMap,
-      });
+      setInput(strategyToInput(next));
       if (String(strategyId) !== String(next.id))
         navigate(`/strategies/${next.id}`, { replace: true });
     }
@@ -65,11 +67,19 @@ export default function Strategies() {
       setStatsResult(null);
       return;
     }
+    let cancelled = false;
     setStatsResult(null);
     void electronService
       .getStrategyStats(selected.id)
-      .then(setStatsResult)
-      .catch((reason) => setError(String(reason?.message ?? reason)));
+      .then((result) => {
+        if (!cancelled) setStatsResult(result);
+      })
+      .catch((reason) => {
+        if (!cancelled) setError(String(reason?.message ?? reason));
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [selected]);
 
   useEffect(() => {
@@ -194,7 +204,12 @@ export default function Strategies() {
                   <p>{selected.description}</p>
                 </div>
                 <div className="Strategies__Actions">
-                  <Button onClick={() => setEditing(!editing)}>
+                  <Button
+                    onClick={() => {
+                      if (editing) setInput(strategyToInput(selected));
+                      setEditing(!editing);
+                    }}
+                  >
                     {editing ? 'Cancel' : 'Edit'}
                   </Button>
                   <Button color="error" onClick={remove}>

--- a/src/renderer/routes/Strategies.tsx
+++ b/src/renderer/routes/Strategies.tsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button, Divider, LinearProgress, Tab, Tabs, TextField } from '@mui/material';
+import MainStats from '../components/Stats/MainStats/MainStats';
+import AreaStats from '../components/Stats/AreaStats/AreaStats';
+import BossStats from '../components/Stats/BossStats/BossStats';
+import LootStats from '../components/Stats/LootStats/LootStats';
+import ItemStore from '../stores/itemStore';
+import Price from '../components/Pricing/Price';
+import { electronService } from '../electron.service';
+import type { Strategy, StrategyInput } from '../../shared/strategies';
+import './Strategies.css';
+
+const emptyInput: StrategyInput = {
+  name: '',
+  description: '',
+  color: '#6666FF',
+  costPerMap: 0,
+};
+
+const formatNumber = (value: number) => (Number(value) || 0).toFixed(2);
+
+export default function Strategies() {
+  const navigate = useNavigate();
+  const { strategyId } = useParams();
+  const [strategies, setStrategies] = useState<Strategy[]>([]);
+  const [selected, setSelected] = useState<Strategy | null>(null);
+  const [statsResult, setStatsResult] = useState<any>(null);
+  const [tab, setTab] = useState(0);
+  const [input, setInput] = useState<StrategyInput>(emptyInput);
+  const [editing, setEditing] = useState(false);
+  const [error, setError] = useState('');
+  const itemStore = useMemo(() => new ItemStore([]), []);
+
+  const loadStrategies = async () => {
+    const loaded = (await electronService.listStrategies()) ?? [];
+    setStrategies(loaded);
+    const id = strategyId ? Number(strategyId) : loaded[0]?.id;
+    const next = loaded.find((strategy) => strategy.id === id) ?? null;
+    setSelected(next);
+    if (next) {
+      setInput({
+        name: next.name,
+        description: next.description,
+        color: next.color,
+        costPerMap: next.costPerMap,
+      });
+      if (String(strategyId) !== String(next.id))
+        navigate(`/strategies/${next.id}`, { replace: true });
+    }
+  };
+
+  useEffect(() => {
+    void loadStrategies().catch((reason) => setError(String(reason?.message ?? reason)));
+  }, [strategyId]);
+
+  useEffect(() => {
+    if (!selected) {
+      setStatsResult(null);
+      return;
+    }
+    setStatsResult(null);
+    void electronService
+      .getStrategyStats(selected.id)
+      .then(setStatsResult)
+      .catch((reason) => setError(String(reason?.message ?? reason)));
+  }, [selected]);
+
+  useEffect(() => {
+    const loot = statsResult?.stats?.items?.loot;
+    if (Array.isArray(loot)) {
+      itemStore.createItems(loot.map((item) => ({ ...item, ...JSON.parse(item.raw_data) })));
+    }
+  }, [statsResult, itemStore]);
+
+  const save = async () => {
+    setError('');
+    try {
+      const saved =
+        editing && selected
+          ? await electronService.updateStrategy(selected.id, input)
+          : await electronService.createStrategy(input);
+      await loadStrategies();
+      setEditing(false);
+      navigate(`/strategies/${saved.id}`);
+    } catch (reason: any) {
+      setError(String(reason?.message ?? reason));
+    }
+  };
+
+  const remove = async () => {
+    if (!selected) return;
+    const count = selected.assignmentCount ?? 0;
+    if (!window.confirm(`Delete ${selected.name}? This will remove its tag from ${count} run(s).`))
+      return;
+    try {
+      await electronService.deleteStrategy(selected.id);
+      await loadStrategies();
+      const next = strategies.find((strategy) => strategy.id !== selected.id);
+      navigate(next ? `/strategies/${next.id}` : '/strategies');
+    } catch (reason: any) {
+      setError(String(reason?.message ?? reason));
+    }
+  };
+
+  const selectStrategy = (strategy: Strategy) => navigate(`/strategies/${strategy.id}`);
+
+  const editor = (
+    <div className="Strategies__Editor">
+      <TextField
+        label="Name"
+        value={input.name}
+        onChange={(event) => setInput({ ...input, name: event.target.value })}
+      />
+      <TextField
+        label="Description"
+        value={input.description}
+        onChange={(event) => setInput({ ...input, description: event.target.value })}
+      />
+      <TextField
+        label="Cost per map (chaos)"
+        type="number"
+        value={input.costPerMap}
+        onChange={(event) => setInput({ ...input, costPerMap: Number(event.target.value) })}
+      />
+      <label>
+        Color{' '}
+        <input
+          type="color"
+          value={input.color}
+          onChange={(event) => setInput({ ...input, color: event.target.value })}
+        />
+      </label>
+      <Button variant="contained" onClick={save}>
+        Save
+      </Button>
+    </div>
+  );
+
+  return (
+    <div className="Strategies Page Box">
+      <div className="Strategies__Layout">
+        <aside className="Strategies__Nav">
+          <div className="Page__Title">Strategies</div>
+          {strategies.map((strategy) => (
+            <button
+              className={`Strategies__NavItem ${
+                selected?.id === strategy.id ? 'Strategies__NavItem--selected' : ''
+              }`}
+              key={strategy.id}
+              onClick={() => selectStrategy(strategy)}
+            >
+              <span className="Strategies__Color" style={{ backgroundColor: strategy.color }} />
+              <span>{strategy.name}</span>
+              <small>{strategy.assignmentCount ?? 0}</small>
+            </button>
+          ))}
+          <Button
+            variant="outlined"
+            onClick={() => {
+              setSelected(null);
+              setInput(emptyInput);
+              setEditing(true);
+            }}
+          >
+            New strategy
+          </Button>
+        </aside>
+
+        <main className="Strategies__Content">
+          {error && <div className="Text--Error">{error}</div>}
+          {!selected ? (
+            editing ? (
+              editor
+            ) : (
+              <div className="Strategies__Empty">Create a strategy to start tagging runs.</div>
+            )
+          ) : !statsResult ? (
+            <LinearProgress />
+          ) : (
+            <>
+              <div className="Strategies__Header">
+                <div>
+                  <h1 style={{ color: selected.color }}>{selected.name}</h1>
+                  <p>{selected.description}</p>
+                </div>
+                <div className="Strategies__Actions">
+                  <Button onClick={() => setEditing(!editing)}>
+                    {editing ? 'Cancel' : 'Edit'}
+                  </Button>
+                  <Button color="error" onClick={remove}>
+                    Delete
+                  </Button>
+                </div>
+              </div>
+              {editing && editor}
+              <div className="Strategies__Economics">
+                <div>
+                  Runs: <strong>{statsResult.economics.completedRunCount}</strong>
+                </div>
+                <div>
+                  Cost / map:{' '}
+                  <Price
+                    value={formatNumber(selected.costPerMap)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+                <div>
+                  Gross:{' '}
+                  <Price
+                    value={formatNumber(statsResult.economics.grossValue)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+                <div>
+                  Cost:{' '}
+                  <Price
+                    value={formatNumber(statsResult.economics.totalCost)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+                <div>
+                  Net:{' '}
+                  <Price
+                    value={formatNumber(statsResult.economics.netValue)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+                <div>
+                  Gross / map:{' '}
+                  <Price
+                    value={formatNumber(statsResult.economics.grossPerMap)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+                <div>
+                  Gross / hour:{' '}
+                  <Price
+                    value={formatNumber(statsResult.economics.grossPerHour)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+                <div>
+                  Net / map:{' '}
+                  <Price
+                    value={formatNumber(statsResult.economics.netPerMap)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+                <div>
+                  Net / hour:{' '}
+                  <Price
+                    value={formatNumber(statsResult.economics.netPerHour)}
+                    divinePrice={statsResult.stats.divinePrice}
+                  />
+                </div>
+              </div>
+              {statsResult.economics.incompleteRunCount > 0 && (
+                <div className="Text--small">
+                  {statsResult.economics.incompleteRunCount} incomplete tagged run(s) excluded from
+                  results.
+                </div>
+              )}
+              <Divider />
+              <Tabs value={tab} onChange={(_event, value) => setTab(value)}>
+                <Tab label="Main Stats" />
+                <Tab label="Area Stats" />
+                <Tab label="Boss Stats" />
+                <Tab label="Loot Stats" />
+              </Tabs>
+              {tab === 0 && <MainStats stats={statsResult.stats} />}
+              {tab === 1 && <AreaStats stats={statsResult.stats} />}
+              {tab === 2 && <BossStats stats={statsResult.stats.bosses} />}
+              {tab === 3 && <LootStats stats={statsResult.stats.items} store={itemStore} />}
+            </>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/stores/domain/run.ts
+++ b/src/renderer/stores/domain/run.ts
@@ -2,6 +2,7 @@ import { makeAutoObservable, computed } from 'mobx';
 import { v4 as uuidv4 } from 'uuid';
 import dayjs, { Dayjs } from 'dayjs';
 import ItemStore from '../itemStore';
+import type { RunStrategy } from '../../../shared/strategies';
 
 type JSONRun = {
   id: number;
@@ -55,6 +56,7 @@ export class Run {
   saveHandler = null;
   itemStore: ItemStore | null = null;
   mods: { mod: string }[] = [];
+  strategies: RunStrategy[] = [];
 
   constructor(store, options = {}) {
     const id = uuidv4();
@@ -88,6 +90,13 @@ export class Run {
     this.profitPerHour = this.profit / this.duration.asHours();
     this.kills = json.kills;
     this.runInfo = json.run_info ? JSON.parse(json.run_info) : {};
+    try {
+      this.strategies = Array.isArray(json.strategies)
+        ? json.strategies
+        : JSON.parse(json.strategies || '[]');
+    } catch {
+      this.strategies = [];
+    }
     this.lastUpdate = dayjs();
     this.completed = !!json.completed || false;
   }
@@ -99,6 +108,13 @@ export class Run {
     this.events = details.events;
     this.items = details.items;
     this.mods = details.mods || [];
+    try {
+      this.strategies = Array.isArray(details.strategies)
+        ? details.strategies
+        : JSON.parse(details.strategies || '[]');
+    } catch {
+      this.strategies = this.strategies || [];
+    }
     this.completed = !!details.completed || false;
 
     // Logger.debug('Building Store', details.items);

--- a/src/renderer/stores/runStore.ts
+++ b/src/renderer/stores/runStore.ts
@@ -92,6 +92,12 @@ export default class RunStore {
     });
   }
 
+  async setRunStrategies(run: Run, strategyIds: number[]) {
+    const strategies = await electronService.setRunStrategies(run.runId, strategyIds);
+    run.strategies = Array.isArray(strategies) ? strategies : [];
+    return run.strategies;
+  }
+
   getSortedRuns(size = this.runs.length, page = 0) {
     const startingIndex = page * size;
     return this.runs

--- a/src/shared/contracts/exileDiaryApi.ts
+++ b/src/shared/contracts/exileDiaryApi.ts
@@ -1,3 +1,5 @@
+import type { Strategy, StrategyInput, StrategyStatsResult } from '../strategies';
+
 export const invokeChannels = {
   getAppGlobals: 'app-globals',
   loadRuns: 'load-runs',
@@ -26,6 +28,12 @@ export const invokeChannels = {
   debugFetchStashTabs: 'debug:fetch-stash-tabs',
   getOverlayPersistence: 'overlay:get-persistence',
   updateItemsIgnoreStatus: 'items:filters:db-update',
+  listStrategies: 'strategies:list',
+  createStrategy: 'strategies:create',
+  updateStrategy: 'strategies:update',
+  deleteStrategy: 'strategies:delete',
+  setRunStrategies: 'run:strategies:set',
+  getStrategyStats: 'strategies:stats',
   getOverlayPosition: 'overlay:get-position',
   openFileDialog: 'open-file-dialog',
   showCharacterDbFile: 'show-character-db-file',
@@ -251,6 +259,12 @@ export interface ExileDiaryApi {
   getOverlayPersistence(): Promise<boolean>;
   getOverlayPosition(): Promise<OverlayPosition>;
   updateItemsIgnoreStatus(data: Array<{ id: string; status: boolean }>): Promise<void>;
+  listStrategies(): Promise<Strategy[]>;
+  createStrategy(input: StrategyInput): Promise<Strategy>;
+  updateStrategy(strategyId: number, input: StrategyInput): Promise<Strategy>;
+  deleteStrategy(strategyId: number): Promise<void>;
+  setRunStrategies(runId: string | number, strategyIds: number[]): Promise<any[]>;
+  getStrategyStats(strategyId: number): Promise<StrategyStatsResult>;
   openFileDialog(options: OpenFileDialogOptions): Promise<OpenFileDialogResult>;
   showCharacterDbFile(): Promise<void>;
   refreshUi(): void;

--- a/src/shared/contracts/runtimeSidecar.ts
+++ b/src/shared/contracts/runtimeSidecar.ts
@@ -25,6 +25,12 @@ export const runtimeRendererMethodKeys = [
   'debugFetchRates',
   'debugFetchStashTabs',
   'updateItemsIgnoreStatus',
+  'listStrategies',
+  'createStrategy',
+  'updateStrategy',
+  'deleteStrategy',
+  'setRunStrategies',
+  'getStrategyStats',
 ] as const;
 
 export type RuntimeRendererMethodKey = (typeof runtimeRendererMethodKeys)[number];

--- a/src/shared/strategies.ts
+++ b/src/shared/strategies.ts
@@ -1,0 +1,37 @@
+export type Strategy = {
+  id: number;
+  name: string;
+  description: string;
+  color: string;
+  costPerMap: number;
+  assignmentCount?: number;
+};
+
+export type StrategyInput = {
+  name: string;
+  description: string;
+  color: string;
+  costPerMap: number;
+};
+
+export type RunStrategy = Pick<Strategy, 'id' | 'name' | 'color'>;
+
+export type StrategyEconomics = {
+  taggedRunCount: number;
+  completedRunCount: number;
+  incompleteRunCount: number;
+  totalTimeSeconds: number;
+  grossValue: number;
+  totalCost: number;
+  netValue: number;
+  grossPerMap: number;
+  netPerMap: number;
+  grossPerHour: number;
+  netPerHour: number;
+};
+
+export type StrategyStatsResult = {
+  strategy: Strategy;
+  economics: StrategyEconomics;
+  stats: any;
+};

--- a/test/main/db/strategies.spec.ts
+++ b/test/main/db/strategies.spec.ts
@@ -59,4 +59,19 @@ describe('strategy repository', () => {
       Strategies.create({ name: 'x', description: 'x', color: '#ffffff', costPerMap: -1 })
     ).rejects.toThrow('non-negative');
   });
+
+  it('allows an empty description', async () => {
+    mockDB.run.mockResolvedValue({ lastInsertRowid: 8 } as any);
+    mockDB.get.mockResolvedValue({
+      id: 8,
+      name: 'Atlas',
+      description: '',
+      color: '#AABBCC',
+      costPerMap: 0,
+    });
+
+    await expect(
+      Strategies.create({ name: 'Atlas', description: '', color: '#aabbcc', costPerMap: 0 })
+    ).resolves.toMatchObject({ id: 8, description: '' });
+  });
 });

--- a/test/main/db/strategies.spec.ts
+++ b/test/main/db/strategies.spec.ts
@@ -1,0 +1,62 @@
+jest.mock('../../../src/main/db/index', () => ({
+  all: jest.fn(),
+  get: jest.fn(),
+  run: jest.fn(),
+  transactionSteps: jest.fn(),
+}));
+
+import Strategies from '../../../src/main/db/repositories/strategies';
+import DB from '../../../src/main/db/index';
+
+const mockDB = DB as jest.Mocked<typeof DB>;
+
+describe('strategy repository', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it('normalizes and creates a strategy', async () => {
+    mockDB.run.mockResolvedValue({ lastInsertRowid: 7 } as any);
+    mockDB.get.mockResolvedValue({
+      id: 7,
+      name: 'Atlas',
+      description: 'Red maps',
+      color: '#AABBCC',
+      costPerMap: 12.5,
+    });
+
+    await expect(
+      Strategies.create({
+        name: ' Atlas ',
+        description: ' Red maps ',
+        color: '#aabbcc',
+        costPerMap: 12.5,
+      })
+    ).resolves.toMatchObject({ id: 7, name: 'Atlas', color: '#AABBCC' });
+    expect(mockDB.run).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO strategy'), [
+      'Atlas',
+      'Red maps',
+      '#AABBCC',
+      12.5,
+    ]);
+  });
+
+  it('replaces all run assignments atomically', async () => {
+    mockDB.get.mockResolvedValueOnce({ id: 42 }).mockResolvedValueOnce(undefined);
+    mockDB.all.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]).mockResolvedValueOnce([]);
+    mockDB.transactionSteps.mockResolvedValue(undefined as any);
+    await expect(Strategies.setForRun(42, [1, 2, 2])).resolves.toEqual([]);
+    expect(mockDB.transactionSteps).toHaveBeenCalledWith([
+      { query: 'DELETE FROM run_strategy WHERE run_id = ?', params: [42] },
+      { query: 'INSERT INTO run_strategy(run_id, strategy_id) VALUES(?, ?)', params: [42, 1] },
+      { query: 'INSERT INTO run_strategy(run_id, strategy_id) VALUES(?, ?)', params: [42, 2] },
+    ]);
+  });
+
+  it('rejects invalid definitions', async () => {
+    await expect(
+      Strategies.create({ name: '', description: 'x', color: '#fff', costPerMap: 0 })
+    ).rejects.toThrow('Strategy name is required');
+    await expect(
+      Strategies.create({ name: 'x', description: 'x', color: '#ffffff', costPerMap: -1 })
+    ).rejects.toThrow('non-negative');
+  });
+});

--- a/test/renderer/AppShell.spec.tsx
+++ b/test/renderer/AppShell.spec.tsx
@@ -35,6 +35,8 @@ vi.mock('../../src/renderer/electron.service', () => {
       refreshGlobals: vi.fn(),
       refreshProfitPerHour: vi.fn(),
       requestNetWorthRefresh: vi.fn(),
+      listStrategies: vi.fn().mockResolvedValue([]),
+      setRunStrategies: vi.fn().mockResolvedValue([]),
     },
   };
 });

--- a/test/ui/mockExileDiaryApi.ts
+++ b/test/ui/mockExileDiaryApi.ts
@@ -180,6 +180,24 @@ export function installMockExileDiaryApi(requestedScenario: string) {
     getOverlayPersistence: async () => state.overlayPersistence,
     getOverlayPosition: async () => structuredClone(state.overlayPosition),
     updateItemsIgnoreStatus: async (data) => record('updateItemsIgnoreStatus', data),
+    listStrategies: async () => [],
+    createStrategy: async (input) => {
+      record('createStrategy', input);
+      return {} as any;
+    },
+    updateStrategy: async (strategyId, input) => {
+      record('updateStrategy', { strategyId, input });
+      return {} as any;
+    },
+    deleteStrategy: async (strategyId) => record('deleteStrategy', strategyId),
+    setRunStrategies: async (runId, strategyIds) => {
+      record('setRunStrategies', { runId, strategyIds });
+      return [];
+    },
+    getStrategyStats: async (strategyId) => {
+      record('getStrategyStats', strategyId);
+      return {} as any;
+    },
     openFileDialog: async (options) => {
       record('openFileDialog', options);
       return { canceled: false, filePaths: ['C:\\Fixture'] };


### PR DESCRIPTION
## What changed

- Add user-defined strategies with color, name, description, and cost per map.
- Allow runs to carry zero or more strategy tags, shown on run details and the run list.
- Add strategy navigation and result views with raw benefit and cost-adjusted statistics.
- Remove the Graftblood column from the run list.

## Validation

- `npm run test:main -- test/main/db/strategies.spec.ts`
- `npm run typecheck:renderer`
- Main Jest suite: 74 suites / 532 tests passed.

Note: the initial combined `npm test -- …` invocation also forwarded the main-test path to the renderer project; the focused commands above pass.