### PR TITLE
fix(stats): capture full screenshot height

### DIFF
--- a/src/renderer/routes/Stats.tsx
+++ b/src/renderer/routes/Stats.tsx
@@ -13,6 +13,7 @@ import ItemStore from '../stores/itemStore';
 import { toCanvas } from 'html-to-image';
 import { electronService } from '../electron.service';
 import dayjs from 'dayjs';
+import { getFullCaptureDimensions } from '../utils/captureDimensions';
 const { logger } = electronService;
 
 function a11yProps(index: number) {
@@ -82,25 +83,39 @@ const Stats = () => {
   }, [stats]);
 
   const screenshot = useCallback(async () => {
-    if (screenShotRef.current === null) {
+    if (screenShotRef.current === null || isTakingScreenshot) {
       return;
     }
 
     setIsTakingScreenshot(true);
-    toCanvas(screenShotRef.current, { cacheBust: true })
-      .then((canvas) => {
-        const now = dayjs().format('YYYY-MM-DD_HH-mm-ss');
-        const link = document.createElement('a');
-        link.download = `${characterName}_${now}.jpg`;
-        link.href = canvas.toDataURL('image/jpeg');
-        link.click();
-        setIsTakingScreenshot(false);
-      })
-      .catch((error) => {
-        setIsTakingScreenshot(false);
-        logger.error(error);
+    try {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      const captureTarget = screenShotRef.current;
+      if (captureTarget === null) return;
+
+      const { width: captureWidth, height: captureHeight } = getFullCaptureDimensions(captureTarget);
+      const canvas = await toCanvas(captureTarget, {
+        cacheBust: true,
+        width: captureWidth,
+        height: captureHeight,
+        canvasWidth: captureWidth,
+        canvasHeight: captureHeight,
+        style: {
+          overflow: 'visible',
+        },
       });
-  }, [screenShotRef]); // eslint-disable-line react-hooks/exhaustive-deps
+      const now = dayjs().format('YYYY-MM-DD_HH-mm-ss');
+      const link = document.createElement('a');
+      link.download = `${characterName}_${now}.jpg`;
+      link.href = canvas.toDataURL('image/jpeg');
+      link.click();
+    } catch (error) {
+      logger.error(error);
+    } finally {
+      setIsTakingScreenshot(false);
+    }
+  }, [characterName, isTakingScreenshot]);
 
   const screenshotIcon = (
     <div

--- a/src/renderer/utils/captureDimensions.ts
+++ b/src/renderer/utils/captureDimensions.ts
@@ -1,0 +1,6 @@
+type CaptureDimensions = Pick<HTMLElement, 'clientHeight' | 'clientWidth' | 'scrollHeight' | 'scrollWidth'>;
+
+export const getFullCaptureDimensions = (target: CaptureDimensions) => ({
+  width: Math.max(target.scrollWidth, target.clientWidth),
+  height: Math.max(target.scrollHeight, target.clientHeight),
+});

--- a/test/renderer/CaptureDimensions.spec.tsx
+++ b/test/renderer/CaptureDimensions.spec.tsx
@@ -1,0 +1,25 @@
+import { getFullCaptureDimensions } from '../../src/renderer/utils/captureDimensions';
+
+describe('full capture dimensions', () => {
+  it('uses the full scroll extent when content exceeds the visible box', () => {
+    expect(
+      getFullCaptureDimensions({
+        clientWidth: 800,
+        clientHeight: 600,
+        scrollWidth: 820,
+        scrollHeight: 1_750,
+      })
+    ).toEqual({ width: 820, height: 1_750 });
+  });
+
+  it('does not shrink below the visible box', () => {
+    expect(
+      getFullCaptureDimensions({
+        clientWidth: 800,
+        clientHeight: 600,
+        scrollWidth: 0,
+        scrollHeight: 0,
+      })
+    ).toEqual({ width: 800, height: 600 });
+  });
+});

--- a/test/renderer/StatsPageSource.spec.tsx
+++ b/test/renderer/StatsPageSource.spec.tsx
@@ -23,4 +23,14 @@ describe('Stats page source contracts', () => {
 
     expect(source).not.toContain('keepMounted');
   });
+
+  it('waits for screenshot content and captures the full Stats scroll height', () => {
+    const source = readSource('src', 'renderer', 'routes', 'Stats.tsx');
+
+    expect(source).toContain('await new Promise<void>((resolve) => requestAnimationFrame');
+    expect(source).toContain('getFullCaptureDimensions(captureTarget)');
+    expect(source).toContain('height: captureHeight');
+    expect(source).toContain('canvasHeight: captureHeight');
+    expect(source).toContain("overflow: 'visible'");
+  });
 });


### PR DESCRIPTION
## Summary

- wait for screenshot-only Stats content to render before measuring the capture target
- capture the full scroll width and height instead of relying on html-to-image's client-size defaults
- pass consistent source and canvas dimensions and force visible overflow in the cloned subtree
- prevent duplicate captures and always restore the capture UI state
- add focused regression coverage for full-content dimension selection and the Stats export contract

## Root cause

The Stats page set its screenshot state and immediately invoked `html-to-image`. The capture-only footer had not necessarily committed when the library synchronously measured the element. `html-to-image` also defaults to `clientHeight`, so content extending beyond that measured box could be clipped from the bottom.

## Impact

Stats exports now include the entire captured page through the footer, even when the content is taller than the visible application window.

## Validation

Passed:

- `npx vitest run --config vitest.renderer.config.ts test/renderer/CaptureDimensions.spec.tsx test/renderer/StatsPageSource.spec.tsx` — 5 tests
- `npm run test:ui:capture` — 1 populated-route capture test
- `git diff --check`
- independent Ultracode review — no actionable findings

Baseline failure unrelated to this PR:

- `npm run typecheck:renderer` — existing deprecated MUI prop typing errors in `src/renderer/routes/Prices.tsx`

## Testing note

A direct data-URL export assertion was evaluated but not retained because the browser test harness cannot complete `html-to-image` cloning for one embedded resource. The deterministic dimension helper is behavior-tested, the export integration is source-contracted, and the standard UI capture suite passes.
