### PR TITLE
Fix overlay map profit totals

### DIFF
--- a/src/main/db/repositories/run.ts
+++ b/src/main/db/repositories/run.ts
@@ -70,6 +70,7 @@ type AreaInfo = {
 interface ItemsFromTimestamp extends Item {
   event_text: string;
   drop_time: string;
+  zone_event_id: number;
 }
 
 const getItemNameFromIcon = (iconUrl: string) => {
@@ -273,6 +274,26 @@ const Runs = {
     const events = await DB.all(eventsQuery, [mapId]);
 
     return events;
+  },
+
+  getRunProfit: async (runId: number): Promise<number | null> => {
+    logger.info(`Getting persisted profit for run ${runId}`);
+    const query = `
+      SELECT COALESCE(SUM(item.value), 0) AS gained
+      FROM run
+      LEFT JOIN event
+        ON DATETIME(event.timestamp) BETWEEN DATETIME(run.first_event) AND DATETIME(run.last_event)
+      LEFT JOIN item
+        ON item.event_id = event.id AND item.ignored = 0
+      WHERE run.id = ?
+    `;
+    try {
+      const row = await DB.get(query, [runId]);
+      return Number(row?.gained ?? 0);
+    } catch (err) {
+      logger.error(`Error getting persisted profit: ${JSON.stringify(err)}`);
+      return null;
+    }
   },
 
   getRunInfo: async (mapId: number): Promise<any> => {
@@ -698,7 +719,7 @@ const Runs = {
   ): Promise<ItemsFromTimestamp[]> => {
     logger.info(`Getting items dropped between ${startTime} and ${endTime}`);
     const query = `
-      SELECT event_text, item.*, event.timestamp AS drop_time
+      SELECT event_text, item.*, event.id AS zone_event_id, event.timestamp AS drop_time
       FROM event, run
         LEFT JOIN item
         ON item.event_id = event.id

--- a/src/main/modules/RunParser.ts
+++ b/src/main/modules/RunParser.ts
@@ -337,7 +337,7 @@ const RunParser = {
 
     if (formattedItems.length > 0) {
       logger.debug(formattedItems);
-      RunParser.updateItemValues(formattedItems);
+      await RunParser.updateItemValues(formattedItems);
     }
 
     return { count, value: totalValue, importantDrops };
@@ -360,7 +360,7 @@ const RunParser = {
 
       // Get Zones from the items list
       const zones: Zone[] = rows
-        .map((row) => ({ event_text: row.event_text, id: row.event_id }))
+        .map((row) => ({ event_text: row.event_text, id: row.zone_event_id }))
         .filter((zone, index, self) => self.findIndex((t) => t.id === zone.id) === index);
       logger.debug(`Got ${zones.length} zones`);
       logger.debug(zones);
@@ -969,9 +969,10 @@ const RunParser = {
     ];
 
     await RunParser.updateMapRun(runId, runArguments);
+    const persistedProfit = await DB.getRunProfit(runId);
     return {
       name: areaInfo.name,
-      gained: items.value,
+      gained: persistedProfit ?? items.value,
       xp: xpDiff,
       kills: killCount > -1 ? killCount : null,
       firstEvent,

--- a/test/main/db/run.spec.ts
+++ b/test/main/db/run.spec.ts
@@ -235,6 +235,21 @@ describe('Runs', () => {
     });
   });
 
+  describe('getRunProfit', () => {
+    it('uses the persisted non-ignored item sum for completed-run profit', async () => {
+      mockDB.get.mockClear();
+      mockDB.get.mockResolvedValue({ gained: 1012.21 });
+
+      await expect(Runs.getRunProfit(199)).resolves.toBe(1012.21);
+
+      expect(mockDB.get).toHaveBeenCalledWith(
+        expect.stringContaining('SUM(item.value)'),
+        [199]
+      );
+      expect(mockDB.get.mock.calls.at(-1)?.[0]).toContain('item.ignored = 0');
+    });
+  });
+
   describe('getItems', () => {
     it('should get and format items for a run', async () => {
       const mapId = 42;
@@ -539,6 +554,21 @@ describe('Runs', () => {
         [from, to]
       );
       expect(result).toEqual(mockRuns);
+    });
+  });
+
+  describe('getItemsBetweenEvents', () => {
+    it('selects the source event id even when an event has no item row', async () => {
+      mockDB.all.mockResolvedValue([]);
+
+      await expect(
+        Runs.getItemsBetweenEvents('2026-07-22T09:00:00.000Z', '2026-07-22T10:00:00.000Z')
+      ).resolves.toEqual([]);
+
+      expect(mockDB.all).toHaveBeenCalledWith(
+        expect.stringContaining('event.id AS zone_event_id'),
+        ['2026-07-22T09:00:00.000Z', '2026-07-22T10:00:00.000Z']
+      );
     });
   });
 

--- a/test/main/modules/RunParser.spec.ts
+++ b/test/main/modules/RunParser.spec.ts
@@ -24,6 +24,7 @@ jest.mock('../../../src/main/db/run', () => ({
     updateLastEvent: jest.fn(),
     insertEvent: jest.fn(),
     getItemsBetweenEvents: jest.fn(),
+    getRunProfit: jest.fn(),
     getLatestUncompletedRun: jest.fn(),
     getDeferredRun: jest.fn(),
     markRunDeferred: jest.fn(),
@@ -485,11 +486,13 @@ describe('RunParser', () => {
     it('counts explicit-end items associated with a synthetic closing zone', async () => {
       const firstZone = {
         event_text: 'Dunes Map',
+        zone_event_id: 1,
         event_id: 1,
         item_id: null,
       };
       const closingZoneItem = {
         event_text: 'Dunes Map',
+        zone_event_id: 2,
         event_id: 2,
         item_id: 42,
       };
@@ -517,6 +520,46 @@ describe('RunParser', () => {
       });
 
       expect(RunParser.parseItems).toHaveBeenCalledWith([closingZoneItem]);
+    });
+
+    it('keeps separate map re-entry zones when itemless events have null item ids', async () => {
+      jest.restoreAllMocks();
+      const firstMap = { event_text: 'Dunes Map', zone_event_id: 1, event_id: null, item_id: null };
+      const firstHideoutItem = {
+        event_text: 'Hideout',
+        zone_event_id: 2,
+        event_id: 2,
+        item_id: 42,
+      };
+      const secondMap = { event_text: 'Dunes Map', zone_event_id: 3, event_id: null, item_id: null };
+      const secondHideoutItem = {
+        event_text: 'Hideout',
+        zone_event_id: 4,
+        event_id: 4,
+        item_id: 43,
+      };
+      (RunsDB.getItemsBetweenEvents as jest.Mock).mockResolvedValue([
+        firstMap,
+        firstHideoutItem,
+        secondMap,
+        secondHideoutItem,
+      ]);
+      (Utils.isTown as jest.Mock).mockImplementation((area) => area === 'Hideout');
+      const parseItems = jest
+        .spyOn(RunParser, 'parseItems')
+        .mockResolvedValueOnce({ count: 1, value: 5, importantDrops: {} })
+        .mockResolvedValueOnce({ count: 1, value: 7, importantDrops: {} });
+
+      await expect(
+        RunParser.generateItemStats(
+          '123',
+          '2026-07-22T09:00:00.000Z',
+          '2026-07-22T10:00:00.000Z'
+        )
+      ).resolves.toEqual({ count: 2, value: 12, importantDrops: {} });
+
+      expect(parseItems).toHaveBeenNthCalledWith(1, [firstHideoutItem]);
+      expect(parseItems).toHaveBeenNthCalledWith(2, [secondHideoutItem]);
     });
   });
 


### PR DESCRIPTION
## What changed

- Preserve source event IDs for itemless map transitions during item accounting.
- Await item-value persistence before completing accounting.
- Use the persisted non-ignored item sum as the completed-run profit sent to the overlay, with a provisional fallback.
- Add regression coverage for multi-portal captures and persisted totals.

## Why

The overlay was displaying the provisional value from the first map-to-hideout inventory batch. Itemless map re-entry events shared a null item event ID, so later captures were collapsed or skipped. The run view instead sums all persisted non-ignored items, causing the overlay to under-report multi-portal runs.

## Validation

- `npm run test:main` — 74 suites, 536 tests
- `npm run typecheck:main`
- `git diff --check`