### PR TITLE
feat(strategies): add shareable strategy summary

### DIFF
--- a/src/main/StatsManager.ts
+++ b/src/main/StatsManager.ts
@@ -8,7 +8,7 @@ import { Run } from '../helpers/types';
 import Constants from '../helpers/constants';
 import ItemPricer from './pricing/matching/ItemPricer';
 import Strategies from './db/repositories/strategies';
-import type { StrategyEconomics } from '../shared/strategies';
+import type { StrategyActivityStats, StrategyEconomics } from '../shared/strategies';
 const { areas } = Constants;
 
 dayjs.extend(duration);
@@ -973,6 +973,16 @@ const statsManager = {
     const netPerMap = completedRunCount > 0 ? netValue / completedRunCount : 0;
     const grossPerHour = totalTimeSeconds > 0 ? (grossValue / totalTimeSeconds) * 3600 : 0;
     const netPerHour = totalTimeSeconds > 0 ? (netValue / totalTimeSeconds) * 3600 : 0;
+    const totalXp = runs.reduce((total: number, run: any) => total + (Number(run.xpgained) || 0), 0);
+    const totalDeaths = runs.reduce((total: number, run: any) => total + (Number(run.deaths) || 0), 0);
+    const activity: StrategyActivityStats = {
+      totalXp,
+      xpPerMap: completedRunCount > 0 ? totalXp / completedRunCount : 0,
+      xpPerHour: totalTimeSeconds > 0 ? (totalXp / totalTimeSeconds) * 3600 : 0,
+      totalDeaths,
+      deathsPerMap: completedRunCount > 0 ? totalDeaths / completedRunCount : 0,
+      deathsPerHour: totalTimeSeconds > 0 ? (totalDeaths / totalTimeSeconds) * 3600 : 0,
+    };
     const economics: StrategyEconomics = {
       taggedRunCount: taggedRuns.length,
       completedRunCount,
@@ -986,7 +996,7 @@ const statsManager = {
       grossPerHour,
       netPerHour,
     };
-    return { ...manager.stats, strategy, economics };
+    return { ...manager.stats, strategy, economics, activity };
   },
   getAllMapNames: async () => {
     const mapNames = await DB.getAllMapNames();

--- a/src/main/db/repositories/stats.ts
+++ b/src/main/db/repositories/stats.ts
@@ -53,6 +53,8 @@ const stats = {
     const query = `
       SELECT
         area_info.name, run.*,
+        (run.xp - (SELECT xp FROM run m WHERE m.id < run.id AND xp IS NOT null ORDER BY m.id desc LIMIT 1)) xpgained,
+        (SELECT count(1) FROM event WHERE event_type='slain' AND DATETIME(event.timestamp) BETWEEN DATETIME(run.first_event) AND DATETIME(run.last_event)) deaths,
         (SELECT COALESCE(SUM(value),0) 
             FROM item
             INNER JOIN event ON event.id = item.event_id

--- a/src/main/runtime-core/use-cases/createRendererStatsUseCases.ts
+++ b/src/main/runtime-core/use-cases/createRendererStatsUseCases.ts
@@ -1,4 +1,5 @@
 import logger from 'electron-log';
+import type { StrategyStatsResult } from '../../../shared/strategies';
 import { RendererStatsUseCaseDependencies } from '../rendererRuntimeDependencies';
 
 export function createRendererStatsUseCases(deps: RendererStatsUseCaseDependencies) {
@@ -30,11 +31,13 @@ export function createRendererStatsUseCases(deps: RendererStatsUseCaseDependenci
         deps.now(),
         profile?.league
       );
-      return {
+      const result: StrategyStatsResult = {
         strategy: stats.strategy,
         economics: stats.economics,
+        activity: stats.activity,
         stats,
       };
+      return result;
     },
 
     async triggerSearch(params: Record<string, any>) {

--- a/src/renderer/components/Pricing/Price.tsx
+++ b/src/renderer/components/Pricing/Price.tsx
@@ -3,14 +3,24 @@ import ChaosIcon from './ChaosIcon';
 import DivineIcon from './DivineIcon';
 import './Pricing.css';
 
-const OptionalDivineValue = ({ value, divinePrice, displayChaos }) => {
+export const formatPriceNumber = (value, compact = false) => {
+  const numericValue = parseFloat(value) || 0;
+  const roundedValue = parseFloat(numericValue.toFixed(2));
+  if (!compact || Math.abs(roundedValue) < 100_000) return roundedValue;
+
+  const divisor = Math.abs(roundedValue) >= 1_000_000 ? 1_000_000 : 1_000;
+  const suffix = divisor === 1_000_000 ? 'm' : 'k';
+  return `${parseFloat((roundedValue / divisor).toFixed(2))}${suffix}`;
+};
+
+const OptionalDivineValue = ({ value, divinePrice, displayChaos, compact }) => {
   const parsedDivinePrice = parseFloat(divinePrice);
   const parsedValue = parseFloat(value);
   if (parsedDivinePrice > 0 && parsedValue > 0.01 * parsedDivinePrice) {
     return (
       <>
         {displayChaos && '('}
-        {(parsedValue / parsedDivinePrice).toFixed(2)}
+        {formatPriceNumber(parsedValue / parsedDivinePrice, compact)}
         <DivineIcon />
         {displayChaos && ')'}
       </>
@@ -19,7 +29,7 @@ const OptionalDivineValue = ({ value, divinePrice, displayChaos }) => {
   return <></>;
 };
 
-const Price = ({ value, divinePrice = 0, displayChaos = true }) => {
+const Price = ({ value, divinePrice = 0, displayChaos = true, compact = false }) => {
   const realDivinePrice = divinePrice ?? 0;
   const shouldDisplayChaos = displayChaos || value < realDivinePrice;
   const formattedValue = parseFloat(parseFloat(value).toFixed(2)); // We make sure all values are formatted to 2 decimal places
@@ -27,7 +37,7 @@ const Price = ({ value, divinePrice = 0, displayChaos = true }) => {
     <span className="Price">
       {shouldDisplayChaos && (
         <>
-          {formattedValue}
+          {formatPriceNumber(formattedValue, compact)}
           <ChaosIcon />{' '}
         </>
       )}
@@ -35,6 +45,7 @@ const Price = ({ value, divinePrice = 0, displayChaos = true }) => {
         value={formattedValue}
         divinePrice={realDivinePrice}
         displayChaos={shouldDisplayChaos}
+        compact={compact}
       />
     </span>
   );

--- a/src/renderer/components/Strategies/StrategySummary.tsx
+++ b/src/renderer/components/Strategies/StrategySummary.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo } from 'react';
+import dayjs from 'dayjs';
+import type { Strategy, StrategyActivityStats, StrategyEconomics } from '../../../shared/strategies';
+import Price from '../Pricing/Price';
+
+type Props = {
+  strategy: Strategy;
+  economics: StrategyEconomics;
+  activity?: StrategyActivityStats;
+  stats: any;
+  exportRef: React.RefObject<HTMLDivElement>;
+  includeFooter: boolean;
+  exporting: boolean;
+  characterName?: string;
+  league?: string;
+};
+
+const format = (value: number, digits = 2) => (Number(value) || 0).toLocaleString('en-US', {
+  minimumFractionDigits: digits,
+  maximumFractionDigits: digits,
+});
+const priceFormat = (value: number) => (Number(value) || 0).toFixed(2);
+const formatDuration = (value: number) => {
+  const totalSeconds = Math.max(0, Math.round(Number(value) || 0));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours, minutes, seconds].map((part) => String(part).padStart(2, '0')).join(':');
+};
+const formatLootTime = (value?: string | null) => {
+  const timestamp = dayjs(value);
+  return value && timestamp.isValid() ? timestamp.format('YYYY-MM-DD HH:mm:ss') : 'Unknown time';
+};
+const mapsPerHour = (completedRunCount: number, totalTimeSeconds: number) =>
+  totalTimeSeconds > 0 ? completedRunCount / (totalTimeSeconds / 3600) : 0;
+
+const normalizeLoot = (row: any) => {
+  let item = row;
+  try { item = { ...row, ...JSON.parse(row.raw_data ?? '{}') }; } catch { /* use row */ }
+  const type = item.hybrid?.baseTypeName ?? item.typeLine ?? item.name ?? 'Unknown item';
+  const name = item.name || item.secretName;
+  return {
+    name: name ? `${type} (${name})` : type,
+    quantity: Number(item.maxStackSize)
+      ? Number(item.pickupStackSize ?? item.stackSize ?? 1)
+      : 1,
+    totalValue: Number(row.value ?? item.value) || 0,
+    lootedAt: row.drop_timestamp ?? item.drop_timestamp ?? null,
+  };
+};
+
+const groupedLoot = (loot: any[] = []) => {
+  const groups = new Map<string, { name: string; quantity: number; totalValue: number }>();
+  for (const row of loot) {
+    const item = normalizeLoot(row);
+    const group = groups.get(item.name) ?? { name: item.name, quantity: 0, totalValue: 0 };
+    group.quantity += item.quantity;
+    group.totalValue += item.totalValue;
+    groups.set(item.name, group);
+  }
+  return [...groups.values()].sort((a, b) => b.totalValue - a.totalValue || a.name.localeCompare(b.name)).slice(0, 5);
+};
+
+const priciestDrops = (loot: any[] = []) =>
+  loot
+    .map(normalizeLoot)
+    .sort((a, b) => b.totalValue - a.totalValue || a.name.localeCompare(b.name))
+    .slice(0, 3);
+
+const Metric = ({ label, value, detail, tone }: { label: string; value: React.ReactNode; detail?: React.ReactNode; tone?: 'positive' | 'negative' }) => (
+  <div className="Strategies__SummaryMetric">
+    <span>{label}</span>
+    <strong>{tone ? <span className={tone}>{value}</span> : value}</strong>
+    {detail && <small className="Strategies__SummaryMetricDetail">{detail}</small>}
+  </div>
+);
+
+export default function StrategySummary({ strategy, economics, activity, stats, exportRef, includeFooter, exporting, characterName, league }: Props) {
+  const safeActivity = activity ?? { totalXp: 0, xpPerMap: 0, xpPerHour: 0, totalDeaths: 0, deathsPerMap: 0, deathsPerHour: 0 };
+  const loot = useMemo(() => groupedLoot(stats?.items?.loot), [stats?.items?.loot]);
+  const drops = useMemo(() => priciestDrops(stats?.items?.loot), [stats?.items?.loot]);
+  const divinePrice = stats?.divinePrice ?? stats?.items?.divinePrice ?? 0;
+  const price = (value: number) => <Price value={priceFormat(value)} divinePrice={divinePrice} compact />;
+  return (
+    <div
+      ref={exportRef}
+      className={`Strategies__SummaryCard${
+        exporting ? ' Strategies__SummaryCard--exporting' : ''
+      }`}
+    >
+      {includeFooter && (
+        <div className="Strategies__SummaryProfile">
+          Stats for <span className="Text--Legendary">{characterName || 'Unknown character'}</span>{' '}
+          in the <span className="Text--Legendary">{league || 'Unknown'}</span> League
+        </div>
+      )}
+      <header className="Strategies__SummaryHeader"><div><h1 style={{ color: strategy.color }}>{strategy.name}</h1>{strategy.description && <p>{strategy.description}</p>}</div><div className="Strategies__SummaryRuns"><strong>{economics.completedRunCount.toLocaleString('en-US')}</strong><span>completed runs</span></div></header>
+      <div className="Strategies__SummaryGrid">
+        <section className="Strategies__SummarySection"><h2>Economics</h2><div className="Strategies__SummaryMetrics">
+          <Metric label="Cost / map" value={price(strategy.costPerMap)} />
+          <Metric label="Total Cost" value={price(economics.totalCost)} />
+          <Metric label="Gross / hour" value={price(economics.grossPerHour)} detail={<><span>{price(economics.grossValue)} total</span><span>{price(economics.grossPerMap)} / map</span></>} />
+          <Metric label="Net / hour" value={price(economics.netPerHour)} detail={<><span>{price(economics.netValue)} total</span><span>{price(economics.netPerMap)} / map</span></>} />
+        </div></section>
+        <section className="Strategies__SummarySection"><h2>Progress</h2><div className="Strategies__SummaryMetrics">
+          <Metric
+            label="Time spent"
+            value={formatDuration(economics.totalTimeSeconds)}
+            detail={`${formatDuration(
+              economics.completedRunCount > 0
+              ? economics.totalTimeSeconds / economics.completedRunCount
+                : 0
+              )} / map`}
+          />
+          <Metric
+            label="Maps per hour"
+            value={format(mapsPerHour(economics.completedRunCount, economics.totalTimeSeconds))}
+          />
+          <Metric
+            label="XP / hour"
+            value={format(safeActivity.xpPerHour, 0)}
+            detail={<><span><span className="positive">{format(safeActivity.totalXp, 0)}</span> total</span><span><span className="positive">{format(safeActivity.xpPerMap, 0)}</span> / map</span></>}
+            tone="positive"
+          />
+          <Metric
+            label="Deaths / hour"
+            value={format(safeActivity.deathsPerHour)}
+            detail={<><span><span className="negative">{format(safeActivity.totalDeaths, 0)}</span> total</span><span><span className="negative">{format(safeActivity.deathsPerMap)}</span> / map</span></>}
+            tone="negative"
+          />
+        </div></section>
+        <section className="Strategies__SummarySection Strategies__SummaryLoot"><h2>Top loot</h2>{loot.length === 0 ? <p className="Text--small">No loot recorded.</p> : <ol>{loot.map((item) => <li key={item.name}><span>{item.name} x {item.quantity.toLocaleString('en-US')}</span><strong>{price(item.totalValue)}</strong></li>)}</ol>}</section>
+        <section className="Strategies__SummarySection Strategies__SummaryLoot"><h2>Priciest drops</h2>{drops.length === 0 ? <p className="Text--small">No loot recorded.</p> : <ol>{drops.map((item, index) => <li key={`${item.name}-${index}`}><span className="Strategies__SummaryLootDetails"><span>{item.name}{item.quantity > 1 ? ` x ${item.quantity.toLocaleString('en-US')}` : ''}</span><small>Looted {formatLootTime(item.lootedAt)}</small></span><strong>{price(item.totalValue)}</strong></li>)}</ol>}</section>
+      </div>
+      {economics.incompleteRunCount > 0 && <p className="Text--small">{economics.incompleteRunCount} incomplete tagged run(s) excluded from results.</p>}
+      {includeFooter && <footer className="Strategies__SummaryFooter">
+              Generated by <span className="Text--Legendary">Exile Diary Reborn</span>. Find out
+              more on <span className="Text--Magic">https://exilediary.com</span>
+            </footer>}
+    </div>
+  );
+}
+
+export { formatDuration, formatLootTime, groupedLoot, mapsPerHour, priciestDrops };

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -5,7 +5,7 @@ html {
     'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-family: FontIn;
+  font-family: Fontin;
   color: #aaaaaa;
   background: #000;
   padding: 0;
@@ -230,7 +230,7 @@ span.negative {
 
 .Page__Title {
   margin: 10px 0;
-  font-family: FontInSmallCaps;
+  font-family: FontinSmallCaps;
   font-size: 1.5em;
   color: white;
   text-align: center;

--- a/src/renderer/routes/Strategies.css
+++ b/src/renderer/routes/Strategies.css
@@ -5,11 +5,34 @@
 .Strategies__NavItem small { margin-left: auto; opacity: .7; }
 .Strategies__Color { width: 12px; height: 12px; border-radius: 50%; flex: 0 0 auto; }
 .Strategies__Content { flex: 1; min-width: 0; }
-.Strategies__Header { display: flex; justify-content: space-between; align-items: flex-start; }
-.Strategies__Header h1 { margin: 0; }
-.Strategies__Header p { margin-top: 4px; }
+.Strategies__Header { display: flex; justify-content: flex-end; align-items: flex-start; margin-bottom: 12px; }
 .Strategies__Actions { display: flex; gap: 4px; }
 .Strategies__Editor { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin: 12px 0; }
-.Strategies__Economics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin: 16px 0; }
-.Strategies__Economics > div { padding: 10px; border: 1px solid rgba(255,255,255,.15); }
+.Strategies__SummaryCard { color: #fff; padding: 20px; border-radius: 6px; font-family: Fontin; }
+.Strategies__SummaryCard--exporting { box-sizing: border-box; width: 1000px; border-radius: 0; background: #000; }
+.Strategies__SummaryCard--exporting .Strategies__SummaryGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.Strategies__SummaryCard--exporting .Strategies__SummaryLoot { grid-column: 1 / -1; }
+.Strategies__SummaryProfile { margin-bottom: 14px; text-align: center; font-family: FontinSmallCaps; font-size: 1.2rem; }
+.Strategies__SummaryHeader { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; }
+.Strategies__SummaryHeader h1 { margin: 0; font-family: FontinSmallCaps; }
+.Strategies__SummaryHeader p { margin: 5px 0 0; opacity: .8; }
+.Strategies__SummaryRuns { display: flex; flex-direction: column; align-items: flex-end; white-space: nowrap; }
+.Strategies__SummaryRuns strong { font-size: 1.5rem; }
+.Strategies__SummaryRuns span, .Strategies__SummaryMetric > span, .Strategies__SummaryMetric > small { opacity: .75; }
+.Strategies__SummaryGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-top: 18px; }
+.Strategies__SummarySection { display: flex; flex-direction: column; border: 1px solid rgba(255,255,255,.15); padding: 12px; }
+.Strategies__SummarySection h2 { text-align: center; font-size: 1rem; margin: 0 0 10px; font-family: FontinSmallCaps; }
+.Strategies__SummaryMetrics { display: grid; flex: 1; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: repeat(2, minmax(0, 1fr)); column-gap: 10px; row-gap: 10px; }
+.Strategies__SummaryMetric { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.Strategies__SummaryMetric strong { font-size: 1.1rem; }
+.Strategies__SummaryMetric small { font-size: .75rem; }
+.Strategies__SummaryMetricDetail { display: flex; flex-direction: column; gap: 2px; }
+.Strategies__SummaryLoot { grid-column: 1 / -1; }
+.Strategies__SummaryLoot ol { margin: 0; padding-left: 1.4rem; }
+.Strategies__SummaryLoot li { display: flex; justify-content: space-between; gap: 12px; padding: 4px 0; }
+.Strategies__SummaryLoot li span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.Strategies__SummaryLootDetails { display: flex; flex-direction: column; min-width: 0; }
+.Strategies__SummaryLootDetails small { opacity: .7; }
+.Strategies__SummaryFooter { margin-top: 14px; padding-top: 12px; text-align: center; opacity: .75; }
+@media (max-width: 800px) { .Strategies__SummaryGrid { grid-template-columns: 1fr; } .Strategies__SummaryLoot { grid-column: auto; } }
 .Strategies__Empty { padding: 40px; text-align: center; }

--- a/src/renderer/routes/Strategies.tsx
+++ b/src/renderer/routes/Strategies.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button, Divider, LinearProgress, Tab, Tabs, TextField } from '@mui/material';
 import MainStats from '../components/Stats/MainStats/MainStats';
@@ -6,9 +6,11 @@ import AreaStats from '../components/Stats/AreaStats/AreaStats';
 import BossStats from '../components/Stats/BossStats/BossStats';
 import LootStats from '../components/Stats/LootStats/LootStats';
 import ItemStore from '../stores/itemStore';
-import Price from '../components/Pricing/Price';
+import StrategySummary from '../components/Strategies/StrategySummary';
 import { electronService } from '../electron.service';
 import type { Strategy, StrategyInput } from '../../shared/strategies';
+import { toCanvas } from 'html-to-image';
+import dayjs from 'dayjs';
 import './Strategies.css';
 
 const randomStrategyColor = () =>
@@ -31,22 +33,28 @@ const strategyToInput = (strategy: Strategy): StrategyInput => ({
   costPerMap: strategy.costPerMap,
 });
 
-const formatNumber = (value: number) => (Number(value) || 0).toFixed(2);
-
 export default function Strategies() {
   const navigate = useNavigate();
   const { strategyId } = useParams();
   const [strategies, setStrategies] = useState<Strategy[]>([]);
+  const [activeProfile, setActiveProfile] = useState<any>(null);
   const [selected, setSelected] = useState<Strategy | null>(null);
   const [statsResult, setStatsResult] = useState<any>(null);
   const [tab, setTab] = useState(0);
   const [input, setInput] = useState<StrategyInput>(createEmptyInput);
   const [editing, setEditing] = useState(false);
   const [error, setError] = useState('');
+  const [exporting, setExporting] = useState(false);
+  const summaryRef = useRef<HTMLDivElement>(null);
   const itemStore = useMemo(() => new ItemStore([]), []);
 
   const loadStrategies = async () => {
-    const loaded = (await electronService.listStrategies()) ?? [];
+    const [loadedStrategies, settings] = await Promise.all([
+      electronService.listStrategies(),
+      electronService.getSettings(),
+    ]);
+    const loaded = loadedStrategies ?? [];
+    setActiveProfile(settings?.activeProfile ?? null);
     setStrategies(loaded);
     const id = strategyId ? Number(strategyId) : loaded[0]?.id;
     const next = loaded.find((strategy) => strategy.id === id) ?? null;
@@ -120,6 +128,35 @@ export default function Strategies() {
   };
 
   const selectStrategy = (strategy: Strategy) => navigate(`/strategies/${strategy.id}`);
+
+  const exportSummary = useCallback(async () => {
+    if (!summaryRef.current || exporting || !selected) return;
+    setExporting(true);
+    try {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      const canvas = await toCanvas(summaryRef.current, {
+        cacheBust: true,
+        backgroundColor: '#000000',
+        width: 1000,
+        canvasWidth: 1000,
+        pixelRatio: 1,
+        style: {
+          backgroundColor: '#000000',
+          width: '1000px',
+        },
+      });
+      const safeName = selected.name.replace(/[^a-z0-9-_]+/gi, '-').replace(/^-|-$/g, '') || 'strategy';
+      const link = document.createElement('a');
+      link.download = `${safeName}-${dayjs().format('YYYY-MM-DD_HH-mm-ss')}.png`;
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+    } catch (reason: any) {
+      setError(String(reason?.message ?? reason));
+      electronService.logger.error('Error saving strategy summary', reason);
+    } finally {
+      setExporting(false);
+    }
+  }, [exporting, selected]);
 
   const editor = (
     <div className="Strategies__Editor">
@@ -199,11 +236,15 @@ export default function Strategies() {
           ) : (
             <>
               <div className="Strategies__Header">
-                <div>
-                  <h1 style={{ color: selected.color }}>{selected.name}</h1>
-                  <p>{selected.description}</p>
-                </div>
                 <div className="Strategies__Actions">
+                  <Button
+                    variant="outlined"
+                    onClick={exportSummary}
+                    disabled={exporting}
+                    aria-label="Export strategy summary as PNG"
+                  >
+                    {exporting ? 'Exporting...' : 'Export PNG'}
+                  </Button>
                   <Button
                     onClick={() => {
                       if (editing) setInput(strategyToInput(selected));
@@ -218,73 +259,17 @@ export default function Strategies() {
                 </div>
               </div>
               {editing && editor}
-              <div className="Strategies__Economics">
-                <div>
-                  Runs: <strong>{statsResult.economics.completedRunCount}</strong>
-                </div>
-                <div>
-                  Cost / map:{' '}
-                  <Price
-                    value={formatNumber(selected.costPerMap)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-                <div>
-                  Gross:{' '}
-                  <Price
-                    value={formatNumber(statsResult.economics.grossValue)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-                <div>
-                  Cost:{' '}
-                  <Price
-                    value={formatNumber(statsResult.economics.totalCost)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-                <div>
-                  Net:{' '}
-                  <Price
-                    value={formatNumber(statsResult.economics.netValue)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-                <div>
-                  Gross / map:{' '}
-                  <Price
-                    value={formatNumber(statsResult.economics.grossPerMap)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-                <div>
-                  Gross / hour:{' '}
-                  <Price
-                    value={formatNumber(statsResult.economics.grossPerHour)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-                <div>
-                  Net / map:{' '}
-                  <Price
-                    value={formatNumber(statsResult.economics.netPerMap)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-                <div>
-                  Net / hour:{' '}
-                  <Price
-                    value={formatNumber(statsResult.economics.netPerHour)}
-                    divinePrice={statsResult.stats.divinePrice}
-                  />
-                </div>
-              </div>
-              {statsResult.economics.incompleteRunCount > 0 && (
-                <div className="Text--small">
-                  {statsResult.economics.incompleteRunCount} incomplete tagged run(s) excluded from
-                  results.
-                </div>
-              )}
+              <StrategySummary
+                strategy={selected}
+                economics={statsResult.economics}
+                activity={statsResult.activity}
+                stats={statsResult.stats}
+                exportRef={summaryRef}
+                includeFooter={exporting}
+                exporting={exporting}
+                characterName={activeProfile?.characterName}
+                league={activeProfile?.league}
+              />
               <Divider />
               <Tabs value={tab} onChange={(_event, value) => setTab(value)}>
                 <Tab label="Main Stats" />

--- a/src/shared/strategies.ts
+++ b/src/shared/strategies.ts
@@ -30,8 +30,18 @@ export type StrategyEconomics = {
   netPerHour: number;
 };
 
+export type StrategyActivityStats = {
+  totalXp: number;
+  xpPerMap: number;
+  xpPerHour: number;
+  totalDeaths: number;
+  deathsPerMap: number;
+  deathsPerHour: number;
+};
+
 export type StrategyStatsResult = {
   strategy: Strategy;
   economics: StrategyEconomics;
+  activity: StrategyActivityStats;
   stats: any;
 };

--- a/test/main/runtime/RendererRuntimeService.spec.ts
+++ b/test/main/runtime/RendererRuntimeService.spec.ts
@@ -196,6 +196,62 @@ describe('RendererRuntimeService', () => {
     );
   });
 
+  it('exposes strategy activity stats to the renderer', async () => {
+    const createRendererRuntimeService = await loadFactory();
+    const deps = createDeps();
+    const strategy = {
+      id: 7,
+      name: 'Juiced Maps',
+      description: 'Fixture strategy',
+      color: '#aabbcc',
+      costPerMap: 25,
+    };
+    const economics = {
+      taggedRunCount: 3,
+      completedRunCount: 2,
+      incompleteRunCount: 1,
+      totalTimeSeconds: 1800,
+      grossValue: 300,
+      totalCost: 50,
+      netValue: 250,
+      grossPerMap: 150,
+      netPerMap: 125,
+      grossPerHour: 600,
+      netPerHour: 500,
+    };
+    const activity = {
+      totalXp: 12_000_000,
+      xpPerMap: 6_000_000,
+      xpPerHour: 24_000_000,
+      totalDeaths: 3,
+      deathsPerMap: 1.5,
+      deathsPerHour: 6,
+    };
+    deps.settingsManager.get.mockImplementation((key: string) =>
+      key === 'activeProfile' ? { league: 'Mirage', characterName: 'Mapper' } : null
+    );
+    deps.statsManager.getAllStats.mockResolvedValue({ strategy, economics, activity, items: {} });
+    deps.itemPricer.getCurrencyByName.mockResolvedValue(180);
+    const runtime = createRendererRuntimeService(deps as any);
+
+    await expect(runtime.getStrategyStats(7)).resolves.toEqual({
+      strategy,
+      economics,
+      activity,
+      stats: { strategy, economics, activity, items: {}, divinePrice: 180 },
+    });
+    expect(deps.statsManager.getAllStats).toHaveBeenCalledWith({
+      league: 'Mirage',
+      characterName: 'Mapper',
+      strategyId: 7,
+    });
+    expect(deps.itemPricer.getCurrencyByName).toHaveBeenCalledWith(
+      'Divine Orb',
+      '20260704',
+      'Mirage'
+    );
+  });
+
   it('marks tracked stash tabs consistently for parent and child tabs', async () => {
     const createRendererRuntimeService = await loadFactory();
     const deps = createDeps();

--- a/test/renderer/StatsPageSource.spec.tsx
+++ b/test/renderer/StatsPageSource.spec.tsx
@@ -23,4 +23,61 @@ describe('Stats page source contracts', () => {
 
     expect(source).not.toContain('keepMounted');
   });
+
+  it('uses the proven canvas export path for strategy summary images', () => {
+    const source = readSource('src', 'renderer', 'routes', 'Strategies.tsx');
+
+    expect(source).toContain("import { toCanvas } from 'html-to-image'");
+    expect(source).toContain("canvas.toDataURL('image/png')");
+    expect(source).toContain("backgroundColor: '#000000'");
+    expect(source).toContain('canvasWidth: 1000');
+    expect(source).toContain('pixelRatio: 1');
+    expect(source).not.toContain('canvasHeight:');
+    expect(source).not.toContain('height: 1000');
+    expect(source).not.toContain('toBlob(');
+    expect(source).not.toContain('saveAs(');
+  });
+
+  it('uses exact font-face names in the strategy export subtree', () => {
+    const strategiesCss = readSource('src', 'renderer', 'routes', 'Strategies.css');
+    const globalCss = readSource('src', 'renderer', 'index.css');
+
+    expect(strategiesCss).toContain('font-family: Fontin;');
+    expect(strategiesCss).toContain('font-family: FontinSmallCaps;');
+    expect(globalCss).not.toContain('font-family: FontIn;');
+    expect(globalCss).not.toContain('font-family: FontInSmallCaps;');
+    expect(strategiesCss).toContain('row-gap: 10px;');
+    expect(strategiesCss).toContain('grid-template-rows: repeat(2, minmax(0, 1fr));');
+  });
+
+  it('uses the run-list semantic colors for strategy XP and deaths', () => {
+    const source = readSource(
+      'src',
+      'renderer',
+      'components',
+      'Strategies',
+      'StrategySummary.tsx'
+    );
+
+    expect(source).toContain('tone="positive"');
+    expect(source).toContain('tone="negative"');
+    expect(source).toContain('Strategies__SummaryMetricDetail');
+  });
+
+  it('includes the active character and league in strategy captures', () => {
+    const route = readSource('src', 'renderer', 'routes', 'Strategies.tsx');
+    const summary = readSource(
+      'src',
+      'renderer',
+      'components',
+      'Strategies',
+      'StrategySummary.tsx'
+    );
+
+    expect(route).toContain('activeProfile?.characterName');
+    expect(route).toContain('activeProfile?.league');
+    expect(summary).toContain('Stats for');
+    expect(summary).toContain('League');
+    expect(summary).toContain('{includeFooter && (');
+  });
 });

--- a/test/renderer/StrategySummary.spec.tsx
+++ b/test/renderer/StrategySummary.spec.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatDuration,
+  formatLootTime,
+  groupedLoot,
+  mapsPerHour,
+  priciestDrops,
+} from '../../src/renderer/components/Strategies/StrategySummary';
+import { formatPriceNumber } from '../../src/renderer/components/Pricing/Price';
+
+describe('strategy summary loot grouping', () => {
+  it('groups by display name, sums quantity and value, and keeps the top five', () => {
+    const loot = Array.from({ length: 6 }, (_, index) => ({
+      typeLine: `Item ${index}`,
+      value: index + 1,
+      maxStackSize: 1,
+      raw_data: JSON.stringify({ typeLine: `Item ${index}` }),
+    }));
+    loot.push(
+      { typeLine: 'Orb', value: 10, maxStackSize: 20, pickupStackSize: 2, raw_data: JSON.stringify({ typeLine: 'Orb' }) },
+      { typeLine: 'Orb', value: 15, maxStackSize: 20, pickupStackSize: 3, raw_data: JSON.stringify({ typeLine: 'Orb' }) }
+    );
+
+    const result = groupedLoot(loot);
+    expect(result).toHaveLength(5);
+    expect(result[0]).toEqual({ name: 'Orb', quantity: 5, totalValue: 25 });
+  });
+
+  it('returns an empty list for missing loot', () => {
+    expect(groupedLoot()).toEqual([]);
+    expect(priciestDrops()).toEqual([]);
+  });
+
+  it('keeps the three priciest individual drops separate', () => {
+    const loot = [
+      { id: 'a', typeLine: 'Divine Orb', value: 180, drop_timestamp: '2026-08-11T12:00:00' },
+      { id: 'b', typeLine: 'Divine Orb', value: 180, drop_timestamp: '2026-08-11T12:01:00' },
+      { id: 'c', typeLine: 'Mirror of Kalandra', value: 50_000, drop_timestamp: '2026-08-11T12:02:00' },
+      { id: 'd', typeLine: 'Sacred Orb', value: 25 },
+    ];
+
+    expect(priciestDrops(loot)).toEqual([
+      { name: 'Mirror of Kalandra', quantity: 1, totalValue: 50_000, lootedAt: '2026-08-11T12:02:00' },
+      { name: 'Divine Orb', quantity: 1, totalValue: 180, lootedAt: '2026-08-11T12:00:00' },
+      { name: 'Divine Orb', quantity: 1, totalValue: 180, lootedAt: '2026-08-11T12:01:00' },
+    ]);
+  });
+
+  it('formats drop timestamps and handles missing values', () => {
+    expect(formatLootTime('2026-08-11T12:34:56')).toBe('2026-08-11 12:34:56');
+    expect(formatLootTime(null)).toBe('Unknown time');
+  });
+
+  it('formats total and per-map durations without wrapping after 24 hours', () => {
+    expect(formatDuration(3_661)).toBe('01:01:01');
+    expect(formatDuration(90_061)).toBe('25:01:01');
+    expect(formatDuration(Number.NaN)).toBe('00:00:00');
+  });
+
+  it('calculates maps per hour and handles an empty duration', () => {
+    expect(mapsPerHour(12, 7_200)).toBe(6);
+    expect(mapsPerHour(12, 0)).toBe(0);
+  });
+
+  it('abbreviates six-digit prices with lowercase units', () => {
+    expect(formatPriceNumber(99_999.99, true)).toBe(99_999.99);
+    expect(formatPriceNumber(100_000, true)).toBe('100k');
+    expect(formatPriceNumber(125_500, true)).toBe('125.5k');
+    expect(formatPriceNumber(1_250_000, true)).toBe('1.25m');
+  });
+});


### PR DESCRIPTION
## Summary

- replace the flat Strategies economics grid with a responsive summary card
- add real XP, death, time, and maps-per-hour activity statistics for completed non-ignored strategy runs
- show grouped top loot and the three priciest individual drops with loot timestamps
- export a consistent 1000px-wide PNG with a black background, capture-only character/league context, and Exile Diary branding
- prioritize per-hour values, stack total/per-map details, color XP and deaths semantically, and compact six-digit prices

## Why

The Strategies page exposed only basic economics and its activity fields were not passed through the renderer runtime response. This made XP and death figures render as defensive zero fallbacks and left no useful shareable overview.

## Implementation

- query XP deltas and death events for strategy runs
- calculate typed activity totals and per-map/per-hour rates in `StatsManager`
- include `activity` in the typed renderer strategy response
- add a dedicated `StrategySummary` renderer component and PNG export flow
- keep Export/Edit/Delete controls outside the capture
- preserve the existing detailed Main, Area, Boss, and Loot tabs

## Validation

Passed:

- `npx jest --config jest.config.js --selectProjects main --runInBand test/main/runtime/RendererRuntimeService.spec.ts` — 8 tests
- `npx vitest run --config vitest.renderer.config.ts test/renderer/StrategySummary.spec.tsx test/renderer/StatsPageSource.spec.tsx` — 13 tests
- `git diff --check`

Baseline failures unrelated to this PR:

- `npm run typecheck:main` — existing preload and pricing runtime dependency contract errors
- `npm run typecheck:renderer` — existing deprecated MUI prop typing errors in `src/renderer/routes/Prices.tsx`
