### PR TITLE
feat(run-list): add configurable columns

### DIFF
--- a/src/main/SettingsManager.ts
+++ b/src/main/SettingsManager.ts
@@ -90,6 +90,24 @@ const DefaultSettings = {
   // How far back the item price-history chart looks: 1-4 weeks, or 'all' for
   // the item's full recorded league history.
   priceHistoryWindowWeeks: 1 as 1 | 2 | 3 | 4 | 'all',
+  runListColumns: {
+    order: [
+      'date',
+      'map',
+      'level',
+      'iiq',
+      'iir',
+      'packSize',
+      'duration',
+      'profit',
+      'profitPerHour',
+      'xpPerHour',
+      'deaths',
+      'kills',
+      'strategies',
+    ],
+    hidden: [],
+  },
 };
 
 class SettingsManager {

--- a/src/renderer/routes/RunList.css
+++ b/src/renderer/routes/RunList.css
@@ -44,10 +44,19 @@
 
 .Run-List__Header__DefaultStrategy {
   position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
+  left: 0;
+  bottom: 0;
   width: 260px;
+}
+
+.Run-List__Header__ColumnAction {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+}
+
+.Run-List__Header__ColumnAction > .MuiButton-root {
+  min-height: 40px;
 }
 
 .Run-List__Header__DefaultStrategy .MuiAutocomplete-root {

--- a/src/renderer/routes/RunList.tsx
+++ b/src/renderer/routes/RunList.tsx
@@ -1,5 +1,4 @@
 import './RunList.css';
-import dayjs from 'dayjs';
 import React from 'react';
 import {
   TableContainer,
@@ -10,23 +9,28 @@ import {
   TableBody,
   Select,
   MenuItem,
-  Drawer,
   Pagination,
   FormControl,
 } from '@mui/material';
 import classNames from 'classnames';
-import ChaosIcon from '../components/Pricing/ChaosIcon';
 import { useNavigate } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { electronService } from '../electron.service';
 import StrategySelector from '../components/Strategies/StrategySelector';
 import type { RunStrategy, Strategy } from '../../shared/strategies';
+import {
+  ColumnsButton,
+  RUN_LIST_COLUMNS,
+  RunListColumnsPopover,
+  useRunListColumns,
+} from '../runListColumns';
 
 const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
   const navigate = useNavigate();
-  const [runsPerPage, setrunsPerPage] = React.useState<number>(NumbersOfMapsToShow);
-  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+  const { preferences, ready } = useRunListColumns();
+  const [runsPerPage, setRunsPerPage] = React.useState(NumbersOfMapsToShow);
   const [page, setPage] = React.useState(0);
+  const [columnsAnchor, setColumnsAnchor] = React.useState<HTMLElement | null>(null);
   const [strategies, setStrategies] = React.useState<Strategy[]>([]);
   const [defaultStrategies, setDefaultStrategies] = React.useState<RunStrategy[]>([]);
 
@@ -37,67 +41,29 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
       .then((loaded) => setStrategies(loaded ?? []))
       .catch(() => undefined);
   }, []);
-
   React.useEffect(() => {
     void electronService
       .getSettings(['defaultStrategyIds'])
       .then((loaded) => {
         const ids: number[] = loaded?.defaultStrategyIds ?? [];
-        if (ids.length === 0) return;
-        const matches = strategies.filter((strategy) => ids.includes(strategy.id));
-        if (matches.length > 0) setDefaultStrategies(matches);
+        setDefaultStrategies(strategies.filter((strategy) => ids.includes(strategy.id)));
       })
       .catch(() => undefined);
   }, [strategies]);
-
   const handleDefaultStrategyChange = (next: Strategy[]) => {
     setDefaultStrategies(next);
     void electronService.saveSettings({ defaultStrategyIds: next.map((strategy) => strategy.id) });
   };
-
-  const togglePopupMenu = () => {
-    setIsDrawerOpen(!isDrawerOpen);
-  };
-
-  const handleMapFilterChange = (event) => {
-    setrunsPerPage(Number(event.target.value));
-    setPage(0);
-  };
-
-  const getXPClassName = (xp: number) => {
-    return classNames({
-      'Run-List__XP--Positive': xp > 0,
-      'Run-List__XP--Negative': xp <= 0,
-    });
-  };
-  const handleRunClick = (mapId) => {
-    navigate(`/run/${mapId}`);
-  };
-  const handleChangePage = (event: unknown, newPage: number) => {
-    setPage(newPage - 1);
-  };
-
-  const FilterMenu = () => {
-    return <div> This feature was disabled - Coming Soon </div>; // TODO: Add filter menu
-  };
-
-  const mainClasses = classNames({
-    Box: isBoxed,
-    'Run-List': true,
-  });
+  const getXPClassName = (xp: number) =>
+    classNames({ 'Run-List__XP--Positive': xp > 0, 'Run-List__XP--Negative': xp <= 0 });
+  const visibleColumns = preferences.order
+    .map((id) => RUN_LIST_COLUMNS.find((column) => column.id === id)!)
+    .filter((column) => !preferences.hidden.includes(column.id));
+  const mainClasses = classNames({ Box: isBoxed, 'Run-List': true });
 
   return (
     <div className={mainClasses}>
       <div className="Run-List__Header">
-        <div className="Page__Title Run-List__Header__Title">
-          Most Recent {store.runs.length} Runs
-        </div>
-        <div className="">
-          (Total Time: {store.getFullDuration().format('D [days] HH[h] mm[m] ss[s]')})
-        </div>
-        {/* <MenuIcon className="Run-List__Header__Burger" onClick={togglePopupMenu}>
-          ≡
-        </MenuIcon> */}
         <div className="Run-List__Header__DefaultStrategy">
           <StrategySelector
             options={strategies}
@@ -107,71 +73,30 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
             placeholder="No strategy"
           />
         </div>
+        <div className="Page__Title Run-List__Header__Title">
+          Most Recent {store.runs.length} Runs
+        </div>
+        <div>(Total Time: {store.getFullDuration().format('D [days] HH[h] mm[m] ss[s]')})</div>
+        <div className="Run-List__Header__ColumnAction">
+          <ColumnsButton onOpen={(event) => setColumnsAnchor(event.currentTarget)} />
+        </div>
       </div>
-      <Drawer anchor="right" open={isDrawerOpen} onClose={togglePopupMenu}>
-        {FilterMenu()}
-      </Drawer>
+      {ready && (
+        <RunListColumnsPopover anchorEl={columnsAnchor} onClose={() => setColumnsAnchor(null)} />
+      )}
       <TableContainer className="Run-List__List">
         <Table size="small" align="center">
           <TableHead>
             <TableRow className="Run-List__List-Header">
-              <TableCell variant="head">Date</TableCell>
-              <TableCell variant="head">Map</TableCell>
-              <TableCell variant="head" align="center">
-                Level
-              </TableCell>
-              <TableCell variant="head" align="center">
-                IIQ
-              </TableCell>
-              <TableCell variant="head" align="center">
-                IIR
-              </TableCell>
-              <TableCell variant="head" align="center">
-                Pack Size
-              </TableCell>
-              <TableCell variant="head">Duration</TableCell>
-              <TableCell variant="head" align="center">
-                <span
-                  style={{
-                    display: 'flex',
-                    gap: '0.2em',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <ChaosIcon />
-                </span>
-              </TableCell>
-              <TableCell variant="head" align="center">
-                <span
-                  style={{
-                    display: 'flex',
-                    gap: '0.2em',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <ChaosIcon />/ Hr
-                </span>
-              </TableCell>
-              <TableCell variant="head" align="center">
-                XP/Hr
-              </TableCell>
-              <TableCell variant="head" align="center">
-                Deaths
-              </TableCell>
-              <TableCell variant="head" align="center">
-                Kills
-              </TableCell>
-              <TableCell variant="head">Strategies</TableCell>
+              {visibleColumns.map((column) => (
+                <TableCell key={column.id} variant="head" align={column.align}>
+                  {column.header}
+                </TableCell>
+              ))}
             </TableRow>
           </TableHead>
           <TableBody>
-            {store.getSortedRuns(runsPerPage, page).map((run, i) => {
-              if (i > runsPerPage) return null;
-              const deaths = [...Array(run.deaths || 0)].map((death, i) => (
-                <div key={`death-${i}`} className="Run__Death-Icon" />
-              ));
+            {store.getSortedRuns(runsPerPage, page).map((run) => {
               const classes = classNames({
                 'Run-list__Run': true,
                 'Run-list__Run--Incomplete': !run.completed,
@@ -179,42 +104,30 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
               return (
                 <TableRow
                   key={run.id}
-                  onClick={() => handleRunClick(run.runId)}
+                  onClick={() => navigate(`/run/${run.runId}`)}
                   className={classes}
                   hover
                 >
-                  <TableCell>{run.firstEvent?.calendar()}</TableCell>
-                  <TableCell>{run.name}</TableCell>
-                  <TableCell align="center">
-                    {run.level}
-                    {run.tier !== null ? ` (T${run.tier})` : '-'}
-                  </TableCell>
-                  <TableCell align="center">{run.iiq ? `${run.iiq}%` : '-'}</TableCell>
-                  <TableCell align="center">{run.iir ? `${run.iir}%` : '-'}</TableCell>
-                  <TableCell align="center">{run.packSize ? `${run.packSize}%` : '-'}</TableCell>
-                  <TableCell>{dayjs.utc(run.duration?.asMilliseconds()).format('mm:ss')}</TableCell>
-                  <TableCell align="center">{run.gained?.toFixed(2)}</TableCell>
-                  <TableCell align="center">{run.gainedPerHour?.toFixed(2)}</TableCell>
-                  <TableCell align="center" className={getXPClassName(run.xpPerHour)}>
-                    {run.completed ? run.xpPerHour.toLocaleString('en') : '-- Ongoing --'}
-                  </TableCell>
-                  <TableCell align="center">{deaths.length > 0 ? deaths : '-'}</TableCell>
-                  <TableCell align="center">
-                    {run.kills && run.kills > -1 ? run.kills : '-'}
-                  </TableCell>
-                  <TableCell onClick={(event) => event.stopPropagation()}>
-                    <StrategySelector
-                      compact
-                      options={strategies}
-                      value={run.strategies}
-                      onChange={(next) =>
-                        store.setRunStrategies(
-                          run,
-                          next.map((strategy) => strategy.id)
-                        )
+                  {visibleColumns.map((column) => (
+                    <TableCell
+                      key={column.id}
+                      align={column.align}
+                      className={
+                        column.id === 'xpPerHour' ? getXPClassName(run.xpPerHour) : undefined
                       }
-                    />
-                  </TableCell>
+                    >
+                      {column.cell(
+                        run,
+                        strategies,
+                        (next) =>
+                          store.setRunStrategies(
+                            run,
+                            next.map((strategy) => strategy.id)
+                          ),
+                        getXPClassName
+                      )}
+                    </TableCell>
+                  ))}
                 </TableRow>
               );
             })}
@@ -228,32 +141,24 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
             <Select
               id="Run-Filter-Selector"
               className="Run-Filter-Selector"
-              onChange={handleMapFilterChange}
+              onChange={(event) => {
+                setRunsPerPage(Number(event.target.value));
+                setPage(0);
+              }}
               value={runsPerPage}
             >
-              <MenuItem className="Map_Filter-Selector__Item" value={5}>
-                5
-              </MenuItem>
-              <MenuItem className="Map_Filter-Selector__Item" value={10}>
-                10
-              </MenuItem>
-              <MenuItem className="Map_Filter-Selector__Item" value={25}>
-                25
-              </MenuItem>
-              <MenuItem className="Map_Filter-Selector__Item" value={50}>
-                50
-              </MenuItem>
-              <MenuItem className="Map_Filter-Selector__Item" value={100}>
-                100
-              </MenuItem>
+              {[5, 10, 25, 50, 100].map((value) => (
+                <MenuItem key={value} value={value}>
+                  {value}
+                </MenuItem>
+              ))}
             </Select>
           </FormControl>
         </div>
-        {/* <Divider orientation="vertical" flexItem /> */}
         <Pagination
           count={store.getPageCount(runsPerPage)}
           page={page + 1}
-          onChange={handleChangePage}
+          onChange={(_, newPage) => setPage(newPage - 1)}
           color="secondary"
           size="large"
           variant="outlined"
@@ -261,17 +166,12 @@ const RunList = ({ NumbersOfMapsToShow = 10, store, isBoxed = true }) => {
           showFirstButton
         />
       </div>
-
       <div className="Text--Bottom">
         This product is <span className="Text--Error">NOT</span> affiliated with or endorsed by{' '}
         <span className="Text--Legendary">Grinding Gear Games</span> in any way.
       </div>
     </div>
   );
-};
-
-RunList.propTypes = {
-  // version: PropTypes.string.isRequired,
 };
 
 export default observer(RunList);

--- a/src/renderer/routes/root.tsx
+++ b/src/renderer/routes/root.tsx
@@ -6,6 +6,7 @@ import { electronService } from '../electron.service';
 import IgnoreManager from '../../helpers/ignoreManager';
 import LogBox from '../components/LogBox/LogBox';
 import LogStore from '../stores/logStore';
+import { RunListColumnsProvider } from '../runListColumns';
 const logStore = new LogStore([]);
 IgnoreManager.initialize(electronService.logger.scope('renderer/IgnoreManager'), () =>
   electronService.notifyFiltersUiUpdated()
@@ -76,7 +77,9 @@ function Root() {
         </Box>
       </div>
       <div className="Right-Column">
-        <Outlet />
+        <RunListColumnsProvider>
+          <Outlet />
+        </RunListColumnsProvider>
       </div>
       <div className="Log-Box__Overlay">
         <LogBox store={logStore} enableAutoscroll={enableAutoscroll} />

--- a/src/renderer/runListColumns.tsx
+++ b/src/renderer/runListColumns.tsx
@@ -1,0 +1,360 @@
+import React from 'react';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import ViewColumnIcon from '@mui/icons-material/ViewColumn';
+import {
+  Checkbox,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Popover,
+  Button,
+  Stack,
+  Typography,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import ChaosIcon from './components/Pricing/ChaosIcon';
+import { electronService } from './electron.service';
+import type { Run } from './stores/domain/run';
+import type { RunStrategy, Strategy } from '../shared/strategies';
+import StrategySelector from './components/Strategies/StrategySelector';
+
+export type RunListColumnId =
+  | 'date'
+  | 'map'
+  | 'level'
+  | 'iiq'
+  | 'iir'
+  | 'packSize'
+  | 'duration'
+  | 'profit'
+  | 'profitPerHour'
+  | 'xpPerHour'
+  | 'deaths'
+  | 'kills'
+  | 'strategies';
+
+export type RunListColumnPreferences = { order: RunListColumnId[]; hidden: RunListColumnId[] };
+
+export const RUN_LIST_COLUMN_IDS: RunListColumnId[] = [
+  'date',
+  'map',
+  'level',
+  'iiq',
+  'iir',
+  'packSize',
+  'duration',
+  'profit',
+  'profitPerHour',
+  'xpPerHour',
+  'deaths',
+  'kills',
+  'strategies',
+];
+
+export const DEFAULT_RUN_LIST_COLUMNS: RunListColumnPreferences = {
+  order: RUN_LIST_COLUMN_IDS,
+  hidden: [],
+};
+
+export function normalizeRunListColumns(value: unknown): RunListColumnPreferences {
+  const input = value as Partial<RunListColumnPreferences> | null;
+  const order = Array.isArray(input?.order) ? input.order : [];
+  const normalizedOrder = order.filter(
+    (id, index, list): id is RunListColumnId =>
+      RUN_LIST_COLUMN_IDS.includes(id as RunListColumnId) && list.indexOf(id) === index
+  );
+  RUN_LIST_COLUMN_IDS.forEach((id) => {
+    if (!normalizedOrder.includes(id)) normalizedOrder.push(id);
+  });
+  const hidden = Array.isArray(input?.hidden)
+    ? input.hidden.filter(
+        (id, index, list) =>
+          RUN_LIST_COLUMN_IDS.includes(id) && list.indexOf(id) === index && id !== 'map'
+      )
+    : [];
+  return { order: normalizedOrder, hidden };
+}
+
+type ColumnDefinition = {
+  id: RunListColumnId;
+  label: string;
+  align?: 'left' | 'center' | 'right' | 'inherit' | 'justify';
+  header: React.ReactNode;
+  cell: (
+    run: Run,
+    strategies: Strategy[],
+    onStrategiesChange: (next: Strategy[]) => void,
+    getXPClassName: (xp: number) => string
+  ) => React.ReactNode;
+};
+
+export const RUN_LIST_COLUMNS: ColumnDefinition[] = [
+  { id: 'date', label: 'Date', header: 'Date', cell: (run) => run.firstEvent?.calendar() },
+  { id: 'map', label: 'Map', header: 'Map', cell: (run) => run.name },
+  {
+    id: 'level',
+    label: 'Level',
+    header: 'Level',
+    align: 'center',
+    cell: (run) => (
+      <>
+        {run.level}
+        {run.tier !== null ? ` (T${run.tier})` : '-'}
+      </>
+    ),
+  },
+  {
+    id: 'iiq',
+    label: 'IIQ',
+    header: 'IIQ',
+    align: 'center',
+    cell: (run) => (run.iiq ? `${run.iiq}%` : '-'),
+  },
+  {
+    id: 'iir',
+    label: 'IIR',
+    header: 'IIR',
+    align: 'center',
+    cell: (run) => (run.iir ? `${run.iir}%` : '-'),
+  },
+  {
+    id: 'packSize',
+    label: 'Pack Size',
+    header: 'Pack Size',
+    align: 'center',
+    cell: (run) => (run.packSize ? `${run.packSize}%` : '-'),
+  },
+  {
+    id: 'duration',
+    label: 'Duration',
+    header: 'Duration',
+    cell: (run) => dayjs.utc(run.duration?.asMilliseconds()).format('mm:ss'),
+  },
+  {
+    id: 'profit',
+    label: 'Profit',
+    align: 'center',
+    header: <ChaosIcon />,
+    cell: (run) => run.gained?.toFixed(2),
+  },
+  {
+    id: 'profitPerHour',
+    label: 'Profit / Hr',
+    align: 'center',
+    header: (
+      <>
+        <ChaosIcon /> / Hr
+      </>
+    ),
+    cell: (run) => run.gainedPerHour?.toFixed(2),
+  },
+  {
+    id: 'xpPerHour',
+    label: 'XP / Hr',
+    align: 'center',
+    header: 'XP/Hr',
+    cell: (run, _s, _c, getXPClassName) => (
+      <span className={getXPClassName(run.xpPerHour)}>
+        {run.completed ? run.xpPerHour.toLocaleString('en') : '-- Ongoing --'}
+      </span>
+    ),
+  },
+  {
+    id: 'deaths',
+    label: 'Deaths',
+    align: 'center',
+    header: 'Deaths',
+    cell: (run) =>
+      run.deaths > 0
+        ? [...Array(run.deaths)].map((_, i) => (
+            <div key={`death-${i}`} className="Run__Death-Icon" />
+          ))
+        : '-',
+  },
+  {
+    id: 'kills',
+    label: 'Kills',
+    align: 'center',
+    header: 'Kills',
+    cell: (run) => (run.kills && run.kills > -1 ? run.kills : '-'),
+  },
+  {
+    id: 'strategies',
+    label: 'Strategies',
+    header: 'Strategies',
+    cell: (run, strategies, onStrategiesChange) => (
+      <div onClick={(event) => event.stopPropagation()}>
+        <StrategyCell
+          strategies={strategies}
+          value={run.strategies}
+          onChange={onStrategiesChange}
+        />
+      </div>
+    ),
+  },
+];
+
+function StrategyCell({
+  strategies,
+  value,
+  onChange,
+}: {
+  strategies: Strategy[];
+  value: RunStrategy[];
+  onChange: (next: Strategy[]) => void;
+}) {
+  return <StrategySelector compact options={strategies} value={value} onChange={onChange} />;
+}
+
+type ContextValue = {
+  preferences: RunListColumnPreferences;
+  update: (next: RunListColumnPreferences) => void;
+  reset: () => void;
+  ready: boolean;
+};
+const RunListColumnsContext = React.createContext<ContextValue | null>(null);
+
+export function RunListColumnsProvider({ children }: { children: React.ReactNode }) {
+  const [preferences, setPreferences] = React.useState(DEFAULT_RUN_LIST_COLUMNS);
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    void electronService
+      .getSettings(['runListColumns'])
+      .then((settings) => {
+        setPreferences(normalizeRunListColumns(settings?.runListColumns));
+        setReady(true);
+      })
+      .catch(() => setReady(true));
+  }, []);
+  const update = React.useCallback((next: RunListColumnPreferences) => {
+    const normalized = normalizeRunListColumns(next);
+    setPreferences(normalized);
+    void electronService.saveSettings({ runListColumns: normalized });
+  }, []);
+  const reset = React.useCallback(() => update(DEFAULT_RUN_LIST_COLUMNS), [update]);
+  return (
+    <RunListColumnsContext.Provider value={{ preferences, update, reset, ready }}>
+      {children}
+    </RunListColumnsContext.Provider>
+  );
+}
+
+export function useRunListColumns() {
+  const value = React.useContext(RunListColumnsContext);
+  if (!value) throw new Error('useRunListColumns must be used inside RunListColumnsProvider');
+  return value;
+}
+
+export function RunListColumnsPopover({
+  anchorEl,
+  onClose,
+}: {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+}) {
+  const { preferences, update, reset } = useRunListColumns();
+  const [dragged, setDragged] = React.useState<RunListColumnId | null>(null);
+  const move = (id: RunListColumnId, direction: -1 | 1) => {
+    const order = [...preferences.order];
+    const index = order.indexOf(id);
+    const target = index + direction;
+    if (target < 0 || target >= order.length) return;
+    [order[index], order[target]] = [order[target], order[index]];
+    update({ ...preferences, order });
+  };
+  const drop = (target: RunListColumnId) => {
+    if (!dragged || dragged === target) return;
+    const order = preferences.order.filter((id) => id !== dragged);
+    order.splice(order.indexOf(target), 0, dragged);
+    update({ ...preferences, order });
+    setDragged(null);
+  };
+  return (
+    <Popover
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+    >
+      <Stack sx={{ p: 1, width: 280 }} spacing={0.5}>
+        <Stack direction="row" sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
+          <Typography variant="subtitle1">Run columns</Typography>
+          <Button size="small" onClick={reset}>
+            Reset
+          </Button>
+        </Stack>
+        <List dense disablePadding>
+          {preferences.order.map((id, index) => {
+            const column = RUN_LIST_COLUMNS.find((item) => item.id === id)!;
+            const visible = !preferences.hidden.includes(id);
+            return (
+              <ListItem
+                key={id}
+                draggable
+                onDragStart={() => setDragged(id)}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={() => drop(id)}
+                secondaryAction={
+                  <Stack direction="row">
+                    <IconButton
+                      size="small"
+                      aria-label={`Move ${column.label} earlier`}
+                      disabled={index === 0}
+                      onClick={() => move(id, -1)}
+                    >
+                      <ArrowUpwardIcon fontSize="inherit" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      aria-label={`Move ${column.label} later`}
+                      disabled={index === preferences.order.length - 1}
+                      onClick={() => move(id, 1)}
+                    >
+                      <ArrowDownwardIcon fontSize="inherit" />
+                    </IconButton>
+                  </Stack>
+                }
+              >
+                <ListItemIcon sx={{ minWidth: 28, cursor: 'grab' }}>
+                  <DragIndicatorIcon fontSize="small" />
+                </ListItemIcon>
+                <Checkbox
+                  edge="start"
+                  checked={visible}
+                  disabled={id === 'map'}
+                  aria-label={`Show ${column.label}`}
+                  onChange={() =>
+                    update({
+                      ...preferences,
+                      hidden: visible
+                        ? [...preferences.hidden, id]
+                        : preferences.hidden.filter((hidden) => hidden !== id),
+                    })
+                  }
+                />
+                <ListItemText primary={column.label} />
+              </ListItem>
+            );
+          })}
+        </List>
+      </Stack>
+    </Popover>
+  );
+}
+
+export function ColumnsButton({
+  onOpen,
+}: {
+  onOpen: (event: React.MouseEvent<HTMLElement>) => void;
+}) {
+  return (
+    <Button size="small" startIcon={<ViewColumnIcon />} onClick={onOpen}>
+      Columns
+    </Button>
+  );
+}

--- a/test/renderer/RunListColumns.spec.tsx
+++ b/test/renderer/RunListColumns.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_RUN_LIST_COLUMNS,
+  normalizeRunListColumns,
+} from '../../src/renderer/runListColumns';
+
+describe('run-list column preferences', () => {
+  it('fills missing columns, removes unknown and duplicate ids, and keeps Map visible', () => {
+    const result = normalizeRunListColumns({
+      order: ['profit', 'profit', 'unknown', 'map'],
+      hidden: ['map', 'kills', 'kills', 'unknown'],
+    });
+    expect(result.order).toEqual([
+      'profit',
+      'map',
+      ...DEFAULT_RUN_LIST_COLUMNS.order.filter((id) => id !== 'map' && id !== 'profit'),
+    ]);
+    expect(result.hidden).toEqual(['kills']);
+  });
+
+  it('falls back to the current all-visible layout for malformed settings', () => {
+    expect(normalizeRunListColumns(null)).toEqual(DEFAULT_RUN_LIST_COLUMNS);
+    expect(normalizeRunListColumns({ order: [], hidden: [] })).toEqual(DEFAULT_RUN_LIST_COLUMNS);
+  });
+});


### PR DESCRIPTION
## What changed

- add a typed registry for all run-list columns
- let users show, hide, drag, and move columns from a compact Columns popover
- persist and normalize one global layout shared by the main run list and Search results
- keep Map visible, preserve the current all-column default, and provide Reset
- place Default Strategies on the left and Columns on the right of the header

## Why

The run table currently renders every metric in a fixed order. This gives users a durable way to tailor the table to the metrics they care about without changing run data or backend contracts.

## Validation

- `npx vitest run --config vitest.renderer.config.ts test/renderer/RunListColumns.spec.tsx`
- `npm run build:app`
- `npm run test:ui:smoke` (9 passed)
- `git diff --check`

The broader renderer suite has existing failures in Prices tests and React Router/AbortSignal test infrastructure unrelated to this change.