### PR TITLE
fix: restore map loot tracking and deduplicate league DB init

### DIFF
--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -711,6 +711,7 @@ class DBManager {
   isBusy: boolean = true;
   eventEmitter: EventEmitter = new EventEmitter();
   hasRegexExtension: boolean = false;
+  leagueSchemaInitPromise: Promise<void> | null = null;
 
   constructor({ dbPath }: { dbPath: string }) {
     logger.info('Starting DB:', dbPath);
@@ -931,6 +932,23 @@ class DBManager {
     );
     return null;
   };
+
+  ensureLeagueSchemaInitialized(sqlList: string[][], maintSqlList: string[] = []) {
+    if (this.leagueSchemaInitPromise) {
+      return this.leagueSchemaInitPromise;
+    }
+
+    this.leagueSchemaInitPromise = (async () => {
+      await this.init(sqlList, maintSqlList);
+      await this.validateTables(RequiredLeagueTables);
+    })();
+
+    this.leagueSchemaInitPromise.catch(() => {
+      this.leagueSchemaInitPromise = null;
+    });
+
+    return this.leagueSchemaInitPromise;
+  }
 }
 
 // Map of all the DB Managers that have been instantiated, by path
@@ -1105,12 +1123,11 @@ const DB = {
     if (!manager) return null;
 
     const { init, maintenance } = Migrations.league;
-    await manager.init(init, maintenance);
-    await manager.validateTables(RequiredLeagueTables);
+    await manager.ensureLeagueSchemaInitialized(init, maintenance);
 
     const activeProfile = SettingsManager.get('activeProfile');
 
-    if (!characterName && activeProfile.characterName) {
+    if (!characterName && activeProfile?.characterName) {
       await manager.runTask(() =>
         manager.db
           .prepare('insert or ignore into characters values (?)')

--- a/src/main/modules/LogProcessor.ts
+++ b/src/main/modules/LogProcessor.ts
@@ -374,7 +374,8 @@ const LogProcessor = {
                 persistedEventId,
                 dayjs().toISOString(),
                 currentInventory
-              )
+              ),
+            true
           );
         }
       } catch (e) {

--- a/test/main/db/index.spec.ts
+++ b/test/main/db/index.spec.ts
@@ -84,6 +84,17 @@ function getFirstDbInstance() {
   return first?.value;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('db/index', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -380,25 +391,57 @@ describe('db/index', () => {
     expect(preparedSql).not.toContain('insert or ignore into characters values (?)');
   });
 
-  it('initLeagueDB always re-applies league schema guards for partially initialized dbs', async () => {
+  it('caches successful league schema initialization across sequential calls', async () => {
     const DB = loadDbModule();
     const leagueManager = DB.getManager('Mercenaries');
-    leagueManager.db.pragma.mockReturnValue(1);
+    const initSpy = jest.spyOn(leagueManager, 'init').mockResolvedValue(null);
+    const validateSpy = jest.spyOn(leagueManager, 'validateTables').mockResolvedValue(undefined);
 
-    await DB.initLeagueDB('Mercenaries', 'GivenChar');
+    await DB.initLeagueDB('Mercenaries', '');
+    await DB.initLeagueDB('Mercenaries', '');
 
-    const preparedSql = leagueManager.db.prepare.mock.calls.map((call: [string]) => call[0]);
-    expect(
-      preparedSql.filter((sql: string) => sql.includes('create table if not exists characters'))
-        .length
-    ).toBeGreaterThan(0);
-    expect(
-      preparedSql.filter((sql: string) => sql.includes('create table if not exists fullrates'))
-        .length
-    ).toBeGreaterThan(0);
-    expect(
-      preparedSql.filter((sql: string) => sql.includes('create table if not exists stashes')).length
-    ).toBeGreaterThan(0);
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+
+    const insertStatements = leagueManager.db.prepare.mock.calls.filter(
+      (call: [string]) => call[0] === 'insert or ignore into characters values (?)'
+    );
+    expect(insertStatements).toHaveLength(2);
+  });
+
+  it('shares concurrent league schema initialization callers', async () => {
+    const DB = loadDbModule();
+    const leagueManager = DB.getManager('Mercenaries');
+    const deferredInit = createDeferred<null>();
+    const initSpy = jest.spyOn(leagueManager, 'init').mockReturnValue(deferredInit.promise);
+    const validateSpy = jest.spyOn(leagueManager, 'validateTables').mockResolvedValue(undefined);
+
+    const firstInit = DB.initLeagueDB('Mercenaries', 'GivenChar');
+    const secondInit = DB.initLeagueDB('Mercenaries', 'GivenChar');
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+
+    deferredInit.resolve(null);
+    await Promise.all([firstInit, secondInit]);
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears cached league initialization after a failed validation and retries', async () => {
+    const DB = loadDbModule();
+    const leagueManager = DB.getManager('Mercenaries');
+    const schemaError = new Error('schema invalid');
+    const initSpy = jest.spyOn(leagueManager, 'init').mockResolvedValue(null);
+    const validateSpy = jest
+      .spyOn(leagueManager, 'validateTables')
+      .mockRejectedValueOnce(schemaError)
+      .mockResolvedValueOnce(undefined);
+
+    await expect(DB.initLeagueDB('Mercenaries', 'GivenChar')).rejects.toThrow('schema invalid');
+    await expect(DB.initLeagueDB('Mercenaries', 'GivenChar')).resolves.toBeUndefined();
+
+    expect(initSpy).toHaveBeenCalledTimes(2);
+    expect(validateSpy).toHaveBeenCalledTimes(2);
   });
 
   it('loads sqlite regex extension when creating a manager', () => {

--- a/test/main/modules/InventoryGetter.spec.ts
+++ b/test/main/modules/InventoryGetter.spec.ts
@@ -35,13 +35,10 @@ describe('InventoryGetter capture contract', () => {
   });
 
   it('updates the inventory baseline only after the diff persists', async () => {
-    const previousInventory = {
-      existing: { id: 'existing', name: 'Chaos Orb', typeLine: 'Chaos Orb', stackSize: 1 },
-    };
     const currentInventory = {
-      existing: { id: 'existing', name: 'Chaos Orb', typeLine: 'Chaos Orb', stackSize: 2 },
+      item: { id: 'item', name: 'Chaos Orb', typeLine: 'Chaos Orb', stackSize: 1 },
     };
-    jest.spyOn(InventoryGetter, 'getPreviousInventory').mockResolvedValue(previousInventory);
+    jest.spyOn(InventoryGetter, 'getPreviousInventory').mockResolvedValue({});
     jest.spyOn(InventoryGetter, 'getCurrentInventory').mockResolvedValue(currentInventory);
     const updateLastInventory = jest
       .spyOn(InventoryGetter, 'updateLastInventory')
@@ -52,14 +49,7 @@ describe('InventoryGetter capture contract', () => {
       InventoryGetter.captureInventoryDiff('2026-07-22T10:00:00.000Z', persistDiff)
     ).rejects.toThrow('item insert failed');
 
-    expect(persistDiff).toHaveBeenCalledWith({
-      existing: {
-        id: 'existing',
-        name: 'Chaos Orb',
-        typeLine: 'Chaos Orb',
-        stackSize: 1,
-      },
-    });
+    expect(persistDiff).toHaveBeenCalledWith(currentInventory);
     expect(updateLastInventory).not.toHaveBeenCalled();
   });
 
@@ -124,6 +114,20 @@ describe('InventoryGetter capture contract', () => {
 
     expect(getInventoryCapture).toHaveBeenCalledTimes(2);
     expect(secondPersist).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through the fresh-capture requirement without breaking serialization', async () => {
+    const getInventoryCapture = jest
+      .spyOn(InventoryGetter, 'getInventoryCapture')
+      .mockResolvedValue({ diff: {}, currentInventory: {} });
+
+    await InventoryGetter.captureAndPersistInventory(
+      '2026-07-22T10:00:00.000Z',
+      async () => undefined,
+      true
+    );
+
+    expect(getInventoryCapture).toHaveBeenCalledWith('2026-07-22T10:00:00.000Z', true);
   });
 
   it('detects new items and normalizes legacy stack quantities', () => {

--- a/test/main/modules/LogProcessorScheduler.spec.ts
+++ b/test/main/modules/LogProcessorScheduler.spec.ts
@@ -350,5 +350,10 @@ describe('LogProcessorScheduler', () => {
       expect.any(String),
       {}
     );
+    expect(mockCaptureAndPersistInventory).toHaveBeenCalledWith(
+      '2026-07-23T11:04:10.000Z',
+      expect.any(Function),
+      true
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Force fresh character snapshots for automatic map-boundary inventory captures so looted items are not hidden by cached responses.
- Deduplicate league schema initialization per live DB connection while preserving concurrent callers and retry-after-failure behavior.

## Verification

- Focused map, inventory, run-parser, DB, rates, price-override, and GGG API tests passed.
- git diff --check passed.
- Main typecheck still reports unrelated existing preload and renderer price-use-case interface errors.